### PR TITLE
Release v0.1.0a52 — Fix setup site DB schema configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "skrift"
-version = "0.1.0a51"
+version = "0.1.0a52"
 description = "A lightweight async Python CMS for crafting modern websites"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/skrift/setup/controller.py
+++ b/skrift/setup/controller.py
@@ -18,7 +18,7 @@ from litestar.params import Parameter
 from litestar.response import File, Redirect, Template as TemplateResponse
 from litestar.response.sse import ServerSentEvent
 from sqlalchemy import select
-from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine, async_sessionmaker
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from skrift.db.models.role import Role, user_roles
 from skrift.db.services import setting_service
@@ -34,6 +34,7 @@ from skrift.setup.config_writer import (
 from skrift.setup.providers import DUMMY_PROVIDER_KEY, OAUTH_PROVIDERS, get_all_providers, get_provider_info
 from skrift.setup.state import (
     can_connect_to_database,
+    create_setup_engine,
     get_database_url_from_yaml,
     get_first_incomplete_step,
     is_auth_configured,
@@ -54,7 +55,7 @@ async def get_setup_db_session():
     if not db_url:
         raise RuntimeError("Database not configured")
 
-    engine = create_async_engine(db_url)
+    engine = create_setup_engine(db_url)
     async_session = async_sessionmaker(engine, expire_on_commit=False)
 
     async with async_session() as session:

--- a/uv.lock
+++ b/uv.lock
@@ -1250,7 +1250,7 @@ wheels = [
 
 [[package]]
 name = "skrift"
-version = "0.1.0a46"
+version = "0.1.0a51"
 source = { editable = "." }
 dependencies = [
     { name = "advanced-alchemy" },


### PR DESCRIPTION
## Summary
Fix the setup site not applying database schema configuration, causing queries to target the wrong schema when `db.schema` is configured in `app.yaml`.

## Changes

### Bug Fixes
- Setup app (`create_setup_app`) now reads `db.schema` from `app.yaml` and applies `Base.metadata.schema` and `schema_translate_map` to the engine, mirroring the main app's `create_app()`
- `get_setup_db_session()` now uses schema-aware engine via `create_setup_engine()`
- `check_setup_in_db()` now uses schema-aware engine
- `is_site_configured()` and `is_theme_configured()` now use schema-aware engine
- `can_connect_to_database()` now uses schema-aware engine

### Improvements
- Added `get_database_schema_from_yaml()` helper to read schema config from `app.yaml`
- Added `create_setup_engine()` helper that centralizes schema-aware engine creation for all setup operations
- Extracted `_load_db_config_from_yaml()` to avoid duplicating YAML parsing logic

## Release version
`0.1.0a51` -> `0.1.0a52`

🤖 Generated with [Claude Code](https://claude.com/claude-code)