### PR TITLE
Release v0.1.0a24 — System-aware dark theme

### DIFF
--- a/demo/twitter/static/css/twitter.css
+++ b/demo/twitter/static/css/twitter.css
@@ -734,3 +734,13 @@ main.sk-content.twitter-layout {
         border-left: none;
     }
 }
+
+/* ========================================
+   Dark Theme (System Preference)
+   ======================================== */
+
+@media (prefers-color-scheme: dark) {
+    .form-error {
+        background-color: rgba(224, 85, 69, 0.12);
+    }
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "skrift"
-version = "0.1.0a23"
+version = "0.1.0a24"
 description = "A lightweight async Python CMS for crafting modern websites"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/skrift/static/css/admin.css
+++ b/skrift/static/css/admin.css
@@ -482,3 +482,33 @@
     font-size: 1rem;
     margin: 0;
 }
+
+/* ========================================
+   Dark Theme (System Preference)
+   ======================================== */
+
+@media (prefers-color-scheme: dark) {
+    :root {
+        --sk-admin-sidebar-bg: #12151a;
+    }
+
+    .sk-stat-card:hover {
+        box-shadow: 0 0.125rem 0.75rem rgba(0, 0, 0, 0.2);
+    }
+
+    .sk-pill-published {
+        background: rgba(90, 173, 90, 0.15);
+    }
+
+    .sk-pill-review {
+        background: rgba(212, 162, 74, 0.15);
+    }
+
+    .sk-mini-row {
+        border-bottom-color: rgba(255, 255, 255, 0.06);
+    }
+
+    .sk-activity-item {
+        border-bottom-color: rgba(255, 255, 255, 0.06);
+    }
+}

--- a/skrift/static/css/site.css
+++ b/skrift/static/css/site.css
@@ -341,3 +341,21 @@ article footer {
         font-size: 1.75rem;
     }
 }
+
+/* ========================================
+   Dark Theme (System Preference)
+   ======================================== */
+
+@media (prefers-color-scheme: dark) {
+    .sk-bottombar {
+        --sk-bottombar-bg: #12151a;
+    }
+
+    .sk-hero:hover {
+        box-shadow: 0 0.25rem 1.25rem rgba(0, 0, 0, 0.35);
+    }
+
+    .sk-post-card:hover {
+        box-shadow: 0 0.375rem 1.5rem rgba(0, 0, 0, 0.35);
+    }
+}

--- a/skrift/static/css/skrift.css
+++ b/skrift/static/css/skrift.css
@@ -837,3 +837,54 @@ hr {
 :focus:not(:focus-visible) {
     outline: none;
 }
+
+/* ========================================
+   Dark Theme (System Preference)
+   ======================================== */
+
+@media (prefers-color-scheme: dark) {
+    :root {
+        --sk-color-bg: #181b20;
+        --sk-color-text: #e0e4eb;
+        --sk-color-muted: #888e9e;
+        --sk-color-accent: #5b8cf7;
+        --sk-color-accent-hover: #7ba3ff;
+        --sk-color-accent-soft: rgba(91, 140, 247, 0.12);
+        --sk-color-border: #2c3240;
+        --sk-color-surface: #1e222a;
+        --sk-color-warm: #242830;
+
+        --sk-color-success: #5aad5a;
+        --sk-color-warning: #d4a24a;
+        --sk-color-error: #e05545;
+        --sk-color-info: #4da3dc;
+
+        --sk-shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.25);
+        --sk-shadow-md: 0 4px 12px rgba(0, 0, 0, 0.3);
+        --sk-shadow-lg: 0 4px 24px rgba(0, 0, 0, 0.5);
+    }
+
+    .sk-flash-success {
+        background-color: rgba(90, 173, 90, 0.15);
+    }
+
+    .sk-flash-error {
+        background-color: rgba(224, 85, 69, 0.15);
+    }
+
+    .sk-flash-warning {
+        background-color: rgba(212, 162, 74, 0.15);
+    }
+
+    .sk-flash-info {
+        background-color: rgba(77, 163, 220, 0.15);
+    }
+
+    .sk-status-published {
+        background-color: rgba(90, 173, 90, 0.15);
+    }
+
+    .sk-status-scheduled {
+        background-color: rgba(212, 162, 74, 0.15);
+    }
+}


### PR DESCRIPTION
## Summary
Adds a system-aware dark theme that automatically activates based on OS `prefers-color-scheme: dark`. Uses a cool blue/slate palette across all CSS files — no JavaScript or template changes needed.

## Changes

### New Features
- Dark theme via `@media (prefers-color-scheme: dark)` with cool-toned color overrides in `skrift.css`
- Admin-specific dark overrides in `admin.css` (sidebar, pills, borders)
- Public site dark overrides in `site.css` (bottom bar, card hover shadows)
- Twitter demo dark override in `twitter.css` (form error background)

## Release version
`0.1.0a23` -> `0.1.0a24`