### PR TITLE
Release v0.1.0a45 — Per-subdomain site name & tagline admin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "skrift"
-version = "0.1.0a44"
+version = "0.1.0a45"
 description = "A lightweight async Python CMS for crafting modern websites"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/skrift/admin/settings.py
+++ b/skrift/admin/settings.py
@@ -34,17 +34,38 @@ class SettingsAdminController(Controller):
         self, request: Request, db_session: AsyncSession
     ) -> TemplateResponse:
         """Site settings page."""
+        from skrift.config import get_settings as get_app_settings
         from skrift.lib.theme import themes_available, discover_themes
 
         ctx = await get_admin_context(request, db_session)
-        site_settings = await setting_service.get_site_settings(db_session)
+        app_settings = get_app_settings()
 
-        # Build theme data only when themes directory exists
+        # Build sites list when multi-site is configured
+        sites_list: list[dict[str, str]] = []
+        if app_settings.sites and app_settings.domain:
+            sites_list.append({"key": "", "label": f"{app_settings.domain} (primary)"})
+            for name, site_cfg in app_settings.sites.items():
+                sites_list.append({
+                    "key": site_cfg.subdomain,
+                    "label": f"{site_cfg.subdomain}.{app_settings.domain}",
+                })
+
+        selected_site = request.query_params.get("site", "") if sites_list else ""
+
+        # Fetch settings — per-subdomain when a site is selected, global otherwise
+        if selected_site:
+            current_settings = await setting_service.get_site_settings_for_subdomain(
+                db_session, selected_site
+            )
+        else:
+            current_settings = await setting_service.get_site_settings(db_session)
+
+        # Build theme data only for primary domain
         theme_data = None
-        if themes_available():
+        if not selected_site and themes_available():
             theme_data = {
                 "themes": discover_themes(),
-                "active": site_settings.get(setting_service.SITE_THEME_KEY, ""),
+                "active": current_settings.get(setting_service.SITE_THEME_KEY, ""),
             }
 
         flash_messages = get_flash_messages(request)
@@ -52,8 +73,10 @@ class SettingsAdminController(Controller):
             "admin/settings/site.html",
             context={
                 "flash_messages": flash_messages,
-                "settings": site_settings,
+                "settings": current_settings,
                 "theme_data": theme_data,
+                "sites_list": sites_list,
+                "selected_site": selected_site,
                 **ctx,
             },
         )
@@ -72,38 +95,53 @@ class SettingsAdminController(Controller):
         from skrift.app_factory import update_template_directories
         from skrift.lib.theme import themes_available
 
+        subdomain = data.get("_site", "").strip()
         site_name = data.get("site_name", "").strip()
         site_tagline = data.get("site_tagline", "").strip()
-        site_copyright_holder = data.get("site_copyright_holder", "").strip()
-        site_copyright_start_year = data.get("site_copyright_start_year", "").strip()
 
-        await setting_service.set_setting(
-            db_session, setting_service.SITE_NAME_KEY, site_name
-        )
-        await setting_service.set_setting(
-            db_session, setting_service.SITE_TAGLINE_KEY, site_tagline
-        )
-        await setting_service.set_setting(
-            db_session, setting_service.SITE_COPYRIGHT_HOLDER_KEY, site_copyright_holder
-        )
-        await setting_service.set_setting(
-            db_session, setting_service.SITE_COPYRIGHT_START_YEAR_KEY, site_copyright_start_year
-        )
-
-        # Save theme selection if themes are available
-        if themes_available():
-            site_theme = data.get("site_theme", "").strip()
-            await setting_service.set_setting(
-                db_session, setting_service.SITE_THEME_KEY, site_theme
+        if subdomain:
+            # Per-subdomain: only save site_name and site_tagline
+            await setting_service.set_site_setting_for_subdomain(
+                db_session, subdomain, setting_service.SITE_NAME_KEY, site_name
             )
+            await setting_service.set_site_setting_for_subdomain(
+                db_session, subdomain, setting_service.SITE_TAGLINE_KEY, site_tagline
+            )
+        else:
+            # Primary domain: save all fields
+            site_copyright_holder = data.get("site_copyright_holder", "").strip()
+            site_copyright_start_year = data.get("site_copyright_start_year", "").strip()
+
+            await setting_service.set_setting(
+                db_session, setting_service.SITE_NAME_KEY, site_name
+            )
+            await setting_service.set_setting(
+                db_session, setting_service.SITE_TAGLINE_KEY, site_tagline
+            )
+            await setting_service.set_setting(
+                db_session, setting_service.SITE_COPYRIGHT_HOLDER_KEY, site_copyright_holder
+            )
+            await setting_service.set_setting(
+                db_session, setting_service.SITE_COPYRIGHT_START_YEAR_KEY, site_copyright_start_year
+            )
+
+            # Save theme selection if themes are available
+            if themes_available():
+                site_theme = data.get("site_theme", "").strip()
+                await setting_service.set_setting(
+                    db_session, setting_service.SITE_THEME_KEY, site_theme
+                )
+
+            # Update template directories for instant theme switching
+            update_template_directories()
 
         await setting_service.load_site_settings_cache(db_session)
 
-        # Update template directories for instant theme switching
-        update_template_directories()
-
         flash_success(request, "Site settings saved successfully")
-        return Redirect(path="/admin/settings")
+        redirect_path = "/admin/settings"
+        if subdomain:
+            redirect_path += f"?site={subdomain}"
+        return Redirect(path=redirect_path)
 
     @get(
         "/theme-screenshot/{name:str}",

--- a/skrift/asgi.py
+++ b/skrift/asgi.py
@@ -49,6 +49,8 @@ from skrift.db.services.setting_service import (
     load_site_settings_cache,
     get_cached_site_name,
     get_cached_site_tagline,
+    get_cached_site_name_for,
+    get_cached_site_tagline_for,
     get_cached_site_copyright_holder,
     get_cached_site_copyright_start_year,
     get_cached_site_theme,
@@ -544,8 +546,8 @@ def _build_site_app(
     template_dirs = get_template_directories_for_theme(theme)
     engine_callback = build_template_engine_callback(
         extra_globals={
-            "site_name": lambda _n=site_name: _n,
-            "site_tagline": get_cached_site_tagline,
+            "site_name": lambda _sub=site_config.subdomain: get_cached_site_name_for(_sub),
+            "site_tagline": lambda _sub=site_config.subdomain: get_cached_site_tagline_for(_sub),
             "site_copyright_holder": get_cached_site_copyright_holder,
             "site_copyright_start_year": get_cached_site_copyright_start_year,
             "active_theme": lambda _t=theme: _t,

--- a/skrift/templates/admin/settings/site.html
+++ b/skrift/templates/admin/settings/site.html
@@ -8,7 +8,21 @@
     <p>Configure your site's name, tagline, and other metadata</p>
 </hgroup>
 
+{% if sites_list %}
+<label for="site_selector">Site</label>
+<select id="site_selector" onchange="window.location.href='/admin/settings?site=' + this.value">
+    {% for site in sites_list %}
+    <option value="{{ site.key }}"{% if site.key == selected_site %} selected{% endif %}>{{ site.label }}</option>
+    {% endfor %}
+</select>
+<small class="sk-text-muted">Select which site to configure</small>
+{% endif %}
+
 <form method="post" action="/admin/settings">
+    {% if sites_list %}
+    <input type="hidden" name="_site" value="{{ selected_site }}">
+    {% endif %}
+
     <label for="site_name">Site Name</label>
     <input type="text" id="site_name" name="site_name" value="{{ settings.site_name }}" required>
     <small class="sk-text-muted">The name displayed in the header and browser title</small>
@@ -17,6 +31,7 @@
     <input type="text" id="site_tagline" name="site_tagline" value="{{ settings.site_tagline }}">
     <small class="sk-text-muted">A short description or slogan for your site</small>
 
+    {% if not selected_site %}
     <label for="site_copyright_holder">Copyright Holder</label>
     <input type="text" id="site_copyright_holder" name="site_copyright_holder" value="{{ settings.site_copyright_holder }}">
     <small class="sk-text-muted">Name displayed in the copyright notice (defaults to site name if empty)</small>
@@ -36,6 +51,7 @@
         {% endfor %}
     </select>
     <small class="sk-text-muted">Select a theme to change your site's appearance</small>
+    {% endif %}
     {% endif %}
 
     <div class="sk-form-actions">

--- a/uv.lock
+++ b/uv.lock
@@ -1250,7 +1250,7 @@ wheels = [
 
 [[package]]
 name = "skrift"
-version = "0.1.0a39"
+version = "0.1.0a45"
 source = { editable = "." }
 dependencies = [
     { name = "advanced-alchemy" },


### PR DESCRIPTION
## Summary
Adds a site selector to the admin settings page so admins can configure `site_name` and `site_tagline` independently for each subdomain when multi-site is configured. Single-site deployments are unaffected.

## Changes

### New Features
- Site selector dropdown on `/admin/settings` when `domain` + `sites` are configured in `app.yaml`
- Per-subdomain `site_name` and `site_tagline` overrides stored as namespaced keys (`site:{subdomain}:{key}`) in the existing settings table — no new models or migrations
- Per-site in-memory cache loaded alongside global settings cache
- Subdomain site apps now render their per-site name/tagline, falling back to global defaults

### Improvements
- Copyright holder, copyright start year, and theme fields are only shown when editing the primary domain
- POST redirect preserves `?site=` query param for seamless editing flow

## Release version
`0.1.0a44` -> `0.1.0a45`