### PR TITLE
Fix settings loading with nested configs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "skrift"
-version = "0.1.0a12"
+version = "0.1.0a13"
 description = "A lightweight async Python CMS for crafting modern websites"
 readme = "README.md"
 requires-python = ">=3.13"


### PR DESCRIPTION
## Summary
- Fix auth providers not loading correctly when session config is present
- Replace `model_copy` approach with direct Settings instantiation
- This avoids issues with nested BaseModel instances in Pydantic v2

## Root Cause
The `model_copy(update=...)` method in Pydantic v2 can have issues properly replacing nested BaseModel instances. By passing nested configs directly to the Settings constructor, we ensure they take precedence over any default or env-var-based values.

## Test plan
- [ ] Configure multiple auth providers with session config in app.yaml
- [ ] Verify all providers appear on login page
- [ ] Verify OAuth flow works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)