### PR TITLE
Release v0.1.0a9

### DIFF
--- a/docs/core-concepts/security-model.md
+++ b/docs/core-concepts/security-model.md
@@ -155,6 +155,34 @@ guards=[auth_guard, Role("admin") | Role("editor")]
 !!! info "Implementation"
     Auth guards are defined in `skrift/auth/guards.py`. Role definitions are in `skrift/auth/roles.py`.
 
+### Registering Custom Roles
+
+Add custom roles using `register_role()`. Call this at module level in your controller so it runs before the database sync:
+
+```python
+# my_controllers.py
+from litestar import Controller, get
+from skrift.auth import register_role, auth_guard, Permission
+
+# Register custom role at module level
+register_role(
+    "support",
+    "view-tickets",
+    "respond-tickets",
+    display_name="Support Agent",
+    description="Can view and respond to support tickets",
+)
+
+class SupportController(Controller):
+    path = "/support"
+
+    @get("/tickets", guards=[auth_guard, Permission("view-tickets")])
+    async def list_tickets(self):
+        ...
+```
+
+The role is automatically synced to the database when the application starts.
+
 See [Protecting Routes](../guides/protecting-routes.md) for a complete guide.
 
 ## Security Checklist

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "skrift"
-version = "0.1.0a8"
+version = "0.1.0a9"
 description = "A lightweight async Python CMS for crafting modern websites"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/skrift/auth/roles.py
+++ b/skrift/auth/roles.py
@@ -86,9 +86,44 @@ def get_role_definition(name: str) -> RoleDefinition | None:
     return ROLE_DEFINITIONS.get(name)
 
 
-def register_role(role: RoleDefinition) -> None:
+def register_role(
+    name: str,
+    *permissions: str,
+    display_name: str | None = None,
+    description: str | None = None,
+) -> RoleDefinition:
     """Register a custom role definition.
 
     This allows applications to add custom roles beyond the defaults.
+    Call this during application startup (e.g., in a custom controller module
+    or app initialization) before the database sync occurs.
+
+    Args:
+        name: The unique identifier for the role
+        *permissions: Permission strings granted by this role
+        display_name: Human-readable name for the role
+        description: Description of the role's purpose
+
+    Returns:
+        The registered RoleDefinition instance
+
+    Example:
+        from skrift.auth.roles import register_role
+
+        # Register a custom role with permissions
+        register_role(
+            "support",
+            "view-tickets",
+            "respond-tickets",
+            display_name="Support Agent",
+            description="Can view and respond to support tickets",
+        )
     """
+    role = create_role(
+        name,
+        *permissions,
+        display_name=display_name,
+        description=description,
+    )
     ROLE_DEFINITIONS[role.name] = role
+    return role

--- a/skrift/static/css/style.css
+++ b/skrift/static/css/style.css
@@ -791,6 +791,11 @@ main.container.admin-layout {
     color: var(--color-primary-text);
 }
 
+.admin-nav a.active:hover {
+    background-color: var(--color-primary-hover);
+    color: var(--color-primary-text);
+}
+
 .admin-nav a::after {
     display: none;
 }


### PR DESCRIPTION
## Summary
- Fix PostgreSQL migration compatibility for oauth_accounts table (use `gen_random_uuid()` instead of SQLite's `randomblob()`)
- Add `register_role()` API for custom role registration
- Document custom role registration in security model docs
- Fix admin nav active state hover styling

## Test plan
- [ ] Run migrations on PostgreSQL database
- [ ] Test custom role registration
- [ ] Verify admin nav styling

🤖 Generated with [Claude Code](https://claude.com/claude-code)