### PR TITLE
Release v0.1.0a47 — Subdomain CLI & markdown content negotiation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "skrift"
-version = "0.1.0a46"
+version = "0.1.0a47"
 description = "A lightweight async Python CMS for crafting modern websites"
 readme = "README.md"
 requires-python = ">=3.13"


### PR DESCRIPTION
## Summary
Add `--subdomain` CLI option for local multi-site testing and `Accept: text/markdown` content negotiation on page views.

## Changes

### New Features
- `skrift serve --subdomain <name>` forces the site dispatcher to serve a specific subdomain without DNS/hosts configuration
- Page views return raw markdown content when `Accept: text/markdown` is requested (both `WebController` and page type controllers)

### Improvements
- Updated docs and skill files for subdomain CLI usage

## Release version
`0.1.0a46` -> `0.1.0a47`