### PR TITLE
Add next query parameter support for auth redirects

### DIFF
--- a/docs/core-concepts/configuration.md
+++ b/docs/core-concepts/configuration.md
@@ -106,6 +106,7 @@ Configure OAuth providers and redirect URLs:
 ```yaml
 auth:
   redirect_base_url: http://localhost:8080
+  allowed_redirect_domains: []  # Domains allowed for post-login redirects
   providers:
     google:
       client_id: $GOOGLE_CLIENT_ID
@@ -115,7 +116,15 @@ auth:
       client_secret: $GITHUB_CLIENT_SECRET
 ```
 
-See [OAuth Providers](../reference/auth-providers.md) for provider-specific setup.
+| Option | Description | Default |
+|--------|-------------|---------|
+| `redirect_base_url` | Base URL for OAuth callbacks | `http://localhost:8000` |
+| `allowed_redirect_domains` | Domains allowed for `?next=` redirects | `[]` (relative paths only) |
+| `providers` | OAuth provider configurations | `{}` |
+
+The `allowed_redirect_domains` setting controls where users can be redirected after login when using the `?next=` query parameter. Supports wildcard patterns like `*.example.com`.
+
+See [OAuth Providers](../reference/auth-providers.md) for provider-specific setup and redirect configuration.
 
 ## Environment-Specific Configuration
 
@@ -149,6 +158,8 @@ This separation prevents common security mistakes:
 
     auth:
       redirect_base_url: https://yourdomain.com
+      allowed_redirect_domains:
+        - yourdomain.com  # Allow redirects to subdomains
       providers:
         google:
           client_id: $GOOGLE_CLIENT_ID

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "skrift"
-version = "0.1.0a10"
+version = "0.1.0a11"
 description = "A lightweight async Python CMS for crafting modern websites"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/skrift/config.py
+++ b/skrift/config.py
@@ -137,6 +137,7 @@ class AuthConfig(BaseModel):
     """Authentication configuration."""
 
     redirect_base_url: str = "http://localhost:8000"
+    allowed_redirect_domains: list[str] = []
     providers: dict[str, ProviderConfig] = {}
 
     @classmethod


### PR DESCRIPTION
## Summary
- Add `allowed_redirect_domains` config option to control where users can be redirected after login
- Add `?next=` query parameter support to `/auth/login` and `/auth/{provider}/login` routes
- Implement safe redirect URL validation with wildcard pattern support (e.g., `*.example.com`, `app-*.example.com`)
- Update documentation with post-login redirect examples and security notes

## Test plan
- [ ] Test relative paths: `/auth/login?next=/dashboard` → redirects to `/dashboard`
- [ ] Test subdomain redirects with `allowed_redirect_domains` configured
- [ ] Test blocked external URLs redirect to `/` instead
- [ ] Test protocol-relative URLs (`//evil.com`) are blocked

🤖 Generated with [Claude Code](https://claude.com/claude-code)