### PR TITLE
Fix silent settings fallback in alembic env.py

### DIFF
--- a/skrift/alembic/env.py
+++ b/skrift/alembic/env.py
@@ -1,6 +1,7 @@
 """Alembic environment configuration for async SQLAlchemy migrations."""
 
 import asyncio
+import logging
 from logging.config import fileConfig
 
 import sqlalchemy as sa
@@ -44,6 +45,8 @@ config = context.config
 if config.config_file_name is not None:
     fileConfig(config.config_file_name)
 
+logger = logging.getLogger("alembic.env")
+
 # Target metadata for 'autogenerate' support
 target_metadata = Base.metadata
 
@@ -54,6 +57,11 @@ def get_url() -> str:
         settings = get_settings()
         return settings.db.url
     except Exception:
+        logger.warning(
+            "Failed to load database URL from settings (missing env vars?), "
+            "falling back to alembic.ini sqlalchemy.url",
+            exc_info=True,
+        )
         # Fall back to alembic.ini config if settings can't be loaded
         return config.get_main_option("sqlalchemy.url", "")
 
@@ -64,6 +72,11 @@ def get_schema() -> str | None:
         settings = get_settings()
         return settings.db.db_schema
     except Exception:
+        logger.warning(
+            "Failed to load database schema from settings, "
+            "proceeding without schema",
+            exc_info=True,
+        )
         return None
 
 

--- a/skrift/cli.py
+++ b/skrift/cli.py
@@ -166,7 +166,14 @@ def _run_alembic(project_root: Path, args: list[str]) -> None:
     else:
         version_locations = skrift_versions
 
-    # Rewrite "upgrade head" → "upgrade heads" when multiple locations exist
+    # Rewrite "upgrade head" → "upgrade heads" when multiple locations exist.
+    #
+    # Known limitation (Alembic <=1.18): when user migrations use depends_on
+    # to reference Skrift revision IDs across version locations, "upgrade heads"
+    # can raise "RevisionError: Requested revision X overlaps with other
+    # requested revisions Y" if the depended-on revision is already applied.
+    # Workaround: run "skrift db upgrade <specific_revision>" for the new
+    # location's head instead of relying on "upgrade heads".
     if user_versions.is_dir() and len(args) >= 2:
         if args[0] == "upgrade" and args[1] == "head":
             args = list(args)


### PR DESCRIPTION
## Summary

- **Bug**: When `get_settings()` throws an exception in `alembic/env.py` (e.g. missing `REDIS_URL` or other env vars), `get_url()` silently falls back to the `alembic.ini` default (`sqlite+aiosqlite:///./app.db`) and `get_schema()` silently returns `None`. Migrations then run against SQLite instead of the configured Postgres database with zero warning.
- **Fix**: Add `logger.warning(..., exc_info=True)` to both `get_url()` and `get_schema()` exception handlers so the fallback is visible and the root cause exception is logged.
- **Docs**: Add a comment documenting the known Alembic <=1.18 limitation where `depends_on` cross-location references cause `RevisionError: Requested revision X overlaps with other requested revisions Y` when running `upgrade heads`.

## Test plan

- [ ] Verify that with valid env vars, `skrift db upgrade heads` works as before (no warnings emitted)
- [ ] Verify that with a missing env var (e.g. unset `REDIS_URL`), the warning is now logged to stderr before the fallback URL is used
- [ ] Verify the warning includes the full traceback (`exc_info=True`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)