### PR TITLE
Add markdown rendering support for page content

### DIFF
--- a/docs/guides/creating-pages.md
+++ b/docs/guides/creating-pages.md
@@ -72,7 +72,22 @@ pages = await page_service.list_pages(db_session, limit=10, offset=0)
 
 ## Content Tips
 
-Page content is HTML. Use the built-in CSS framework classes for styling:
+Page content supports **Markdown** formatting, which is automatically rendered to HTML. This makes it easy to write rich content:
+
+```markdown
+# Welcome
+
+Here's a **bold** statement and a [link](/about).
+
+| Feature | Status |
+|---------|--------|
+| Tables  | Yes    |
+| Links   | Yes    |
+```
+
+See the [Markdown Content Guide](markdown-content.md) for full syntax documentation.
+
+You can also use HTML directly with the built-in CSS framework classes:
 
 ```html
 <article>
@@ -90,5 +105,6 @@ See the [CSS Framework Reference](../reference/css-framework.md) for available s
 
 ## Next Steps
 
+- [Markdown Content](markdown-content.md) - Full Markdown syntax guide
 - [Custom Templates](custom-templates.md) - Create page-specific designs
 - [CSS Framework](../reference/css-framework.md) - Style your content

--- a/docs/guides/markdown-content.md
+++ b/docs/guides/markdown-content.md
@@ -1,0 +1,167 @@
+# Markdown Content
+
+<span class="skill-badge beginner">:material-star: Beginner</span>
+
+Write page content using Markdown syntax instead of raw HTML.
+
+## Overview
+
+Page content supports Markdown formatting, which is automatically converted to HTML when displayed. This makes it easier to write and maintain content without dealing with HTML tags directly.
+
+## Basic Formatting
+
+### Headings
+
+```markdown
+# Heading 1
+## Heading 2
+### Heading 3
+#### Heading 4
+```
+
+### Text Styles
+
+```markdown
+**Bold text**
+*Italic text*
+***Bold and italic***
+`Inline code`
+```
+
+### Lists
+
+**Unordered list:**
+```markdown
+- Item one
+- Item two
+- Item three
+```
+
+**Ordered list:**
+```markdown
+1. First item
+2. Second item
+3. Third item
+```
+
+### Blockquotes
+
+```markdown
+> This is a blockquote.
+> It can span multiple lines.
+```
+
+## Links
+
+```markdown
+[Link text](https://example.com)
+[Link with title](https://example.com "Title text")
+```
+
+## Images
+
+```markdown
+![Alt text](/static/images/photo.png)
+![Image with title](/static/images/photo.png "Image title")
+```
+
+## Code Blocks
+
+**Inline code:**
+```markdown
+Use `code` for inline code.
+```
+
+**Fenced code blocks:**
+````markdown
+```
+code block
+```
+````
+
+**With language syntax highlighting:**
+````markdown
+```python
+def hello():
+    print("Hello, world!")
+```
+````
+
+## Tables
+
+```markdown
+| Column 1 | Column 2 | Column 3 |
+|----------|----------|----------|
+| Cell 1   | Cell 2   | Cell 3   |
+| Cell 4   | Cell 5   | Cell 6   |
+```
+
+### Column Alignment
+
+```markdown
+| Left     | Center   | Right    |
+|:---------|:--------:|---------:|
+| Left     | Center   | Right    |
+```
+
+- `:---` aligns left
+- `:---:` centers
+- `---:` aligns right
+
+## Footnotes
+
+Add footnotes to provide additional context:
+
+```markdown
+Here is some text with a footnote[^1].
+
+Another statement with a footnote[^note].
+
+[^1]: This is the first footnote.
+[^note]: Footnotes can have any identifier.
+```
+
+Footnotes are collected and displayed at the bottom of the rendered content.
+
+## Example Page Content
+
+```markdown
+# Welcome to Our Site
+
+We're glad you're here! This page demonstrates **Markdown** formatting.
+
+## Our Services
+
+We offer the following:
+
+- Web Development
+- Design Services
+- Consulting
+
+## Contact Us
+
+| Method | Details |
+|--------|---------|
+| Email  | hello@example.com |
+| Phone  | 555-1234 |
+
+For more information, visit our [contact page](/contact).
+
+---
+
+*Last updated: January 2026*
+```
+
+## Technical Details
+
+Skrift uses [markdown-it-py](https://github.com/executablebooks/markdown-it-py) with CommonMark compliance for rendering. The following features are enabled:
+
+- **CommonMark** - Standard Markdown specification
+- **Tables** - GitHub-flavored Markdown tables
+- **Footnotes** - Reference-style footnotes
+- **Typographer** - Smart quotes and typography improvements
+
+## Next Steps
+
+- [Creating Pages](creating-pages.md) - Learn how to create and manage pages
+- [CSS Framework](../reference/css-framework.md) - Style your rendered content

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "skrift"
-version = "0.1.0a13"
+version = "0.1.0a14"
 description = "A lightweight async Python CMS for crafting modern websites"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -17,6 +17,8 @@ dependencies = [
     "uvicorn>=0.34.0",
     "pyyaml>=6.0.0",
     "ruamel.yaml>=0.18.0",
+    "markdown-it-py>=3.0.0",
+    "mdit-py-plugins>=0.4.0",
 ]
 
 [project.scripts]

--- a/skrift/lib/__init__.py
+++ b/skrift/lib/__init__.py
@@ -1,3 +1,4 @@
+from skrift.lib.markdown import render_markdown
 from skrift.lib.template import Template
 
-__all__ = ["Template"]
+__all__ = ["Template", "render_markdown"]

--- a/skrift/lib/markdown.py
+++ b/skrift/lib/markdown.py
@@ -1,0 +1,37 @@
+"""Markdown rendering utilities for page content."""
+
+from markdown_it import MarkdownIt
+from mdit_py_plugins.footnote import footnote_plugin
+
+
+def create_markdown_renderer() -> MarkdownIt:
+    """Create a configured markdown renderer with standard plugins."""
+    md = MarkdownIt("commonmark", {"typographer": True})
+    md.enable("table")
+    footnote_plugin(md)
+    return md
+
+
+_renderer: MarkdownIt | None = None
+
+
+def get_renderer() -> MarkdownIt:
+    """Get the singleton markdown renderer, creating it if needed."""
+    global _renderer
+    if _renderer is None:
+        _renderer = create_markdown_renderer()
+    return _renderer
+
+
+def render_markdown(content: str) -> str:
+    """Render markdown content to HTML.
+
+    Args:
+        content: Markdown text to render.
+
+    Returns:
+        Rendered HTML string. Returns empty string for empty/None input.
+    """
+    if not content:
+        return ""
+    return get_renderer().render(content)

--- a/skrift/templates/page.html
+++ b/skrift/templates/page.html
@@ -14,7 +14,7 @@
     </header>
 
     <div class="page-content">
-        {{ page.content | safe }}
+        {{ page.content | markdown | safe }}
     </div>
 
     {% if not page.is_published %}

--- a/tests/test_markdown.py
+++ b/tests/test_markdown.py
@@ -1,0 +1,196 @@
+"""Tests for markdown rendering functionality."""
+
+import pytest
+
+from skrift.lib.markdown import render_markdown, get_renderer, create_markdown_renderer
+
+
+class TestRenderMarkdownEmptyInput:
+    """Tests for empty/None input handling."""
+
+    def test_none_input_returns_empty_string(self):
+        """None input returns empty string."""
+        assert render_markdown(None) == ""
+
+    def test_empty_string_returns_empty_string(self):
+        """Empty string returns empty string."""
+        assert render_markdown("") == ""
+
+    def test_whitespace_only_returns_empty(self):
+        """Whitespace-only input renders to empty output (markdown behavior)."""
+        result = render_markdown("   ")
+        assert result == ""
+
+
+class TestRenderMarkdownBasicFormatting:
+    """Tests for basic markdown formatting."""
+
+    def test_paragraph(self):
+        """Plain text becomes a paragraph."""
+        result = render_markdown("Hello world")
+        assert "<p>" in result
+        assert "Hello world" in result
+
+    def test_headings(self):
+        """Headings are rendered correctly."""
+        assert "<h1>" in render_markdown("# Heading 1")
+        assert "<h2>" in render_markdown("## Heading 2")
+        assert "<h3>" in render_markdown("### Heading 3")
+
+    def test_bold(self):
+        """Bold text is rendered."""
+        result = render_markdown("**bold text**")
+        assert "<strong>" in result
+        assert "bold text" in result
+
+    def test_italic(self):
+        """Italic text is rendered."""
+        result = render_markdown("*italic text*")
+        assert "<em>" in result
+        assert "italic text" in result
+
+    def test_code_inline(self):
+        """Inline code is rendered."""
+        result = render_markdown("`code`")
+        assert "<code>" in result
+        assert "code" in result
+
+    def test_code_block(self):
+        """Code blocks are rendered."""
+        result = render_markdown("```\ncode block\n```")
+        assert "<pre>" in result
+        assert "<code>" in result
+
+
+class TestRenderMarkdownLinks:
+    """Tests for link rendering."""
+
+    def test_basic_link(self):
+        """Basic link is rendered."""
+        result = render_markdown("[link text](https://example.com)")
+        assert '<a href="https://example.com"' in result
+        assert "link text" in result
+
+    def test_link_with_title(self):
+        """Link with title attribute is rendered."""
+        result = render_markdown('[link](https://example.com "My Title")')
+        assert '<a href="https://example.com"' in result
+        assert 'title="My Title"' in result
+
+
+class TestRenderMarkdownImages:
+    """Tests for image rendering."""
+
+    def test_basic_image(self):
+        """Basic image is rendered."""
+        result = render_markdown("![Alt text](/images/photo.png)")
+        assert "<img" in result
+        assert 'src="/images/photo.png"' in result
+        assert 'alt="Alt text"' in result
+
+    def test_image_with_title(self):
+        """Image with title is rendered."""
+        result = render_markdown('![Alt](/images/photo.png "Image Title")')
+        assert 'title="Image Title"' in result
+
+
+class TestRenderMarkdownTables:
+    """Tests for table rendering."""
+
+    def test_basic_table(self):
+        """Basic table is rendered."""
+        markdown = """| Col 1 | Col 2 |
+|-------|-------|
+| A     | B     |
+| C     | D     |"""
+        result = render_markdown(markdown)
+        assert "<table>" in result
+        assert "<thead>" in result
+        assert "<tbody>" in result
+        assert "<tr>" in result
+        assert "<th>" in result
+        assert "<td>" in result
+
+    def test_table_with_alignment(self):
+        """Table with column alignment is rendered."""
+        markdown = """| Left | Center | Right |
+|:-----|:------:|------:|
+| L    | C      | R     |"""
+        result = render_markdown(markdown)
+        assert "<table>" in result
+        # Alignment should be in style attributes
+        assert 'style="text-align:left"' in result
+        assert 'style="text-align:center"' in result
+        assert 'style="text-align:right"' in result
+
+
+class TestRenderMarkdownFootnotes:
+    """Tests for footnote rendering."""
+
+    def test_single_footnote(self):
+        """Single footnote is rendered."""
+        markdown = """Text with footnote[^1].
+
+[^1]: Footnote content."""
+        result = render_markdown(markdown)
+        # Check for footnote reference
+        assert "footnote" in result.lower()
+
+    def test_multiple_footnotes(self):
+        """Multiple footnotes are rendered."""
+        markdown = """First[^1] and second[^2].
+
+[^1]: First footnote.
+[^2]: Second footnote."""
+        result = render_markdown(markdown)
+        # Both footnotes should be present
+        assert "First footnote" in result
+        assert "Second footnote" in result
+
+
+class TestRendererSingleton:
+    """Tests for renderer singleton behavior."""
+
+    def test_get_renderer_returns_same_instance(self):
+        """get_renderer returns the same instance on multiple calls."""
+        renderer1 = get_renderer()
+        renderer2 = get_renderer()
+        assert renderer1 is renderer2
+
+    def test_create_markdown_renderer_returns_new_instance(self):
+        """create_markdown_renderer creates a new instance each time."""
+        renderer1 = create_markdown_renderer()
+        renderer2 = create_markdown_renderer()
+        assert renderer1 is not renderer2
+
+
+class TestRenderMarkdownLists:
+    """Tests for list rendering."""
+
+    def test_unordered_list(self):
+        """Unordered list is rendered."""
+        markdown = """- Item 1
+- Item 2
+- Item 3"""
+        result = render_markdown(markdown)
+        assert "<ul>" in result
+        assert "<li>" in result
+
+    def test_ordered_list(self):
+        """Ordered list is rendered."""
+        markdown = """1. First
+2. Second
+3. Third"""
+        result = render_markdown(markdown)
+        assert "<ol>" in result
+        assert "<li>" in result
+
+
+class TestRenderMarkdownBlockquotes:
+    """Tests for blockquote rendering."""
+
+    def test_blockquote(self):
+        """Blockquote is rendered."""
+        result = render_markdown("> This is a quote")
+        assert "<blockquote>" in result
+        assert "This is a quote" in result

--- a/uv.lock
+++ b/uv.lock
@@ -543,6 +543,18 @@ wheels = [
 ]
 
 [[package]]
+name = "mdit-py-plugins"
+version = "0.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b2/fd/a756d36c0bfba5f6e39a1cdbdbfdd448dc02692467d83816dff4592a1ebc/mdit_py_plugins-0.5.0.tar.gz", hash = "sha256:f4918cb50119f50446560513a8e311d574ff6aaed72606ddae6d35716fe809c6", size = 44655 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/86/dd6e5db36df29e76c7a7699123569a4a18c1623ce68d826ed96c62643cae/mdit_py_plugins-0.5.0-py3-none-any.whl", hash = "sha256:07a08422fc1936a5d26d146759e9155ea466e842f5ab2f7d2266dd084c8dab1f", size = 57205 },
+]
+
+[[package]]
 name = "mdurl"
 version = "0.1.2"
 source = { registry = "https://pypi.org/simple" }
@@ -937,7 +949,7 @@ wheels = [
 
 [[package]]
 name = "skrift"
-version = "0.1.0a9"
+version = "0.1.0a13"
 source = { editable = "." }
 dependencies = [
     { name = "advanced-alchemy" },
@@ -946,6 +958,8 @@ dependencies = [
     { name = "asyncpg" },
     { name = "httpx" },
     { name = "litestar", extra = ["cryptography", "jinja", "standard"] },
+    { name = "markdown-it-py" },
+    { name = "mdit-py-plugins" },
     { name = "pydantic-settings" },
     { name = "python-dotenv" },
     { name = "pyyaml" },
@@ -976,6 +990,8 @@ requires-dist = [
     { name = "asyncpg", specifier = ">=0.30.0" },
     { name = "httpx", specifier = ">=0.28.0" },
     { name = "litestar", extras = ["standard", "jinja", "cryptography"], specifier = ">=2.14.0" },
+    { name = "markdown-it-py", specifier = ">=3.0.0" },
+    { name = "mdit-py-plugins", specifier = ">=0.4.0" },
     { name = "pydantic-settings", specifier = ">=2.7.0" },
     { name = "python-dotenv", specifier = ">=1.0.0" },
     { name = "pyyaml", specifier = ">=6.0.0" },


### PR DESCRIPTION
## Summary
- Add markdown rendering support for page content using `markdown-it-py`
- Content is stored as markdown and rendered to HTML at display time via a Jinja2 filter
- Supports CommonMark, tables, footnotes, and standard markdown features

## Changes
- Added `markdown-it-py` and `mdit-py-plugins` dependencies
- Created `skrift/lib/markdown.py` renderer module
- Registered `markdown` Jinja2 filter in both main and setup apps
- Updated page template to use `{{ page.content | markdown | safe }}`
- Added comprehensive test suite (22 tests)
- Added markdown syntax documentation

## Test plan
- [x] All 41 tests pass
- [x] Verified basic formatting, links, images, tables, and footnotes render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)