### PR TITLE
Release v0.1.0a29 — Pydantic Logfire observability integration

### DIFF
--- a/.claude/skills/skrift-observability/SKILL.md
+++ b/.claude/skills/skrift-observability/SKILL.md
@@ -1,0 +1,182 @@
+---
+name: skrift-observability
+description: "Skrift logging and observability — Pydantic Logfire integration, structured tracing, ASGI/SQL/HTTPX instrumentation, and no-op degradation."
+---
+
+# Skrift Observability
+
+Optional structured observability powered by Pydantic Logfire. Provides request tracing, SQL query visibility, HTTP client tracking, and hook execution spans. Gracefully no-ops when logfire is not installed or not enabled.
+
+## Installation
+
+```bash
+pip install skrift[logfire]
+```
+
+This installs `logfire[asgi,sqlalchemy,httpx]>=3.0.0`. Without this extra, the observability module silently no-ops.
+
+## Configuration
+
+### app.yaml
+
+```yaml
+logfire:
+  enabled: true
+  service_name: my-site       # defaults to "skrift"
+  environment: production      # defaults to SKRIFT_ENV
+  sample_rate: 1.0             # 0.0–1.0, trace sampling rate
+  console: true                # print spans to console (dev convenience)
+```
+
+### Environment Variables
+
+```bash
+LOGFIRE_TOKEN=your-logfire-token   # Logfire reads this natively
+```
+
+The integration uses `send_to_logfire="if-token-present"`, so it works without a token in development (console-only mode).
+
+### Config Model
+
+```python
+class LogfireConfig(BaseModel):
+    enabled: bool = False
+    service_name: str = "skrift"
+    environment: str | None = None
+    sample_rate: float = 1.0
+    console: bool = False
+```
+
+Defined in `skrift/config.py`, accessed via `settings.logfire`.
+
+## Architecture
+
+### Facade Module (`skrift/lib/observability.py`)
+
+All observability goes through a thin facade that guards on a module-level `_logfire` variable. When logfire is not installed or not enabled, every function is a no-op.
+
+| Function | Purpose |
+|----------|---------|
+| `configure(settings)` | Initialize logfire from `LogfireConfig`. Called once in `create_app()`. |
+| `instrument_app(app)` | Wrap ASGI app with `logfire.instrument_asgi()`. Returns app unchanged if unavailable. |
+| `instrument_sqlalchemy(engine)` | Instrument a SQLAlchemy engine for SQL query tracing. |
+| `instrument_httpx()` | Instrument httpx globally for HTTP client tracing. |
+| `span(name, **attrs)` | Context manager yielding a logfire span or `None`. |
+| `info(msg, **kwargs)` | Structured log at info level, or no-op. |
+| `error(msg, **kwargs)` | Structured log at error level, or no-op. |
+| `warning(msg, **kwargs)` | Structured log at warning level, or no-op. |
+| `get_logfire()` | Return raw `logfire` module or `None` for advanced usage. |
+| `is_available()` | `True` if logfire is installed and configured. |
+
+### Instrumentation Points
+
+Wired in `skrift/asgi.py` during `create_app()`:
+
+1. **Early** (before app creation): `configure(settings)`, `instrument_httpx()`
+2. **On startup** (after DB ready): `instrument_sqlalchemy(engine)`, fire `logfire_configured` hook
+3. **App wrapping**: `instrument_app(app)` wraps the Litestar ASGI app
+
+### Hook Spans
+
+`HookRegistry.do_action()` and `apply_filters()` in `skrift/lib/hooks.py` are wrapped with spans:
+
+```python
+with span(f"hook.action:{hook_name}", hook_name=hook_name):
+    # execute handlers
+```
+
+Only adds overhead when logfire is active.
+
+### OAuth Span
+
+The `_exchange_and_fetch()` function in `skrift/controllers/auth.py` wraps the token exchange + user info fetch:
+
+```python
+with span("oauth.exchange:{provider_key}", provider_key=provider_key):
+    # token exchange + user info fetch
+```
+
+## Using Observability in User Code
+
+### Custom Spans
+
+```python
+from skrift.lib.observability import span
+
+with span("my_operation", item_id=str(item.id)):
+    result = await do_something()
+```
+
+### Structured Logging
+
+```python
+from skrift.lib.observability import info, error
+
+info("Page published", page_id=str(page.id), slug=page.slug)
+error("Payment failed", order_id=str(order.id), reason=str(e))
+```
+
+### Advanced: Raw Logfire Access
+
+```python
+from skrift.lib.observability import get_logfire
+
+lf = get_logfire()
+if lf:
+    # Use any logfire API directly
+    lf.instrument_celery()
+```
+
+### Extensibility via Hooks
+
+The `logfire_configured` action fires after instrumentation is complete:
+
+```python
+from skrift.lib.hooks import action
+from skrift.lib.observability import get_logfire
+
+@action("logfire_configured")
+async def my_custom_instrumentation():
+    lf = get_logfire()
+    if lf:
+        # Add custom instrumentation
+        pass
+```
+
+## What Gets Traced
+
+When enabled, you get automatic visibility into:
+
+- **HTTP requests** — ASGI middleware traces every request with method, path, status, duration
+- **SQL queries** — Every SQLAlchemy query with statement text and parameters
+- **HTTP client calls** — All httpx requests (OAuth exchanges, external APIs)
+- **Hook execution** — Every `do_action()` and `apply_filters()` call with hook name
+- **OAuth flows** — Token exchange + user info fetch grouped in a single span
+
+## No-Op Behavior
+
+When logfire is not installed or `logfire.enabled` is `false`:
+
+- All facade functions return immediately or yield `None`
+- `instrument_app()` returns the app unchanged
+- `span()` yields `None`
+- Zero import overhead (logfire import is inside `configure()`)
+- Existing tests pass without changes
+
+## Hook Constants
+
+```python
+from skrift.lib.hooks import LOGFIRE_CONFIGURED
+
+# LOGFIRE_CONFIGURED = "logfire_configured"
+```
+
+## Key Files
+
+| File | Purpose |
+|------|---------|
+| `skrift/lib/observability.py` | Facade module — all observability API |
+| `skrift/config.py` | `LogfireConfig` model |
+| `skrift/asgi.py` | Wiring: configure, instrument, wrap app |
+| `skrift/lib/hooks.py` | Span wrapping on `do_action`/`apply_filters` |
+| `skrift/controllers/auth.py` | OAuth exchange span |

--- a/.claude/skills/skrift/SKILL.md
+++ b/.claude/skills/skrift/SKILL.md
@@ -36,6 +36,7 @@ Skrift is a lightweight async Python CMS built on Litestar, featuring WordPress-
 - **Forms**: Pydantic-backed with CSRF (see `/skrift-forms`)
 - **Hooks**: WordPress-style extensibility (see `/skrift-hooks`)
 - **Notifications**: Real-time SSE with pluggable backends (see `/skrift-notifications`)
+- **Observability**: Optional Logfire tracing and structured logging (see `/skrift-observability`)
 
 ### AppDispatcher Pattern
 
@@ -74,6 +75,7 @@ Skrift is a lightweight async Python CMS built on Litestar, featuring WordPress-
 | `skrift/auth/` | Guards, roles, permissions |
 | `skrift/lib/notifications.py` | Real-time notification service (SSE) |
 | `skrift/lib/notification_backends.py` | Pluggable backends (InMemory, Redis, PgNotify) |
+| `skrift/lib/observability.py` | Logfire observability facade (tracing, logging) |
 | `skrift/db/models/notification.py` | StoredNotification model for DB-backed backends |
 
 ### Configuration System
@@ -111,6 +113,11 @@ redis:
 
 notifications:
   backend: ""  # empty = InMemoryBackend; or "module:ClassName"
+
+logfire:
+  enabled: true
+  service_name: my-site
+  console: true  # prints spans to console
 
 security_headers:
   content_security_policy: "default-src 'self'"
@@ -273,3 +280,4 @@ For deep-dive guidance on specific subsystems:
 - **`/skrift-forms`** — Form system, CSRF, field customization, template rendering
 - **`/skrift-auth`** — OAuth flow, guard system, roles, permissions
 - **`/skrift-notifications`** — SSE protocol, pluggable backends, group keys, dismiss patterns
+- **`/skrift-observability`** — Logfire integration, structured tracing, instrumentation

--- a/docs/core-concepts/configuration.md
+++ b/docs/core-concepts/configuration.md
@@ -258,6 +258,31 @@ When enabled:
 - Template auto-reload
 - SQL query logging possible
 
+### Observability (Logfire)
+
+Enable structured tracing with [Pydantic Logfire](https://logfire.pydantic.dev/):
+
+```yaml
+logfire:
+  enabled: true
+  service_name: my-site          # Identifies your app in Logfire
+  environment: production         # Defaults to SKRIFT_ENV
+  sample_rate: 1.0                # 0.0–1.0 trace sampling
+  console: true                   # Print spans to console (dev)
+```
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `enabled` | Enable Logfire integration | `false` |
+| `service_name` | Service name in Logfire dashboard | `skrift` |
+| `environment` | Environment label | `SKRIFT_ENV` value |
+| `sample_rate` | Trace sampling rate (0.0–1.0) | `1.0` |
+| `console` | Print spans to stdout | `false` |
+
+Requires the `logfire` extra: `pip install skrift[logfire]`. Without it, the integration silently no-ops. Set `LOGFIRE_TOKEN` in your environment to send data to the Logfire dashboard.
+
+When enabled, Skrift automatically traces HTTP requests, SQL queries, httpx calls, hook execution, and OAuth flows.
+
 ## Programmatic Access
 
 Access configuration in your code:

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -82,6 +82,14 @@ Step-by-step guides for building and customizing your Skrift site.
 
     [:octicons-arrow-right-24: Protecting Routes](protecting-routes.md)
 
+-   :material-chart-timeline-variant:{ .lg .middle } **Observability**
+
+    ---
+
+    Add structured tracing and logging with Pydantic Logfire.
+
+    [:octicons-arrow-right-24: Observability](observability.md)
+
 </div>
 
 ## Guide Overview
@@ -96,6 +104,7 @@ Step-by-step guides for building and customizing your Skrift site.
 | [Forms](forms.md) | Form handling | Python basics |
 | [Custom Middleware](custom-middleware.md) | Request processing | Python, ASGI |
 | [Protecting Routes](protecting-routes.md) | Security | Python basics |
+| [Observability](observability.md) | Tracing & logging | None |
 
 ## What You Can Build
 

--- a/docs/guides/observability.md
+++ b/docs/guides/observability.md
@@ -1,0 +1,122 @@
+# Observability with Logfire
+
+Skrift integrates with [Pydantic Logfire](https://logfire.pydantic.dev/) for structured tracing and observability. The integration is optional — when not installed or not enabled, everything no-ops silently.
+
+## Setup
+
+### 1. Install the extra
+
+```bash
+pip install skrift[logfire]
+```
+
+### 2. Enable in app.yaml
+
+```yaml
+logfire:
+  enabled: true
+  service_name: my-site
+  console: true  # prints spans to stdout
+```
+
+### 3. (Optional) Add a Logfire token
+
+To send data to the Logfire dashboard, set the token in your environment:
+
+```bash
+export LOGFIRE_TOKEN=your-logfire-token
+```
+
+Without a token, spans still print to console when `console: true`.
+
+## What Gets Traced Automatically
+
+Once enabled, Skrift instruments:
+
+- **HTTP requests** — every incoming request with method, path, status code, and duration
+- **SQL queries** — every SQLAlchemy query with statement text
+- **HTTP client calls** — all outgoing httpx requests (OAuth exchanges, external APIs)
+- **Hook execution** — every `do_action()` and `apply_filters()` call
+- **OAuth flows** — token exchange and user info fetch grouped in a span
+
+## Adding Custom Spans
+
+Use the `span()` context manager to trace your own operations:
+
+```python
+from skrift.lib.observability import span
+
+async def process_order(order):
+    with span("process_order", order_id=str(order.id)):
+        await validate_payment(order)
+        await ship_order(order)
+```
+
+When logfire is not available, `span()` yields `None` with zero overhead.
+
+## Structured Logging
+
+```python
+from skrift.lib.observability import info, error, warning
+
+info("Order processed", order_id=str(order.id), total=order.total)
+warning("Slow query detected", query_time_ms=elapsed)
+error("Payment failed", order_id=str(order.id), reason=str(e))
+```
+
+These are no-ops when logfire is not active.
+
+## Custom Instrumentation via Hooks
+
+The `logfire_configured` action fires after all built-in instrumentation is set up. Use it to add your own:
+
+```python
+from skrift.lib.hooks import action
+from skrift.lib.observability import get_logfire
+
+@action("logfire_configured")
+async def add_celery_instrumentation():
+    lf = get_logfire()
+    if lf:
+        lf.instrument_celery()
+```
+
+## Configuration Reference
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `enabled` | `bool` | `false` | Enable Logfire integration |
+| `service_name` | `str` | `"skrift"` | Service name in dashboard |
+| `environment` | `str \| null` | `null` (uses `SKRIFT_ENV`) | Environment label |
+| `sample_rate` | `float` | `1.0` | Trace sampling rate (0.0–1.0) |
+| `console` | `bool` | `false` | Print spans to stdout |
+
+## Development vs Production
+
+=== "Development"
+
+    ```yaml
+    logfire:
+      enabled: true
+      console: true  # See spans in terminal
+    ```
+
+    No `LOGFIRE_TOKEN` needed — spans print to console.
+
+=== "Production"
+
+    ```yaml
+    logfire:
+      enabled: true
+      service_name: my-site
+      sample_rate: 0.5  # Sample 50% of traces
+    ```
+
+    ```bash
+    export LOGFIRE_TOKEN=your-production-token
+    ```
+
+## See Also
+
+- [Configuration](../core-concepts/configuration.md) - Full config reference
+- [Hooks and Filters](hooks-and-filters.md) - Hook system for extensibility

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -70,6 +70,7 @@ These are commonly referenced from `app.yaml`:
 | `GOOGLE_CLIENT_SECRET` | `auth.providers.google.client_secret` | Google OAuth secret |
 | `GITHUB_CLIENT_ID` | `auth.providers.github.client_id` | GitHub OAuth client ID |
 | `GITHUB_CLIENT_SECRET` | `auth.providers.github.client_secret` | GitHub OAuth secret |
+| `LOGFIRE_TOKEN` | Logfire SDK | Pydantic Logfire API token (optional) |
 
 ## SKRIFT_ENV
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -70,6 +70,7 @@ nav:
     - Custom Middleware: guides/custom-middleware.md
     - Markdown Content: guides/markdown-content.md
     - Protecting Routes: guides/protecting-routes.md
+    - Observability: guides/observability.md
   - Admin:
     - admin/index.md
     - Managing Pages: admin/managing-pages.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "skrift"
-version = "0.1.0a28"
+version = "0.1.0a29"
 description = "A lightweight async Python CMS for crafting modern websites"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -61,6 +61,7 @@ exclude = [
 [project.optional-dependencies]
 docs = ["zensical>=0.0.19"]
 redis = ["redis>=5.0.0"]
+logfire = ["logfire[asgi,sqlalchemy,httpx]>=3.0.0"]
 
 [tool.ruff]
 line-length = 100

--- a/skrift/claude_skill/skrift-observability/SKILL.md
+++ b/skrift/claude_skill/skrift-observability/SKILL.md
@@ -1,0 +1,182 @@
+---
+name: skrift-observability
+description: "Skrift logging and observability — Pydantic Logfire integration, structured tracing, ASGI/SQL/HTTPX instrumentation, and no-op degradation."
+---
+
+# Skrift Observability
+
+Optional structured observability powered by Pydantic Logfire. Provides request tracing, SQL query visibility, HTTP client tracking, and hook execution spans. Gracefully no-ops when logfire is not installed or not enabled.
+
+## Installation
+
+```bash
+pip install skrift[logfire]
+```
+
+This installs `logfire[asgi,sqlalchemy,httpx]>=3.0.0`. Without this extra, the observability module silently no-ops.
+
+## Configuration
+
+### app.yaml
+
+```yaml
+logfire:
+  enabled: true
+  service_name: my-site       # defaults to "skrift"
+  environment: production      # defaults to SKRIFT_ENV
+  sample_rate: 1.0             # 0.0–1.0, trace sampling rate
+  console: true                # print spans to console (dev convenience)
+```
+
+### Environment Variables
+
+```bash
+LOGFIRE_TOKEN=your-logfire-token   # Logfire reads this natively
+```
+
+The integration uses `send_to_logfire="if-token-present"`, so it works without a token in development (console-only mode).
+
+### Config Model
+
+```python
+class LogfireConfig(BaseModel):
+    enabled: bool = False
+    service_name: str = "skrift"
+    environment: str | None = None
+    sample_rate: float = 1.0
+    console: bool = False
+```
+
+Defined in `skrift/config.py`, accessed via `settings.logfire`.
+
+## Architecture
+
+### Facade Module (`skrift/lib/observability.py`)
+
+All observability goes through a thin facade that guards on a module-level `_logfire` variable. When logfire is not installed or not enabled, every function is a no-op.
+
+| Function | Purpose |
+|----------|---------|
+| `configure(settings)` | Initialize logfire from `LogfireConfig`. Called once in `create_app()`. |
+| `instrument_app(app)` | Wrap ASGI app with `logfire.instrument_asgi()`. Returns app unchanged if unavailable. |
+| `instrument_sqlalchemy(engine)` | Instrument a SQLAlchemy engine for SQL query tracing. |
+| `instrument_httpx()` | Instrument httpx globally for HTTP client tracing. |
+| `span(name, **attrs)` | Context manager yielding a logfire span or `None`. |
+| `info(msg, **kwargs)` | Structured log at info level, or no-op. |
+| `error(msg, **kwargs)` | Structured log at error level, or no-op. |
+| `warning(msg, **kwargs)` | Structured log at warning level, or no-op. |
+| `get_logfire()` | Return raw `logfire` module or `None` for advanced usage. |
+| `is_available()` | `True` if logfire is installed and configured. |
+
+### Instrumentation Points
+
+Wired in `skrift/asgi.py` during `create_app()`:
+
+1. **Early** (before app creation): `configure(settings)`, `instrument_httpx()`
+2. **On startup** (after DB ready): `instrument_sqlalchemy(engine)`, fire `logfire_configured` hook
+3. **App wrapping**: `instrument_app(app)` wraps the Litestar ASGI app
+
+### Hook Spans
+
+`HookRegistry.do_action()` and `apply_filters()` in `skrift/lib/hooks.py` are wrapped with spans:
+
+```python
+with span(f"hook.action:{hook_name}", hook_name=hook_name):
+    # execute handlers
+```
+
+Only adds overhead when logfire is active.
+
+### OAuth Span
+
+The `_exchange_and_fetch()` function in `skrift/controllers/auth.py` wraps the token exchange + user info fetch:
+
+```python
+with span("oauth.exchange:{provider_key}", provider_key=provider_key):
+    # token exchange + user info fetch
+```
+
+## Using Observability in User Code
+
+### Custom Spans
+
+```python
+from skrift.lib.observability import span
+
+with span("my_operation", item_id=str(item.id)):
+    result = await do_something()
+```
+
+### Structured Logging
+
+```python
+from skrift.lib.observability import info, error
+
+info("Page published", page_id=str(page.id), slug=page.slug)
+error("Payment failed", order_id=str(order.id), reason=str(e))
+```
+
+### Advanced: Raw Logfire Access
+
+```python
+from skrift.lib.observability import get_logfire
+
+lf = get_logfire()
+if lf:
+    # Use any logfire API directly
+    lf.instrument_celery()
+```
+
+### Extensibility via Hooks
+
+The `logfire_configured` action fires after instrumentation is complete:
+
+```python
+from skrift.lib.hooks import action
+from skrift.lib.observability import get_logfire
+
+@action("logfire_configured")
+async def my_custom_instrumentation():
+    lf = get_logfire()
+    if lf:
+        # Add custom instrumentation
+        pass
+```
+
+## What Gets Traced
+
+When enabled, you get automatic visibility into:
+
+- **HTTP requests** — ASGI middleware traces every request with method, path, status, duration
+- **SQL queries** — Every SQLAlchemy query with statement text and parameters
+- **HTTP client calls** — All httpx requests (OAuth exchanges, external APIs)
+- **Hook execution** — Every `do_action()` and `apply_filters()` call with hook name
+- **OAuth flows** — Token exchange + user info fetch grouped in a single span
+
+## No-Op Behavior
+
+When logfire is not installed or `logfire.enabled` is `false`:
+
+- All facade functions return immediately or yield `None`
+- `instrument_app()` returns the app unchanged
+- `span()` yields `None`
+- Zero import overhead (logfire import is inside `configure()`)
+- Existing tests pass without changes
+
+## Hook Constants
+
+```python
+from skrift.lib.hooks import LOGFIRE_CONFIGURED
+
+# LOGFIRE_CONFIGURED = "logfire_configured"
+```
+
+## Key Files
+
+| File | Purpose |
+|------|---------|
+| `skrift/lib/observability.py` | Facade module — all observability API |
+| `skrift/config.py` | `LogfireConfig` model |
+| `skrift/asgi.py` | Wiring: configure, instrument, wrap app |
+| `skrift/lib/hooks.py` | Span wrapping on `do_action`/`apply_filters` |
+| `skrift/controllers/auth.py` | OAuth exchange span |

--- a/skrift/claude_skill/skrift/SKILL.md
+++ b/skrift/claude_skill/skrift/SKILL.md
@@ -36,6 +36,7 @@ Skrift is a lightweight async Python CMS built on Litestar, featuring WordPress-
 - **Forms**: Pydantic-backed with CSRF (see `/skrift-forms`)
 - **Hooks**: WordPress-style extensibility (see `/skrift-hooks`)
 - **Notifications**: Real-time SSE with pluggable backends (see `/skrift-notifications`)
+- **Observability**: Optional Logfire tracing and structured logging (see `/skrift-observability`)
 
 ### AppDispatcher Pattern
 
@@ -74,6 +75,7 @@ Skrift is a lightweight async Python CMS built on Litestar, featuring WordPress-
 | `skrift/auth/` | Guards, roles, permissions |
 | `skrift/lib/notifications.py` | Real-time notification service (SSE) |
 | `skrift/lib/notification_backends.py` | Pluggable backends (InMemory, Redis, PgNotify) |
+| `skrift/lib/observability.py` | Logfire observability facade (tracing, logging) |
 | `skrift/db/models/notification.py` | StoredNotification model for DB-backed backends |
 
 ### Configuration System
@@ -111,6 +113,11 @@ redis:
 
 notifications:
   backend: ""  # empty = InMemoryBackend; or "module:ClassName"
+
+logfire:
+  enabled: true
+  service_name: my-site
+  console: true  # prints spans to console
 
 security_headers:
   content_security_policy: "default-src 'self'"
@@ -273,3 +280,4 @@ For deep-dive guidance on specific subsystems:
 - **`/skrift-forms`** — Form system, CSRF, field customization, template rendering
 - **`/skrift-auth`** — OAuth flow, guard system, roles, permissions
 - **`/skrift-notifications`** — SSE protocol, pluggable backends, group keys, dismiss patterns
+- **`/skrift-observability`** — Logfire integration, structured tracing, instrumentation

--- a/skrift/config.py
+++ b/skrift/config.py
@@ -223,6 +223,16 @@ class RedisConfig(BaseModel):
         return ":".join(segments)
 
 
+class LogfireConfig(BaseModel):
+    """Pydantic Logfire observability configuration."""
+
+    enabled: bool = False
+    service_name: str = "skrift"
+    environment: str | None = None  # defaults to SKRIFT_ENV
+    sample_rate: float = 1.0
+    console: bool = False
+
+
 class NotificationsConfig(BaseModel):
     """Notification backend configuration."""
 
@@ -290,6 +300,9 @@ class Settings(BaseSettings):
 
     # Notifications config (loaded from app.yaml)
     notifications: NotificationsConfig = NotificationsConfig()
+
+    # Logfire observability config (loaded from app.yaml)
+    logfire: LogfireConfig = LogfireConfig()
 
 
 def clear_settings_cache() -> None:
@@ -370,6 +383,9 @@ def get_settings() -> Settings:
 
     if "notifications" in app_config:
         kwargs["notifications"] = NotificationsConfig(**app_config["notifications"])
+
+    if "logfire" in app_config:
+        kwargs["logfire"] = LogfireConfig(**app_config["logfire"])
 
     # Create Settings with YAML nested configs
     # BaseSettings will still load debug/secret_key from env, but kwargs take precedence

--- a/skrift/lib/hooks.py
+++ b/skrift/lib/hooks.py
@@ -156,9 +156,12 @@ class HookRegistry:
             *args: Positional arguments to pass to callbacks
             **kwargs: Keyword arguments to pass to callbacks
         """
-        handlers = self._actions.get(hook_name, [])
-        for handler in handlers:
-            await handler.call(*args, **kwargs)
+        from skrift.lib.observability import span
+
+        with span(f"hook.action:{hook_name}", hook_name=hook_name):
+            handlers = self._actions.get(hook_name, [])
+            for handler in handlers:
+                await handler.call(*args, **kwargs)
 
     async def apply_filters(
         self,
@@ -178,10 +181,13 @@ class HookRegistry:
         Returns:
             The filtered value after all callbacks have been applied
         """
-        handlers = self._filters.get(hook_name, [])
-        for handler in handlers:
-            value = await handler.call(value, *args, **kwargs)
-        return value
+        from skrift.lib.observability import span
+
+        with span(f"hook.filter:{hook_name}", hook_name=hook_name):
+            handlers = self._filters.get(hook_name, [])
+            for handler in handlers:
+                value = await handler.call(value, *args, **kwargs)
+            return value
 
     def clear(self) -> None:
         """Clear all registered hooks. Useful for testing."""
@@ -293,6 +299,9 @@ SITEMAP_URLS = "sitemap_urls"
 SITEMAP_PAGE = "sitemap_page"
 ROBOTS_TXT = "robots_txt"
 TEMPLATE_CONTEXT = "template_context"
+
+# Observability hooks
+LOGFIRE_CONFIGURED = "logfire_configured"
 
 # Notification hooks
 NOTIFICATION_SENT = "notification_sent"

--- a/skrift/lib/observability.py
+++ b/skrift/lib/observability.py
@@ -1,0 +1,101 @@
+"""Observability facade wrapping Pydantic Logfire.
+
+Provides structured tracing, request instrumentation, SQL query visibility,
+and HTTP client tracking. Gracefully no-ops when logfire is not installed
+or not enabled in configuration.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from skrift.config import Settings
+
+_logfire = None
+_configured = False
+
+
+def is_available() -> bool:
+    return _logfire is not None and _configured
+
+
+def get_logfire():
+    """Return the raw logfire module, or None if unavailable."""
+    return _logfire if _configured else None
+
+
+def configure(settings: Settings) -> None:
+    """Initialize logfire from LogfireConfig settings.
+
+    No-ops if logfire is not installed or not enabled.
+    """
+    global _logfire, _configured
+
+    if not settings.logfire.enabled:
+        return
+
+    try:
+        import logfire as lf
+    except ImportError:
+        return
+
+    kwargs: dict[str, Any] = {
+        "service_name": settings.logfire.service_name,
+        "send_to_logfire": "if-token-present",
+    }
+    if settings.logfire.environment:
+        kwargs["environment"] = settings.logfire.environment
+    if settings.logfire.sample_rate != 1.0:
+        kwargs["trace_sample_rate"] = settings.logfire.sample_rate
+    if settings.logfire.console:
+        kwargs["console"] = lf.ConsoleOptions()
+
+    lf.configure(**kwargs)
+    _logfire = lf
+    _configured = True
+
+
+def instrument_app(app):
+    """Wrap an ASGI app with logfire instrumentation. Returns the app unchanged if unavailable."""
+    if not is_available():
+        return app
+    return _logfire.instrument_asgi(app)
+
+
+def instrument_sqlalchemy(engine) -> None:
+    """Instrument a SQLAlchemy engine."""
+    if is_available():
+        _logfire.instrument_sqlalchemy(engine=engine)
+
+
+def instrument_httpx() -> None:
+    """Instrument httpx globally."""
+    if is_available():
+        _logfire.instrument_httpx()
+
+
+@contextmanager
+def span(name: str, **attrs: Any):
+    """Context manager that yields a logfire span, or None if unavailable."""
+    if is_available():
+        with _logfire.span(name, **attrs) as s:
+            yield s
+    else:
+        yield None
+
+
+def info(msg: str, **kwargs: Any) -> None:
+    if is_available():
+        _logfire.info(msg, **kwargs)
+
+
+def error(msg: str, **kwargs: Any) -> None:
+    if is_available():
+        _logfire.error(msg, **kwargs)
+
+
+def warning(msg: str, **kwargs: Any) -> None:
+    if is_available():
+        _logfire.warn(msg, **kwargs)

--- a/uv.lock
+++ b/uv.lock
@@ -954,7 +954,7 @@ wheels = [
 
 [[package]]
 name = "skrift"
-version = "0.1.0a25"
+version = "0.1.0a27"
 source = { editable = "." }
 dependencies = [
     { name = "advanced-alchemy" },


### PR DESCRIPTION
## Summary
Adds optional structured observability powered by Pydantic Logfire. When installed and enabled, Skrift automatically traces HTTP requests, SQL queries, httpx calls, hook execution, and OAuth flows. Gracefully no-ops when logfire is not installed or not enabled.

## Changes

### New Features
- `skrift/lib/observability.py` — thin facade wrapping Logfire with no-op degradation
- `LogfireConfig` model in `skrift/config.py` with `app.yaml` parsing
- `logfire` optional dependency group (`pip install skrift[logfire]`)
- ASGI, SQLAlchemy, and httpx auto-instrumentation wired in `skrift/asgi.py`
- Observability spans on `do_action()`/`apply_filters()` in hooks system
- OAuth token exchange span in `skrift/controllers/auth.py`
- `logfire_configured` action hook for user extensibility

### Docs
- New observability guide (`docs/guides/observability.md`)
- New `skrift-observability` Claude skill
- Updated configuration docs, environment variables reference, guides index, mkdocs nav
- Updated main `skrift` skill with observability references

## Release version
`0.1.0a28` -> `0.1.0a29`