### PR TITLE
Add configurable session cookie domain

### DIFF
--- a/docs/core-concepts/configuration.md
+++ b/docs/core-concepts/configuration.md
@@ -126,6 +126,26 @@ The `allowed_redirect_domains` setting controls where users can be redirected af
 
 See [OAuth Providers](../reference/auth-providers.md) for provider-specific setup and redirect configuration.
 
+### Session
+
+Configure session cookie behavior:
+
+```yaml
+session:
+  cookie_domain: .example.com  # Share sessions across subdomains
+```
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `cookie_domain` | Domain for session cookies | `null` (exact host only) |
+
+Setting `cookie_domain` to `.example.com` allows session cookies to work across all subdomains (e.g., `api.example.com`, `www.example.com`). Leave unset to restrict cookies to the exact host.
+
+```yaml
+session:
+  cookie_domain: $SESSION_COOKIE_DOMAIN  # From environment variable
+```
+
 ## Environment-Specific Configuration
 
 Different environments need different settings. Skrift uses the `SKRIFT_ENV` variable to select the right config file:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "skrift"
-version = "0.1.0a11"
+version = "0.1.0a12"
 description = "A lightweight async Python CMS for crafting modern websites"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/skrift/asgi.py
+++ b/skrift/asgi.py
@@ -416,6 +416,7 @@ def create_app() -> Litestar:
         httponly=True,
         secure=not settings.debug,
         samesite="lax",
+        domain=settings.session.cookie_domain,
     )
 
     # Template configuration

--- a/skrift/config.py
+++ b/skrift/config.py
@@ -133,6 +133,12 @@ class DummyProviderConfig(BaseModel):
 ProviderConfig = OAuthProviderConfig | DummyProviderConfig
 
 
+class SessionConfig(BaseModel):
+    """Session cookie configuration."""
+
+    cookie_domain: str | None = None  # None = exact host only
+
+
 class AuthConfig(BaseModel):
     """Authentication configuration."""
 
@@ -176,6 +182,9 @@ class Settings(BaseSettings):
 
     # Auth config (loaded from app.yaml)
     auth: AuthConfig = AuthConfig()
+
+    # Session config (loaded from app.yaml)
+    session: SessionConfig = SessionConfig()
 
 
 def clear_settings_cache() -> None:
@@ -240,6 +249,9 @@ def get_settings() -> Settings:
 
     if "auth" in app_config:
         updates["auth"] = AuthConfig(**app_config["auth"])
+
+    if "session" in app_config:
+        updates["session"] = SessionConfig(**app_config["session"])
 
     if updates:
         return base_settings.model_copy(update=updates)


### PR DESCRIPTION
## Summary
- Add `SessionConfig` class with `cookie_domain` setting
- Allow session cookies to work across subdomains (e.g., `.example.com`)
- Add documentation for session configuration

## Test plan
- [ ] Without config: Cookie should have no domain attribute (current behavior)
- [ ] With `cookie_domain: .example.com`: Cookie should include `Domain=.example.com`
- [ ] Test via browser dev tools to verify cookie attributes

🤖 Generated with [Claude Code](https://claude.com/claude-code)