### PR TITLE
Add working directory support for templates and static files

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "skrift"
-version = "0.1.0a5"
+version = "0.1.0a6"
 description = "A lightweight async Python CMS for crafting modern websites"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/skrift/asgi.py
+++ b/skrift/asgi.py
@@ -10,6 +10,7 @@ The application uses a dispatcher architecture:
 import asyncio
 import hashlib
 import importlib
+import os
 from datetime import datetime
 from pathlib import Path
 
@@ -309,9 +310,11 @@ def create_app() -> Litestar:
     )
 
     # Template configuration
+    # Search working directory first for user overrides, then package directory
+    working_dir_templates = Path(os.getcwd()) / "templates"
     template_dir = Path(__file__).parent / "templates"
     template_config = TemplateConfig(
-        directory=template_dir,
+        directory=[working_dir_templates, template_dir],
         engine=JinjaTemplateEngine,
         engine_callback=lambda engine: engine.engine.globals.update({
             "now": datetime.now,
@@ -322,10 +325,11 @@ def create_app() -> Litestar:
         }),
     )
 
-    # Static files
+    # Static files - working directory first for user overrides, then package directory
+    working_dir_static = Path(os.getcwd()) / "static"
     static_files_router = create_static_files_router(
         path="/static",
-        directories=[Path(__file__).parent / "static"],
+        directories=[working_dir_static, Path(__file__).parent / "static"],
     )
 
     from skrift.auth import sync_roles_to_database
@@ -381,9 +385,11 @@ def create_setup_app() -> Litestar:
     )
 
     # Template configuration
+    # Search working directory first for user overrides, then package directory
+    working_dir_templates = Path(os.getcwd()) / "templates"
     template_dir = Path(__file__).parent / "templates"
     template_config = TemplateConfig(
-        directory=template_dir,
+        directory=[working_dir_templates, template_dir],
         engine=JinjaTemplateEngine,
         engine_callback=lambda engine: engine.engine.globals.update({
             "now": datetime.now,
@@ -394,10 +400,11 @@ def create_setup_app() -> Litestar:
         }),
     )
 
-    # Static files
+    # Static files - working directory first for user overrides, then package directory
+    working_dir_static = Path(os.getcwd()) / "static"
     static_files_router = create_static_files_router(
         path="/static",
-        directories=[Path(__file__).parent / "static"],
+        directories=[working_dir_static, Path(__file__).parent / "static"],
     )
 
     # Import controllers


### PR DESCRIPTION
## Summary
- Templates and static files now search the working directory first (`./templates/` and `./static/`) before falling back to the package directories
- Allows users to override templates and static assets without modifying the package
- Applies to both the main app and setup app

## Test plan
- [ ] Create a `templates/` directory in working directory with a custom template
- [ ] Verify the custom template is used instead of the package default
- [ ] Create a `static/` directory with custom assets
- [ ] Verify custom static files are served at `/static/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)