### PR TITLE
Fix setup wizard crash — missing csp_nonce template global

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "skrift"
-version = "0.1.0a18"
+version = "0.1.0a19"
 description = "A lightweight async Python CMS for crafting modern websites"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/skrift/asgi.py
+++ b/skrift/asgi.py
@@ -589,6 +589,7 @@ def create_setup_app() -> Litestar:
             "site_tagline": lambda: "Setup",
             "site_copyright_holder": lambda: "",
             "site_copyright_start_year": lambda: None,
+            "csp_nonce": lambda: csp_nonce_var.get(""),
         })
         engine.engine.filters.update({"markdown": render_markdown})
 


### PR DESCRIPTION
## Summary
- Fixed `jinja2.exceptions.UndefinedError: 'csp_nonce' is undefined` crash when accessing the setup wizard on a fresh project
- Added `csp_nonce` to the `configure_setup_template_engine` globals dict in `create_setup_app()`, matching the main app's template configuration
- Bumped version to 0.1.0a19

## Details
The setup wizard templates (`setup/base.html`, `setup/configuring.html`) reference `csp_nonce` for CSP-compliant inline styles, but `create_setup_app()` never registered it as a Jinja2 template global. The main app registers it via `configure_template_engine`, but the setup app has its own separate `configure_setup_template_engine` that was missing this entry.

Fixes #22.

## Test plan
- [ ] Run `uv run skrift serve` on a fresh project (no database configured)
- [ ] Visit `http://localhost:8080` — should redirect to `/setup/database` without a 500 error
- [ ] Confirm the rendered HTML contains a valid `nonce` attribute on `<style>` tags

🤖 Generated with [Claude Code](https://claude.com/claude-code)