### PR TITLE
Add OAuth provider metadata storage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "skrift"
-version = "0.1.0a7"
+version = "0.1.0a8"
 description = "A lightweight async Python CMS for crafting modern websites"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/skrift/alembic/versions/20260129_add_provider_metadata.py
+++ b/skrift/alembic/versions/20260129_add_provider_metadata.py
@@ -1,0 +1,29 @@
+"""add provider_metadata column to oauth_accounts
+
+Revision ID: 2b3c4d5e6f7g
+Revises: 1a2b3c4d5e6f
+Create Date: 2026-01-29 12:00:00.000000
+
+This migration adds a JSON column to store the full raw OAuth provider response.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '2b3c4d5e6f7g'
+down_revision: Union[str, None] = '1a2b3c4d5e6f'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table('oauth_accounts') as batch_op:
+        batch_op.add_column(sa.Column('provider_metadata', sa.JSON(), nullable=True))
+
+
+def downgrade() -> None:
+    with op.batch_alter_table('oauth_accounts') as batch_op:
+        batch_op.drop_column('provider_metadata')

--- a/skrift/controllers/auth.py
+++ b/skrift/controllers/auth.py
@@ -337,6 +337,8 @@ class AuthController(Controller):
             # Update provider email if changed
             if email:
                 oauth_account.provider_email = email
+            # Update provider metadata
+            oauth_account.provider_metadata = user_info
         else:
             # Step 2: Check if a user with this email already exists
             user = None
@@ -352,6 +354,7 @@ class AuthController(Controller):
                     provider=provider,
                     provider_account_id=oauth_id,
                     provider_email=email,
+                    provider_metadata=user_info,
                     user_id=user.id,
                 )
                 db_session.add(oauth_account)
@@ -375,6 +378,7 @@ class AuthController(Controller):
                     provider=provider,
                     provider_account_id=oauth_id,
                     provider_email=email,
+                    provider_metadata=user_info,
                     user_id=user.id,
                 )
                 db_session.add(oauth_account)
@@ -444,6 +448,13 @@ class AuthController(Controller):
         # Generate deterministic oauth_id from email
         oauth_id = f"dummy_{hashlib.sha256(email.encode()).hexdigest()[:16]}"
 
+        # Create synthetic metadata for dummy provider
+        dummy_metadata = {
+            "id": oauth_id,
+            "email": email,
+            "name": name,
+        }
+
         # Step 1: Check if OAuth account already exists
         result = await db_session.execute(
             select(OAuthAccount)
@@ -462,6 +473,7 @@ class AuthController(Controller):
             user.email = email
             user.last_login_at = datetime.now(UTC)
             oauth_account.provider_email = email
+            oauth_account.provider_metadata = dummy_metadata
         else:
             # Step 2: Check if a user with this email already exists
             result = await db_session.execute(
@@ -475,6 +487,7 @@ class AuthController(Controller):
                     provider=DUMMY_PROVIDER_KEY,
                     provider_account_id=oauth_id,
                     provider_email=email,
+                    provider_metadata=dummy_metadata,
                     user_id=user.id,
                 )
                 db_session.add(oauth_account)
@@ -495,6 +508,7 @@ class AuthController(Controller):
                     provider=DUMMY_PROVIDER_KEY,
                     provider_account_id=oauth_id,
                     provider_email=email,
+                    provider_metadata=dummy_metadata,
                     user_id=user.id,
                 )
                 db_session.add(oauth_account)

--- a/skrift/db/models/oauth_account.py
+++ b/skrift/db/models/oauth_account.py
@@ -1,9 +1,9 @@
 """OAuth account model for storing multiple OAuth identities per user."""
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 from uuid import UUID
 
-from sqlalchemy import ForeignKey, String, UniqueConstraint
+from sqlalchemy import ForeignKey, JSON, String, UniqueConstraint
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from skrift.db.base import Base
@@ -17,6 +17,16 @@ class OAuthAccount(Base):
 
     This allows a single user to have multiple OAuth provider accounts
     linked to their profile, enabling login via different providers.
+
+    The provider_metadata column stores the full raw OAuth provider response,
+    which varies by provider:
+
+    - Discord: id, username, global_name, discriminator, avatar, email, verified, locale
+    - GitHub: id, login, name, email, avatar_url, bio, company, location, public_repos
+    - Google: id, email, name, picture, verified_email, locale, hd
+    - Twitter: id, username, name
+    - Microsoft: id, displayName, mail, userPrincipalName
+    - Facebook: id, name, email, picture.data.url
     """
 
     __tablename__ = "oauth_accounts"
@@ -24,6 +34,9 @@ class OAuthAccount(Base):
     provider: Mapped[str] = mapped_column(String(50), nullable=False)
     provider_account_id: Mapped[str] = mapped_column(String(255), nullable=False)
     provider_email: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    provider_metadata: Mapped[dict[str, Any] | None] = mapped_column(
+        JSON, nullable=True, default=None
+    )
     user_id: Mapped[UUID] = mapped_column(
         ForeignKey("users.id", ondelete="CASCADE"), nullable=False
     )

--- a/skrift/db/services/oauth_service.py
+++ b/skrift/db/services/oauth_service.py
@@ -1,0 +1,195 @@
+"""OAuth service for accessing OAuth account data and provider metadata."""
+
+from typing import Any
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from skrift.db.models.oauth_account import OAuthAccount
+
+
+async def get_oauth_account_by_user_and_provider(
+    db_session: AsyncSession,
+    user_id: UUID,
+    provider: str,
+) -> OAuthAccount | None:
+    """Get a specific OAuth account for a user and provider.
+
+    Args:
+        db_session: Database session
+        user_id: User UUID
+        provider: OAuth provider name (e.g., 'discord', 'github')
+
+    Returns:
+        OAuthAccount or None if not found
+    """
+    result = await db_session.execute(
+        select(OAuthAccount).where(
+            OAuthAccount.user_id == user_id,
+            OAuthAccount.provider == provider,
+        )
+    )
+    return result.scalar_one_or_none()
+
+
+async def get_oauth_accounts_by_user(
+    db_session: AsyncSession,
+    user_id: UUID,
+) -> list[OAuthAccount]:
+    """Get all OAuth accounts linked to a user.
+
+    Args:
+        db_session: Database session
+        user_id: User UUID
+
+    Returns:
+        List of OAuthAccount objects
+    """
+    result = await db_session.execute(
+        select(OAuthAccount).where(OAuthAccount.user_id == user_id)
+    )
+    return list(result.scalars().all())
+
+
+async def get_provider_metadata(
+    db_session: AsyncSession,
+    user_id: UUID,
+    provider: str,
+) -> dict[str, Any] | None:
+    """Get the raw provider metadata for a user's OAuth account.
+
+    Args:
+        db_session: Database session
+        user_id: User UUID
+        provider: OAuth provider name
+
+    Returns:
+        Provider metadata dict or None if not found
+    """
+    oauth_account = await get_oauth_account_by_user_and_provider(
+        db_session, user_id, provider
+    )
+    if oauth_account:
+        return oauth_account.provider_metadata
+    return None
+
+
+def extract_metadata_field(
+    metadata: dict[str, Any] | None,
+    *keys: str,
+    default: Any = None,
+) -> Any:
+    """Safely extract a nested field from metadata.
+
+    Args:
+        metadata: Provider metadata dict
+        *keys: Sequence of keys for nested access (e.g., 'picture', 'data', 'url')
+        default: Default value if field not found
+
+    Returns:
+        Field value or default
+    """
+    if metadata is None:
+        return default
+
+    current = metadata
+    for key in keys:
+        if isinstance(current, dict) and key in current:
+            current = current[key]
+        else:
+            return default
+    return current
+
+
+async def get_provider_username(
+    db_session: AsyncSession,
+    user_id: UUID,
+    provider: str,
+) -> str | None:
+    """Get the username from a provider's metadata.
+
+    Provider-specific username fields:
+    - Discord: username
+    - GitHub: login
+    - Twitter: username
+    - Google: email (no username concept)
+    - Microsoft: userPrincipalName
+    - Facebook: name (no username concept)
+
+    Args:
+        db_session: Database session
+        user_id: User UUID
+        provider: OAuth provider name
+
+    Returns:
+        Username string or None
+    """
+    metadata = await get_provider_metadata(db_session, user_id, provider)
+    if metadata is None:
+        return None
+
+    # Provider-specific username extraction
+    username_fields = {
+        "discord": "username",
+        "github": "login",
+        "twitter": "username",
+        "microsoft": "userPrincipalName",
+    }
+
+    field = username_fields.get(provider)
+    if field:
+        return extract_metadata_field(metadata, field)
+
+    # Fallback for providers without usernames
+    return extract_metadata_field(metadata, "email") or extract_metadata_field(
+        metadata, "name"
+    )
+
+
+async def get_provider_avatar_url(
+    db_session: AsyncSession,
+    user_id: UUID,
+    provider: str,
+) -> str | None:
+    """Get the avatar URL from a provider's metadata.
+
+    Provider-specific avatar URL construction:
+    - Discord: Constructed from id + avatar hash
+    - GitHub: avatar_url
+    - Google: picture
+    - Microsoft: No direct URL (requires Graph API call)
+    - Facebook: picture.data.url
+    - Twitter: No avatar in basic userinfo
+
+    Args:
+        db_session: Database session
+        user_id: User UUID
+        provider: OAuth provider name
+
+    Returns:
+        Avatar URL string or None
+    """
+    metadata = await get_provider_metadata(db_session, user_id, provider)
+    if metadata is None:
+        return None
+
+    if provider == "discord":
+        # Discord avatar URL must be constructed
+        user_id_discord = extract_metadata_field(metadata, "id")
+        avatar_hash = extract_metadata_field(metadata, "avatar")
+        if user_id_discord and avatar_hash:
+            return f"https://cdn.discordapp.com/avatars/{user_id_discord}/{avatar_hash}.png"
+        return None
+
+    if provider == "github":
+        return extract_metadata_field(metadata, "avatar_url")
+
+    if provider == "google":
+        return extract_metadata_field(metadata, "picture")
+
+    if provider == "facebook":
+        return extract_metadata_field(metadata, "picture", "data", "url")
+
+    # Microsoft and Twitter don't provide direct avatar URLs
+    return None

--- a/uv.lock
+++ b/uv.lock
@@ -882,7 +882,7 @@ wheels = [
 
 [[package]]
 name = "skrift"
-version = "0.1.0a4"
+version = "0.1.0a7"
 source = { editable = "." }
 dependencies = [
     { name = "advanced-alchemy" },


### PR DESCRIPTION
## Summary
- Store full raw OAuth provider response in new `provider_metadata` JSON column
- Add service functions to access provider-specific data (usernames, avatars, etc.)
- Document available fields per provider

## Changes
- New migration: `20260129_add_provider_metadata.py`
- New service: `skrift/db/services/oauth_service.py`
- Updated: `OAuthAccount` model, `auth.py` controller
- Documentation in `docs/reference/auth-providers.md`

## Test plan
- [x] Migration runs successfully
- [x] All imports verified working
- [ ] Login via OAuth and verify metadata is stored
- [ ] Test service functions to retrieve metadata

🤖 Generated with [Claude Code](https://claude.ai/code)