### PR TITLE
Persist OAuth access_token and refresh_token

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "skrift"
-version = "0.1.0a27"
+version = "0.1.0a28"
 description = "A lightweight async Python CMS for crafting modern websites"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/skrift/alembic/versions/20260216_add_oauth_tokens.py
+++ b/skrift/alembic/versions/20260216_add_oauth_tokens.py
@@ -1,0 +1,27 @@
+"""add access_token and refresh_token to oauth_accounts
+
+Revision ID: 8h9i0j1k2l3m
+Revises: 7g8h9i0j1k2l
+Create Date: 2026-02-16 10:00:00.000000
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '8h9i0j1k2l3m'
+down_revision: Union[str, None] = '7g8h9i0j1k2l'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column('oauth_accounts', sa.Column('access_token', sa.String(2048), nullable=True))
+    op.add_column('oauth_accounts', sa.Column('refresh_token', sa.String(2048), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column('oauth_accounts', 'refresh_token')
+    op.drop_column('oauth_accounts', 'access_token')

--- a/skrift/auth/oauth_account_service.py
+++ b/skrift/auth/oauth_account_service.py
@@ -28,6 +28,8 @@ async def find_or_create_oauth_user(
     provider: str,
     user_data: NormalizedUserData,
     raw_user_info: dict,
+    *,
+    tokens: dict | None = None,
 ) -> LoginResult:
     """Find an existing user by OAuth account or email, or create a new one.
 
@@ -56,6 +58,9 @@ async def find_or_create_oauth_user(
         if user_data.email:
             oauth_account.provider_email = user_data.email
         oauth_account.provider_metadata = raw_user_info
+        if tokens:
+            oauth_account.access_token = tokens.get("access_token")
+            oauth_account.refresh_token = tokens.get("refresh_token")
         return LoginResult(user=user, oauth_account=oauth_account, is_new_user=False)
 
     # Step 2: Check if a user with this email already exists
@@ -72,6 +77,8 @@ async def find_or_create_oauth_user(
             provider_account_id=user_data.oauth_id,
             provider_email=user_data.email,
             provider_metadata=raw_user_info,
+            access_token=tokens.get("access_token") if tokens else None,
+            refresh_token=tokens.get("refresh_token") if tokens else None,
             user_id=user.id,
         )
         db_session.add(oauth_account)
@@ -96,6 +103,8 @@ async def find_or_create_oauth_user(
         provider_account_id=user_data.oauth_id,
         provider_email=user_data.email,
         provider_metadata=raw_user_info,
+        access_token=tokens.get("access_token") if tokens else None,
+        refresh_token=tokens.get("refresh_token") if tokens else None,
         user_id=user.id,
     )
     db_session.add(oauth_account)

--- a/skrift/db/models/oauth_account.py
+++ b/skrift/db/models/oauth_account.py
@@ -37,6 +37,8 @@ class OAuthAccount(Base):
     provider_metadata: Mapped[dict[str, Any] | None] = mapped_column(
         JSON, nullable=True, default=None
     )
+    access_token: Mapped[str | None] = mapped_column(String(2048), nullable=True)
+    refresh_token: Mapped[str | None] = mapped_column(String(2048), nullable=True)
     user_id: Mapped[UUID] = mapped_column(
         ForeignKey("users.id", ondelete="CASCADE"), nullable=False
     )

--- a/skrift/setup/controller.py
+++ b/skrift/setup/controller.py
@@ -719,7 +719,7 @@ class SetupAuthController(Controller):
             tenant = _resolve_env_var(tenant) or "common"
 
         from skrift.controllers.auth import _exchange_and_fetch
-        user_data, user_info = await _exchange_and_fetch(
+        user_data, user_info, tokens = await _exchange_and_fetch(
             provider, None, code, redirect_uri, code_verifier,
             client_id=client_id, client_secret=client_secret, tenant=tenant,
         )
@@ -728,7 +728,7 @@ class SetupAuthController(Controller):
         async with get_setup_db_session() as db_session:
             from skrift.auth.oauth_account_service import find_or_create_oauth_user
             login_result = await find_or_create_oauth_user(
-                db_session, provider, user_data, user_info
+                db_session, provider, user_data, user_info, tokens=tokens
             )
             user = login_result.user
 

--- a/tests/test_auth_controller.py
+++ b/tests/test_auth_controller.py
@@ -127,12 +127,13 @@ class TestExchangeAndFetch:
             MockClient.return_value.__aenter__ = AsyncMock(return_value=mock_client)
             MockClient.return_value.__aexit__ = AsyncMock(return_value=None)
 
-            user_data, user_info = await _exchange_and_fetch(
+            user_data, user_info, tokens = await _exchange_and_fetch(
                 "google", mock_settings, "code123", "https://redirect"
             )
 
             assert user_data.oauth_id == "123"
             assert user_info == {"id": "123"}
+            assert tokens == {"access_token": "token123"}
 
     @pytest.mark.asyncio
     async def test_exchange_with_explicit_credentials(self):
@@ -160,12 +161,13 @@ class TestExchangeAndFetch:
             MockClient.return_value.__aenter__ = AsyncMock(return_value=mock_client)
             MockClient.return_value.__aexit__ = AsyncMock(return_value=None)
 
-            user_data, user_info = await _exchange_and_fetch(
+            user_data, user_info, tokens = await _exchange_and_fetch(
                 "github", None, "code456", "https://redirect",
                 client_id="explicit-id", client_secret="explicit-secret",
             )
 
             assert user_data.oauth_id == "456"
+            assert tokens == {"access_token": "token456"}
 
 
 class TestOAuthLogin:

--- a/tests/test_oauth_account_service.py
+++ b/tests/test_oauth_account_service.py
@@ -22,6 +22,11 @@ def raw_user_info():
     return {"id": "oauth-123", "email": "test@example.com", "name": "Test User"}
 
 
+@pytest.fixture
+def tokens():
+    return {"access_token": "access-abc", "refresh_token": "refresh-xyz"}
+
+
 class TestFindOrCreateOAuthUser:
     @pytest.mark.asyncio
     async def test_existing_oauth_account_updates_and_returns(self, user_data, raw_user_info):
@@ -54,6 +59,36 @@ class TestFindOrCreateOAuthUser:
             assert mock_user.name == "Test User"
             assert mock_user.picture_url == "https://photo.url"
             assert mock_oauth.provider_email == "test@example.com"
+
+    @pytest.mark.asyncio
+    async def test_existing_oauth_account_updates_tokens(self, user_data, raw_user_info, tokens):
+        """When OAuth account exists, tokens are updated."""
+        with patch("skrift.auth.oauth_account_service.select"), \
+             patch("skrift.auth.oauth_account_service.selectinload"):
+            from skrift.auth.oauth_account_service import find_or_create_oauth_user
+
+            mock_user = MagicMock()
+            mock_user.id = uuid4()
+            mock_user.name = "Old Name"
+            mock_user.picture_url = None
+
+            mock_oauth = MagicMock()
+            mock_oauth.user = mock_user
+            mock_oauth.provider_email = "old@email.com"
+            mock_oauth.access_token = None
+            mock_oauth.refresh_token = None
+
+            mock_session = AsyncMock()
+            mock_result = MagicMock()
+            mock_result.scalar_one_or_none.return_value = mock_oauth
+            mock_session.execute.return_value = mock_result
+
+            result = await find_or_create_oauth_user(
+                mock_session, "google", user_data, raw_user_info, tokens=tokens
+            )
+
+            assert result.oauth_account.access_token == "access-abc"
+            assert result.oauth_account.refresh_token == "refresh-xyz"
 
     @pytest.mark.asyncio
     async def test_email_match_links_new_oauth_account(self, user_data, raw_user_info):
@@ -111,6 +146,39 @@ class TestFindOrCreateOAuthUser:
             # Should have added user and oauth account
             assert mock_session.add.call_count == 2
             mock_session.flush.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_new_user_stores_tokens(self, user_data, raw_user_info, tokens):
+        """When creating a new user, tokens are stored on the OAuth account."""
+        with patch("skrift.auth.oauth_account_service.select"), \
+             patch("skrift.auth.oauth_account_service.selectinload"), \
+             patch("skrift.auth.oauth_account_service.User") as MockUser, \
+             patch("skrift.auth.oauth_account_service.OAuthAccount") as MockOAuth:
+            from skrift.auth.oauth_account_service import find_or_create_oauth_user
+
+            mock_new_user = MagicMock()
+            mock_new_user.id = uuid4()
+            MockUser.return_value = mock_new_user
+
+            mock_session = AsyncMock()
+            mock_result_none = MagicMock()
+            mock_result_none.scalar_one_or_none.return_value = None
+            mock_session.execute.side_effect = [mock_result_none, mock_result_none]
+
+            result = await find_or_create_oauth_user(
+                mock_session, "discord", user_data, raw_user_info, tokens=tokens
+            )
+
+            assert result.is_new_user is True
+            MockOAuth.assert_called_once_with(
+                provider="discord",
+                provider_account_id="oauth-123",
+                provider_email="test@example.com",
+                provider_metadata=raw_user_info,
+                access_token="access-abc",
+                refresh_token="refresh-xyz",
+                user_id=mock_new_user.id,
+            )
 
     @pytest.mark.asyncio
     async def test_no_email_skips_email_lookup(self, raw_user_info):


### PR DESCRIPTION
## Summary
- Adds `access_token` and `refresh_token` columns to `OAuthAccount` model
- Returns tokens from `_exchange_and_fetch()` and persists them via `find_or_create_oauth_user()`
- Includes Alembic migration and updated tests

Closes #33

## Test plan
- [x] `uv run pytest -m "not integration"` — 424 passed
- [x] Token storage on new account creation verified
- [x] Token update on existing account login verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)