### PR TITLE
Add working directory support for controller imports

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "skrift"
-version = "0.1.0a6"
+version = "0.1.0a7"
 description = "A lightweight async Python CMS for crafting modern websites"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/skrift/asgi.py
+++ b/skrift/asgi.py
@@ -11,6 +11,7 @@ import asyncio
 import hashlib
 import importlib
 import os
+import sys
 from datetime import datetime
 from pathlib import Path
 
@@ -57,16 +58,17 @@ def load_controllers() -> list:
     if not config:
         return []
 
+    # Add working directory to sys.path for local controller imports
+    cwd = os.getcwd()
+    if cwd not in sys.path:
+        sys.path.insert(0, cwd)
+
     controllers = []
     for controller_spec in config.get("controllers", []):
-        try:
-            module_path, class_name = controller_spec.split(":")
-            module = importlib.import_module(module_path)
-            controller_class = getattr(module, class_name)
-            controllers.append(controller_class)
-        except Exception:
-            # Skip controllers that can't be loaded during setup
-            pass
+        module_path, class_name = controller_spec.split(":")
+        module = importlib.import_module(module_path)
+        controller_class = getattr(module, class_name)
+        controllers.append(controller_class)
 
     return controllers
 


### PR DESCRIPTION
## Summary
- Controllers in `app.yaml` can now be imported from the working directory (adds cwd to `sys.path`)
- Matches existing behavior for templates and static files
- Removes silent exception handling so controller import errors fail fast with clear error messages

## Test plan
- [ ] Create a controller in the working directory (e.g., `./controllers/test.py`)
- [ ] Reference it in `app.yaml` as `controllers.test:TestController`
- [ ] Verify it loads successfully
- [ ] Verify import errors are raised immediately (not silently swallowed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)