### PR TITLE
Fix async migrations not committing DDL

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "skrift"
-version = "0.1.0a41"
+version = "0.1.0a42"
 description = "A lightweight async Python CMS for crafting modern websites"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/skrift/alembic/env.py
+++ b/skrift/alembic/env.py
@@ -128,6 +128,7 @@ async def run_async_migrations() -> None:
         if schema:
             await connection.execute(sa.text(f"SET search_path TO {schema}"))
         await connection.run_sync(do_run_migrations)
+        await connection.commit()
 
     await connectable.dispose()
 


### PR DESCRIPTION
## Summary
- Add missing `await connection.commit()` after `connection.run_sync(do_run_migrations)` in `alembic/env.py`
- SQLAlchemy 2.0 async connections auto-begin but do NOT auto-commit — the migration DDL was silently rolling back
- Bump version to `0.1.0a42`

## Root Cause
The standard alembic async template includes `await connection.commit()` after running migrations, but this was missing from Skrift's env.py. Migrations appeared to succeed (all steps logged, return code 0) but no tables were actually created because the transaction rolled back on connection close.

## Test plan
- Deploy to a Skrift site using a PostgreSQL schema (e.g. `db.schema: my_schema`)
- Run `skrift db upgrade heads`
- Verify tables are created in the configured schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)