### PR TITLE
Release v0.1.0a35 — Fix settings cache preload without sync PG driver

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "skrift"
-version = "0.1.0a34"
+version = "0.1.0a35"
 description = "A lightweight async Python CMS for crafting modern websites"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/uv.lock
+++ b/uv.lock
@@ -1250,7 +1250,7 @@ wheels = [
 
 [[package]]
 name = "skrift"
-version = "0.1.0a34"
+version = "0.1.0a35"
 source = { editable = "." }
 dependencies = [
     { name = "advanced-alchemy" },


### PR DESCRIPTION
## Summary
Fixes settings cache preload silently failing when only `asyncpg` is installed (no `psycopg2`), which caused empty theme resolution and 500 errors.

## Changes

### Bug Fixes
- Remove `_preload_settings_cache_sync()` which required `psycopg2` for PostgreSQL (#43)
- Add `update_template_directories()` to async `on_startup` handler so template search paths include the active theme after settings are loaded
- Remove sync preload call sites in `create_dispatcher()` and `AppDispatcher._get_or_create_main_app()`

## Release version
`0.1.0a34` -> `0.1.0a35`