### PR TITLE
Release v0.1.0a38

### DIFF
--- a/.claude/skills/skrift/SKILL.md
+++ b/.claude/skills/skrift/SKILL.md
@@ -92,6 +92,7 @@ db:
   url: $DATABASE_URL
   pool_size: 5
   echo: false
+  schema: myschema  # optional; PostgreSQL only — prefixes all tables
 
 auth:
   redirect_base_url: "https://example.com"

--- a/docs/core-concepts/configuration.md
+++ b/docs/core-concepts/configuration.md
@@ -97,7 +97,40 @@ db:
   echo: true                          # Log SQL (dev only)
   pool_size: 5                        # Connection pool
   pool_overflow: 10                   # Extra connections allowed
+  schema: myschema                    # PostgreSQL schema (optional)
 ```
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `url` | Database connection string | `sqlite+aiosqlite:///./app.db` |
+| `echo` | Log SQL queries | `false` |
+| `pool_size` | Base connection pool size | `5` |
+| `pool_overflow` | Extra connections beyond pool_size | `10` |
+| `pool_timeout` | Seconds to wait for a connection | `30` |
+| `pool_pre_ping` | Validate connections before use | `true` |
+| `schema` | PostgreSQL schema for all tables | `null` (default schema) |
+
+#### Database Schemas
+
+PostgreSQL supports schemas to isolate tables within a single database. This is useful for multi-tenant setups or separating environments (e.g., `staging` and `production` sharing one database).
+
+```yaml
+# Production (app.yaml) — tables in "app" schema
+db:
+  url: $DATABASE_URL
+  schema: app
+```
+
+When `schema` is set, SQLAlchemy prefixes all table references with the schema name (e.g., `app.users`, `app.pages`) and Alembic migrations target the correct schema.
+
+!!! warning "SQLite does not support schemas"
+    If you set `schema` with a SQLite database URL, Skrift fails at startup with a clear error. Use `app.dev.yaml` to override the database config for local development without a schema:
+
+    ```yaml
+    # Development (app.dev.yaml) — no schema needed
+    db:
+      url: sqlite+aiosqlite:///./dev.db
+    ```
 
 ### Authentication
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "skrift"
-version = "0.1.0a37"
+version = "0.1.0a38"
 description = "A lightweight async Python CMS for crafting modern websites"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/skrift/admin/helpers.py
+++ b/skrift/admin/helpers.py
@@ -12,6 +12,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from skrift.auth.services import get_user_permissions
+from skrift.auth.session_keys import SESSION_USER_ID
 from skrift.admin.navigation import build_admin_nav
 from skrift.db.models.user import User
 from skrift.db.services import page_service
@@ -71,7 +72,7 @@ def extract_page_form_data(data: dict) -> PageFormData:
 
 async def get_admin_context(request: Request, db_session: AsyncSession) -> dict:
     """Get common admin context including nav and user."""
-    user_id = request.session.get("user_id")
+    user_id = request.session.get(SESSION_USER_ID)
     if not user_id:
         raise NotAuthorizedException("Authentication required")
 
@@ -118,7 +119,7 @@ async def check_page_access(
     Raises:
         NotAuthorizedException: If the user doesn't have access.
     """
-    user_id = request.session.get("user_id")
+    user_id = request.session.get(SESSION_USER_ID)
     if not user_id:
         raise NotAuthorizedException("Authentication required")
 

--- a/skrift/admin/users.py
+++ b/skrift/admin/users.py
@@ -24,7 +24,7 @@ from skrift.auth.roles import ROLE_DEFINITIONS
 from skrift.admin.helpers import get_admin_context
 from skrift.admin.navigation import ADMIN_NAV_TAG
 from skrift.db.models.user import User
-from skrift.lib.flash import get_flash_messages
+from skrift.lib.flash import flash_error, flash_success, get_flash_messages
 
 
 class UserAdminController(Controller):
@@ -117,7 +117,7 @@ class UserAdminController(Controller):
         )
         target_user = result.scalar_one_or_none()
         if not target_user:
-            request.session["flash"] = "User not found"
+            flash_error(request, "User not found")
             return Redirect(path="/admin/users")
 
         current_roles = {role.name for role in target_user.roles}
@@ -130,5 +130,5 @@ class UserAdminController(Controller):
 
         invalidate_user_permissions_cache(user_id)
 
-        request.session["flash"] = f"Roles updated for {target_user.name or target_user.email}"
+        flash_success(request, f"Roles updated for {target_user.name or target_user.email}")
         return Redirect(path="/admin/users")

--- a/skrift/asgi.py
+++ b/skrift/asgi.py
@@ -518,6 +518,15 @@ def create_app() -> Litestar:
     # Load middleware from app.yaml
     user_middleware = load_middleware()
 
+    # Database schema configuration
+    if settings.db.db_schema:
+        if "sqlite" in settings.db.url:
+            raise ValueError(
+                f"Database schema '{settings.db.db_schema}' is configured but SQLite does not support schemas. "
+                "For dev environments, use app.dev.yaml to override the database configuration."
+            )
+        Base.metadata.schema = settings.db.db_schema
+
     # Database configuration
     if "sqlite" in settings.db.url:
         engine_config = EngineConfig(echo=settings.db.echo)

--- a/skrift/auth/guards.py
+++ b/skrift/auth/guards.py
@@ -9,6 +9,8 @@ from litestar.connection import ASGIConnection
 from litestar.exceptions import NotAuthorizedException
 from litestar.handlers import BaseRouteHandler
 
+from skrift.auth.session_keys import SESSION_USER_ID
+
 if TYPE_CHECKING:
     from skrift.auth.services import UserPermissions
 
@@ -122,7 +124,7 @@ async def auth_guard(
     from skrift.auth.services import get_user_permissions
 
     # Get user_id from session
-    user_id = connection.session.get("user_id") if connection.session else None
+    user_id = connection.session.get(SESSION_USER_ID) if connection.session else None
 
     if not user_id:
         raise NotAuthorizedException("Authentication required")

--- a/skrift/auth/session_keys.py
+++ b/skrift/auth/session_keys.py
@@ -1,0 +1,10 @@
+"""Session key constants for auth-related session data."""
+
+SESSION_USER_ID = "user_id"
+SESSION_USER_NAME = "user_name"
+SESSION_USER_EMAIL = "user_email"
+SESSION_USER_PICTURE_URL = "user_picture_url"
+SESSION_AUTH_NEXT = "auth_next"
+SESSION_OAUTH_STATE = "oauth_state"
+SESSION_OAUTH_PROVIDER = "oauth_provider"
+SESSION_OAUTH_CODE_VERIFIER = "oauth_code_verifier"

--- a/skrift/config.py
+++ b/skrift/config.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 import yaml
 from dotenv import load_dotenv
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 # Load .env file early so env vars are available for YAML interpolation
@@ -148,6 +148,7 @@ class DatabaseConfig(BaseModel):
     pool_timeout: int = 30
     pool_pre_ping: bool = True  # Validate connections before use
     echo: bool = False
+    db_schema: str | None = Field(default=None, validation_alias="schema")
 
 
 class OAuthProviderConfig(BaseModel):

--- a/skrift/controllers/sitemap.py
+++ b/skrift/controllers/sitemap.py
@@ -23,6 +23,11 @@ class SitemapEntry:
     priority: float | None = None
 
 
+def _get_base_url(request: Request) -> str:
+    """Get the site base URL from settings or fall back to request."""
+    return get_cached_site_base_url() or str(request.base_url).rstrip("/")
+
+
 class SitemapController(Controller):
     """Controller for sitemap.xml and robots.txt."""
 
@@ -33,7 +38,7 @@ class SitemapController(Controller):
         self, request: Request, db_session: AsyncSession
     ) -> Response:
         """Generate sitemap.xml with published pages."""
-        base_url = get_cached_site_base_url() or str(request.base_url).rstrip("/")
+        base_url = _get_base_url(request)
 
         # Get all published pages (respects scheduling)
         pages = await page_service.list_pages(db_session, published_only=True)
@@ -97,7 +102,7 @@ class SitemapController(Controller):
         self, request: Request, db_session: AsyncSession
     ) -> Response:
         """Generate robots.txt with sitemap reference."""
-        base_url = get_cached_site_base_url() or str(request.base_url).rstrip("/")
+        base_url = _get_base_url(request)
         sitemap_url = f"{base_url}/sitemap.xml"
 
         content = f"""User-agent: *

--- a/skrift/controllers/web.py
+++ b/skrift/controllers/web.py
@@ -7,6 +7,7 @@ from litestar.response import Template as TemplateResponse
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from skrift.auth.session_keys import SESSION_USER_ID
 from skrift.db.models.user import User
 from skrift.db.services import page_service
 from skrift.db.services.setting_service import get_cached_site_name, get_cached_site_base_url, get_cached_site_theme
@@ -24,7 +25,7 @@ class WebController(Controller):
         self, request: "Request", db_session: AsyncSession
     ) -> dict:
         """Get user data for template context if logged in."""
-        user_id = request.session.get("user_id")
+        user_id = request.session.get(SESSION_USER_ID)
         if not user_id:
             return {"user": None}
 
@@ -67,7 +68,7 @@ class WebController(Controller):
 
         # Fetch page from database
         page = await page_service.get_page_by_slug(
-            db_session, page_slug, published_only=not request.session.get("user_id")
+            db_session, page_slug, published_only=not request.session.get(SESSION_USER_ID)
         )
         if not page:
             raise NotFoundException(f"Page '{path}' not found")

--- a/skrift/lib/client_ip.py
+++ b/skrift/lib/client_ip.py
@@ -1,0 +1,15 @@
+"""Client IP extraction from ASGI scope."""
+
+from litestar.types import Scope
+
+
+def get_client_ip(scope: Scope) -> str:
+    """Extract client IP, checking x-forwarded-for first."""
+    headers = dict(scope.get("headers", []))
+    forwarded = headers.get(b"x-forwarded-for")
+    if forwarded:
+        return forwarded.decode().split(",")[0].strip()
+    client = scope.get("client")
+    if client:
+        return client[0]
+    return "unknown"

--- a/skrift/lib/sliding_window.py
+++ b/skrift/lib/sliding_window.py
@@ -1,0 +1,69 @@
+"""Per-key sliding window counter using monotonic timestamps."""
+
+import time
+
+
+class SlidingWindowCounter:
+    """Tracks per-key hit counts within a sliding time window.
+
+    Used for rate limiting and failed-auth tracking. Periodically prunes
+    stale entries to bound memory usage.
+    """
+
+    def __init__(self, window: float = 60.0, cleanup_interval: float = 60.0) -> None:
+        self.window = window
+        self._buckets: dict[str, list[float]] = {}
+        self._last_cleanup = time.monotonic()
+        self._cleanup_interval = cleanup_interval
+
+    def _cleanup_stale(self, now: float) -> None:
+        if now - self._last_cleanup < self._cleanup_interval:
+            return
+        self._last_cleanup = now
+        cutoff = now - self.window
+        stale_keys = []
+        for key, timestamps in self._buckets.items():
+            self._buckets[key] = [t for t in timestamps if t > cutoff]
+            if not self._buckets[key]:
+                stale_keys.append(key)
+        for key in stale_keys:
+            del self._buckets[key]
+
+    def record(self, key: str) -> None:
+        """Record a hit for *key*."""
+        now = time.monotonic()
+        self._cleanup_stale(now)
+        self._buckets.setdefault(key, []).append(now)
+
+    def count(self, key: str) -> int:
+        """Return the number of hits for *key* within the current window."""
+        now = time.monotonic()
+        self._cleanup_stale(now)
+        cutoff = now - self.window
+        timestamps = self._buckets.get(key)
+        if not timestamps:
+            return 0
+        self._buckets[key] = [t for t in timestamps if t > cutoff]
+        return len(self._buckets[key])
+
+    def check_and_record(self, key: str, limit: int) -> tuple[bool, int]:
+        """Check if *key* is within *limit* and record if allowed.
+
+        Returns (allowed, retry_after_seconds). If allowed, retry_after is 0.
+        """
+        now = time.monotonic()
+        self._cleanup_stale(now)
+        cutoff = now - self.window
+
+        if key not in self._buckets:
+            self._buckets[key] = []
+
+        self._buckets[key] = [t for t in self._buckets[key] if t > cutoff]
+
+        if len(self._buckets[key]) >= limit:
+            oldest = self._buckets[key][0]
+            retry_after = int(oldest - cutoff) + 1
+            return False, max(retry_after, 1)
+
+        self._buckets[key].append(now)
+        return True, 0

--- a/skrift/middleware/rate_limit.py
+++ b/skrift/middleware/rate_limit.py
@@ -4,9 +4,10 @@ Implements per-client-IP sliding window rate limiting. Auth paths get stricter
 limits, and custom per-path-prefix overrides are supported.
 """
 
-import time
-
 from litestar.types import ASGIApp, Receive, Scope, Send
+
+from skrift.lib.client_ip import get_client_ip
+from skrift.lib.sliding_window import SlidingWindowCounter
 
 
 class RateLimitMiddleware:
@@ -30,21 +31,7 @@ class RateLimitMiddleware:
         self.requests_per_minute = requests_per_minute
         self.auth_requests_per_minute = auth_requests_per_minute
         self.paths = paths or {}
-        # Buckets: key -> list of timestamps
-        self._buckets: dict[str, list[float]] = {}
-        self._last_cleanup = time.monotonic()
-        self._cleanup_interval = 60.0  # seconds
-
-    def _get_client_ip(self, scope: Scope) -> str:
-        """Extract client IP, checking x-forwarded-for first."""
-        headers = dict(scope.get("headers", []))
-        forwarded = headers.get(b"x-forwarded-for")
-        if forwarded:
-            return forwarded.decode().split(",")[0].strip()
-        client = scope.get("client")
-        if client:
-            return client[0]
-        return "unknown"
+        self._counter = SlidingWindowCounter(window=60.0)
 
     def _get_limit(self, path: str) -> tuple[str, int]:
         """Determine the rate limit and bucket suffix for a path.
@@ -66,54 +53,16 @@ class RateLimitMiddleware:
 
         return "", self.requests_per_minute
 
-    def _cleanup_stale(self, now: float) -> None:
-        """Remove expired entries from all buckets."""
-        if now - self._last_cleanup < self._cleanup_interval:
-            return
-        self._last_cleanup = now
-        cutoff = now - 60.0
-        stale_keys = []
-        for key, timestamps in self._buckets.items():
-            self._buckets[key] = [t for t in timestamps if t > cutoff]
-            if not self._buckets[key]:
-                stale_keys.append(key)
-        for key in stale_keys:
-            del self._buckets[key]
-
-    def _check_rate(self, ip: str, bucket_suffix: str, limit: int) -> tuple[bool, int]:
-        """Check if request is within rate limit.
-
-        Returns (allowed, retry_after_seconds).
-        """
-        now = time.monotonic()
-        self._cleanup_stale(now)
-
-        key = f"{ip}:{bucket_suffix}"
-        cutoff = now - 60.0
-
-        if key not in self._buckets:
-            self._buckets[key] = []
-
-        # Prune old entries for this bucket
-        self._buckets[key] = [t for t in self._buckets[key] if t > cutoff]
-
-        if len(self._buckets[key]) >= limit:
-            oldest = self._buckets[key][0]
-            retry_after = int(oldest - cutoff) + 1
-            return False, max(retry_after, 1)
-
-        self._buckets[key].append(now)
-        return True, 0
-
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         if scope["type"] != "http":
             await self.app(scope, receive, send)
             return
 
         path = scope.get("path", "/")
-        ip = self._get_client_ip(scope)
+        ip = get_client_ip(scope)
         bucket_suffix, limit = self._get_limit(path)
-        allowed, retry_after = self._check_rate(ip, bucket_suffix, limit)
+        key = f"{ip}:{bucket_suffix}"
+        allowed, retry_after = self._counter.check_and_record(key, limit)
 
         if not allowed:
             await send({

--- a/tests/test_flash.py
+++ b/tests/test_flash.py
@@ -1,7 +1,6 @@
 """Tests for the enhanced flash message system."""
 
 import pytest
-from unittest.mock import MagicMock
 
 from skrift.lib.flash import (
     FlashType,
@@ -16,11 +15,9 @@ from skrift.lib.flash import (
 
 
 @pytest.fixture
-def mock_request():
+def mock_request(mock_request_factory):
     """Create a mock request with a session dict."""
-    request = MagicMock()
-    request.session = {}
-    return request
+    return mock_request_factory()
 
 
 class TestFlashType:

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -600,9 +600,7 @@ class TestNotificationHooks:
     """Test hook integration in the notification service."""
 
     @pytest.fixture(autouse=True)
-    def _clear_hooks(self):
-        hooks.clear()
-        yield
+    def _clear_hooks(self, clean_hooks):
         hooks.clear()
 
     @pytest.fixture

--- a/tests/test_seo.py
+++ b/tests/test_seo.py
@@ -26,14 +26,6 @@ def mock_page():
     return page
 
 
-@pytest.fixture
-def clean_hooks():
-    """Reset hooks after each test."""
-    original_filters = hooks._filters.copy()
-    yield
-    hooks._filters = original_filters
-
-
 class TestSEOMeta:
     """Test the SEOMeta dataclass."""
 

--- a/tests/test_sitemap.py
+++ b/tests/test_sitemap.py
@@ -18,14 +18,6 @@ def mock_page():
     return page
 
 
-@pytest.fixture
-def clean_hooks():
-    """Reset hooks after each test."""
-    original_filters = hooks._filters.copy()
-    yield
-    hooks._filters = original_filters
-
-
 class TestSitemapEntry:
     """Test the SitemapEntry dataclass."""
 


### PR DESCRIPTION
## Summary
- Add database schema support for PostgreSQL (multi-tenant / environment isolation)
- Extract session keys, client IP, and sliding window counter into shared modules
- Refactor OAuth providers, error handlers, admin controllers, and notification system
- Consolidate test fixtures and reduce test boilerplate

## Changes

### New Features
- **Database schema support** — New `schema` field on `DatabaseConfig` lets PostgreSQL users isolate tables under a named schema (e.g. `app.users`). SQLAlchemy metadata and Alembic migrations both respect the configured schema. SQLite raises a clear startup error with guidance to use `app.dev.yaml`.

### Improvements
- **Session key constants** — All session key strings (`user_id`, `oauth_state`, etc.) centralized in `skrift/auth/session_keys.py`, eliminating scattered magic strings across auth, admin, controllers, and error handling.
- **`SlidingWindowCounter`** — Extracted shared sliding-window rate-counting logic into `skrift/lib/sliding_window.py`, used by both `RateLimitMiddleware` and the webhook `_FailedAuthLimiter`.
- **`get_client_ip`** — Extracted client IP extraction into `skrift/lib/client_ip.py`, shared by rate limiter and webhook controller.
- **OAuth provider cleanup** — `GitHubProvider` and `TwitterProvider` now delegate to `super().fetch_user_info()` instead of duplicating HTTP logic. Twitter's `build_token_data` properly strips `client_secret` from POST body (was done ad-hoc in the controller).
- **Error handler dedup** — `http_exception_handler` and `internal_server_error_handler` now share `_render_error_response`, removing duplicated template rendering.
- **Admin controller refactoring** — Page type context dict built once and spread into templates. Page-not-found redirect logic extracted to `_get_page_or_redirect`. Flash calls migrated from raw session writes to `flash_success`/`flash_error`.
- **Sitemap cleanup** — Base URL logic extracted to `_get_base_url` helper.
- **Notification system cleanup** — Simplified notification backends and service internals.
- **Test fixture consolidation** — `clean_hooks` and `mock_request_factory` fixtures moved to `conftest.py`, removing duplicates from `test_seo`, `test_sitemap`, `test_notifications`, and `test_notification_webhook`. Added `make_csrf_request` helper to reduce CSRF test boilerplate.

### Documentation
- Updated `docs/core-concepts/configuration.md` with full `db:` options table, schema usage examples, and SQLite warning.
- Updated Skrift skill reference with `schema` field in example config.

## Release version
`0.1.0a37` -> `0.1.0a38`