### PR TITLE
Add unified CLI with serve, secret, and db commands

### DIFF
--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -8,11 +8,11 @@ Get your Skrift site running in minutes with secure defaults.
 # Install Skrift
 uv add skrift
 
-# Set a secret key (required)
-export SECRET_KEY=$(python -c "import secrets; print(secrets.token_urlsafe(32))")
+# Generate a secret key and save to .env
+skrift secret --write .env
 
-# Start the server
-python -m skrift
+# Start the development server
+skrift serve --reload
 ```
 
 Open [http://localhost:8080](http://localhost:8080) to begin the setup wizard.
@@ -86,7 +86,7 @@ For local development, you can enable additional features:
 ```bash
 export SKRIFT_ENV=dev
 export DEBUG=true
-python -m skrift
+skrift serve --reload
 ```
 
 This loads `app.dev.yaml` (if it exists) and enables:

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1,0 +1,154 @@
+# CLI Reference
+
+Skrift provides a unified command-line interface for running the server, managing secrets, and handling database migrations.
+
+## Installation
+
+The `skrift` command is installed automatically when you install the package:
+
+```bash
+uv add skrift
+```
+
+## Commands
+
+### skrift serve
+
+Run the Skrift server.
+
+```bash
+skrift serve [OPTIONS]
+```
+
+**Options:**
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--host` | `127.0.0.1` | Host to bind to |
+| `--port` | `8080` | Port to bind to |
+| `--reload` | `false` | Enable auto-reload for development |
+| `--workers` | `1` | Number of worker processes |
+| `--log-level` | `info` | Logging level (`debug`, `info`, `warning`, `error`) |
+
+**Examples:**
+
+```bash
+# Start development server with auto-reload
+skrift serve --reload
+
+# Production server on all interfaces with multiple workers
+skrift serve --host 0.0.0.0 --workers 4
+
+# Debug mode with verbose logging
+skrift serve --reload --log-level debug
+```
+
+!!! note
+    When `--reload` is enabled, `--workers` is ignored (forced to 1) since auto-reload doesn't work with multiple workers.
+
+---
+
+### skrift secret
+
+Generate a secure secret key for session encryption.
+
+```bash
+skrift secret [OPTIONS]
+```
+
+**Options:**
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--write` | - | Write SECRET_KEY to a .env file |
+| `--format` | `urlsafe` | Output format (`urlsafe`, `hex`, `base64`) |
+| `--length` | `32` | Number of random bytes |
+
+**Examples:**
+
+```bash
+# Generate and print a secret key
+skrift secret
+
+# Write directly to .env file
+skrift secret --write .env
+
+# Generate a longer key in hex format
+skrift secret --format hex --length 64
+```
+
+!!! tip
+    The `--write` option will create the file if it doesn't exist, or update an existing `SECRET_KEY` line if the file already exists.
+
+---
+
+### skrift db
+
+Run database migrations via Alembic. This command passes all arguments through to Alembic.
+
+```bash
+skrift db [ALEMBIC_ARGS]
+```
+
+**Common Commands:**
+
+| Command | Description |
+|---------|-------------|
+| `skrift db upgrade head` | Apply all pending migrations |
+| `skrift db downgrade -1` | Rollback one migration |
+| `skrift db current` | Show current database revision |
+| `skrift db history` | Show migration history |
+| `skrift db revision -m "description" --autogenerate` | Create a new migration |
+
+**Examples:**
+
+```bash
+# Apply all migrations
+skrift db upgrade head
+
+# Rollback the last migration
+skrift db downgrade -1
+
+# Check current migration status
+skrift db current
+
+# Create a new migration after model changes
+skrift db revision -m "add user preferences" --autogenerate
+```
+
+!!! note
+    The `db` command automatically locates `alembic.ini` from either your project root or the Skrift package directory.
+
+---
+
+## Global Options
+
+All commands support these global options:
+
+| Option | Description |
+|--------|-------------|
+| `--version` | Show the version and exit |
+| `--help` | Show help message and exit |
+
+```bash
+# Show version
+skrift --version
+
+# Show help for any command
+skrift --help
+skrift serve --help
+skrift secret --help
+skrift db --help
+```
+
+## Quick Start
+
+```bash
+# Generate a secret key and save to .env
+skrift secret --write .env
+
+# Start the development server
+skrift serve --reload
+```
+
+Then open [http://localhost:8080](http://localhost:8080) to access the setup wizard.

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -2,6 +2,20 @@
 
 Technical reference documentation for Skrift.
 
+## CLI
+
+<div class="grid cards" markdown>
+
+-   :material-console:{ .lg .middle } **CLI Reference**
+
+    ---
+
+    Command-line interface for running the server, managing secrets, and database migrations.
+
+    [:octicons-arrow-right-24: CLI Reference](cli.md)
+
+</div>
+
 ## Configuration
 
 <div class="grid cards" markdown>
@@ -56,6 +70,7 @@ Technical reference documentation for Skrift.
 
 | Topic | Description |
 |-------|-------------|
+| [CLI Reference](cli.md) | Command-line interface |
 | [Environment Variables](environment-variables.md) | Configuration and secrets |
 | [OAuth Providers](auth-providers.md) | Authentication setup |
 | [Security Features](security-features.md) | Security implementation details |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -72,6 +72,7 @@ nav:
     - Custom Admin Pages: admin/custom-admin-pages.md
   - Reference:
     - reference/index.md
+    - CLI Reference: reference/cli.md
     - Environment Variables: reference/environment-variables.md
     - Environment-Specific Config: reference/environments.md
     - OAuth Providers: reference/auth-providers.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "skrift"
-version = "0.1.0a4"
+version = "0.1.0a5"
 description = "A lightweight async Python CMS for crafting modern websites"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -20,8 +20,7 @@ dependencies = [
 ]
 
 [project.scripts]
-skrift = "skrift.__main__:main"
-skrift-db = "skrift.cli:db"
+skrift = "skrift.cli:cli"
 
 [tool.uv]
 package = true

--- a/skrift/__main__.py
+++ b/skrift/__main__.py
@@ -1,16 +1,11 @@
 """Entry point for the skrift package."""
 
-import uvicorn
+from skrift.cli import cli
 
 
 def main():
-    """Run the Skrift development server."""
-    uvicorn.run(
-        "skrift.asgi:app",
-        host="0.0.0.0",
-        port=8080,
-        reload=True,
-    )
+    """Run the Skrift CLI."""
+    cli()
 
 
 if __name__ == "__main__":

--- a/skrift/cli.py
+++ b/skrift/cli.py
@@ -1,25 +1,118 @@
-"""CLI commands for Skrift database management."""
+"""CLI commands for Skrift."""
 
+import base64
+import os
+import re
+import secrets
 import sys
 from pathlib import Path
 
+import click
 
-def db() -> None:
-    """Run Alembic database migrations.
 
-    This is a thin wrapper around Alembic that sets up the correct working
-    directory and passes through all arguments.
+@click.group()
+@click.version_option(package_name="skrift")
+def cli():
+    """Skrift - A lightweight async Python CMS."""
+    pass
 
-    Usage:
-        skrift-db upgrade head     # Apply all migrations
-        skrift-db downgrade -1     # Rollback one migration
-        skrift-db current          # Show current revision
-        skrift-db history          # Show migration history
-        skrift-db revision -m "description" --autogenerate  # Create new migration
+
+@cli.command()
+@click.option("--host", default="127.0.0.1", help="Host to bind to")
+@click.option("--port", default=8080, type=int, help="Port to bind to")
+@click.option("--reload", is_flag=True, help="Enable auto-reload for development")
+@click.option("--workers", default=1, type=int, help="Number of worker processes")
+@click.option(
+    "--log-level",
+    default="info",
+    type=click.Choice(["debug", "info", "warning", "error"]),
+    help="Logging level",
+)
+def serve(host, port, reload, workers, log_level):
+    """Run the Skrift server."""
+    import uvicorn
+
+    uvicorn.run(
+        "skrift.asgi:app",
+        host=host,
+        port=port,
+        reload=reload,
+        workers=workers if not reload else 1,
+        log_level=log_level,
+    )
+
+
+@cli.command()
+@click.option(
+    "--write",
+    type=click.Path(),
+    default=None,
+    help="Write SECRET_KEY to a .env file",
+)
+@click.option(
+    "--format",
+    "fmt",
+    default="urlsafe",
+    type=click.Choice(["urlsafe", "hex", "base64"]),
+    help="Output format for the secret key",
+)
+@click.option("--length", default=32, type=int, help="Number of random bytes")
+def secret(write, fmt, length):
+    """Generate a secure secret key."""
+    # Generate key based on format
+    if fmt == "urlsafe":
+        key = secrets.token_urlsafe(length)
+    elif fmt == "hex":
+        key = secrets.token_hex(length)
+    else:  # base64
+        key = base64.b64encode(secrets.token_bytes(length)).decode("ascii")
+
+    if write:
+        env_path = Path(write)
+        env_content = ""
+
+        # Read existing content if file exists
+        if env_path.exists():
+            env_content = env_path.read_text()
+
+        # Update or add SECRET_KEY
+        secret_key_pattern = re.compile(r"^SECRET_KEY=.*$", re.MULTILINE)
+        new_line = f"SECRET_KEY={key}"
+
+        if secret_key_pattern.search(env_content):
+            # Replace existing SECRET_KEY
+            env_content = secret_key_pattern.sub(new_line, env_content)
+        else:
+            # Add SECRET_KEY at the end
+            if env_content and not env_content.endswith("\n"):
+                env_content += "\n"
+            env_content += new_line + "\n"
+
+        env_path.write_text(env_content)
+        click.echo(f"SECRET_KEY written to {env_path}")
+    else:
+        click.echo(key)
+
+
+@cli.command(
+    context_settings=dict(
+        ignore_unknown_options=True,
+        allow_extra_args=True,
+    )
+)
+@click.pass_context
+def db(ctx):
+    """Run database migrations via Alembic.
+
+    \b
+    Examples:
+        skrift db upgrade head     # Apply all migrations
+        skrift db downgrade -1     # Rollback one migration
+        skrift db current          # Show current revision
+        skrift db history          # Show migration history
+        skrift db revision -m "description" --autogenerate  # Create new migration
     """
     from alembic.config import main as alembic_main
-
-    import os
 
     # Always run from the project root (where app.yaml and .env are)
     # This ensures database paths like ./app.db resolve correctly
@@ -36,19 +129,15 @@ def db() -> None:
         alembic_ini = skrift_dir / "alembic.ini"
 
         if not alembic_ini.exists():
-            print("Error: Could not find alembic.ini", file=sys.stderr)
-            print("Make sure you're running from the project root directory.", file=sys.stderr)
+            click.echo("Error: Could not find alembic.ini", err=True)
+            click.echo("Make sure you're running from the project root directory.", err=True)
             sys.exit(1)
 
-    # Build argv with config path at the beginning (before any subcommand)
-    # Original argv: ['skrift-db', 'upgrade', 'head']
-    # New argv: ['skrift-db', '-c', '/path/to/alembic.ini', 'upgrade', 'head']
-    new_argv = [sys.argv[0], "-c", str(alembic_ini)] + sys.argv[1:]
-    sys.argv = new_argv
+    # Build argv for alembic: ['-c', '/path/to/alembic.ini', ...extra_args]
+    alembic_argv = ["-c", str(alembic_ini)] + ctx.args
 
-    # Pass through all CLI arguments to Alembic
-    sys.exit(alembic_main(sys.argv[1:]))
+    sys.exit(alembic_main(alembic_argv))
 
 
 if __name__ == "__main__":
-    db()
+    cli()

--- a/uv.lock
+++ b/uv.lock
@@ -882,7 +882,7 @@ wheels = [
 
 [[package]]
 name = "skrift"
-version = "0.1.0a2"
+version = "0.1.0a4"
 source = { editable = "." }
 dependencies = [
     { name = "advanced-alchemy" },


### PR DESCRIPTION
## Summary

- Add unified `skrift` CLI using Click with three subcommands:
  - `skrift serve` - Run the server with configurable host, port, workers, and log level
  - `skrift secret` - Generate secure secret keys with `--write .env` support
  - `skrift db` - Database migrations via Alembic (consolidates `skrift-db`)
- Remove separate `skrift-db` entry point (consolidated into `skrift db`)
- Add CLI reference documentation
- Update quickstart guide with new CLI commands
- Bump version to 0.1.0a5

## Test plan

- [x] Verify `skrift --help` shows all commands
- [x] Verify `skrift serve --reload` starts dev server
- [x] Verify `skrift secret` generates keys
- [x] Verify `skrift secret --write .env` writes to file
- [x] Verify `skrift db current` runs alembic

🤖 Generated with [Claude Code](https://claude.com/claude-code)