### PR TITLE
Release v0.1.0a48 — Markdown tables & config error handling

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -107,6 +107,7 @@ Then switch back to the main branch and pull.
 
 1. Create a release with `gh release create v<new-version>` using a body that mirrors the PR's change categories but written for end-users (concise, no internal jargon).
 2. Print the release URL for the user.
+3. Creating the GitHub release automatically publishes the package to PyPI via a trusted publisher GitHub Actions workflow — no manual publish step is needed.
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "skrift"
-version = "0.1.0a47"
+version = "0.1.0a48"
 description = "A lightweight async Python CMS for crafting modern websites"
 readme = "README.md"
 requires-python = ">=3.13"


### PR DESCRIPTION
## Summary
Markdown table rendering support and fail-fast config interpolation errors.

## Changes

### New Features
- Markdown table rendering with `js-default` preset and CSS styles for content areas

### Improvements
- Config env var interpolation now fails fast with clear errors showing the YAML path and a hint to set the variable
- Release skill updated to note PyPI trusted publisher auto-publish

## Release version
`0.1.0a47` -> `0.1.0a48`