### PR TITLE
Fix site apps overwriting primary Jinja env

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "skrift"
-version = "0.1.0a42"
+version = "0.1.0a43"
 description = "A lightweight async Python CMS for crafting modern websites"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/skrift/app_factory.py
+++ b/skrift/app_factory.py
@@ -94,11 +94,21 @@ def update_template_directories() -> None:
 def build_template_engine_callback(
     extra_globals: dict[str, Any],
     extra_filters: dict[str, Any] | None = None,
+    register_for_updates: bool = True,
 ) -> Callable:
-    """Build a template engine callback that sets globals and filters."""
+    """Build a template engine callback that sets globals and filters.
+
+    Args:
+        register_for_updates: When True, store this engine as the module-level
+            ``_jinja_env`` so that ``update_template_directories()`` can update
+            its searchpath at runtime (e.g. after theme changes).  Set to False
+            for subsidiary apps (subdomain sites) whose template directories
+            are fixed at creation time.
+    """
     def configure_engine(engine: JinjaTemplateEngine):
-        global _jinja_env
-        _jinja_env = engine.engine
+        if register_for_updates:
+            global _jinja_env
+            _jinja_env = engine.engine
 
         engine.engine.globals.update({
             "now": datetime.now,

--- a/skrift/asgi.py
+++ b/skrift/asgi.py
@@ -556,6 +556,7 @@ def _build_site_app(
             "theme_url": ThemeStaticURL(static_url, lambda _t=theme: _t),
             "login_url": lambda: f"https://{settings.domain}/auth/login",
         },
+        register_for_updates=False,
     )
     template_config = create_template_config(template_dirs, engine_callback)
 


### PR DESCRIPTION
## Summary
- Site apps created by `_build_site_app()` call `build_template_engine_callback()` which overwrites the module-level `_jinja_env`
- This causes `update_template_directories()` (called during primary app `on_startup`) to update the wrong Jinja environment
- The primary app's theme never takes effect because its Jinja searchpath is never updated
- Add `register_for_updates` parameter — site apps pass `False` so they don't clobber the primary env reference

## Root Cause
In multisite configurations, `_build_site_app()` is called for each subdomain after the primary app's Litestar is initialized. Each site app's `configure_engine` callback overwrites `_jinja_env`, so by the time `on_startup` runs, `_jinja_env` points to the last site app's env instead of the primary's.

## Test plan
- Deploy a Skrift site with `domain`, `sites`, and a theme set in DB
- Verify the primary site renders with the correct theme
- Verify subdomain sites still render with their configured themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)