### PR TITLE
Release v0.1.0a53 — Add setup migration logging

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "skrift"
-version = "0.1.0a52"
+version = "0.1.0a53"
 description = "A lightweight async Python CMS for crafting modern websites"
 readme = "README.md"
 requires-python = ">=3.13"


### PR DESCRIPTION
## Summary
Add backend logging to the setup flow so migration failures and database connection errors are visible in server logs instead of only being sent to the frontend.

## Changes

### Bug Fixes
- Add `logging.getLogger(__name__)` to `skrift/setup/state.py` and `skrift/setup/controller.py`
- Log migration subprocess stdout/stderr and exit codes when `skrift db upgrade` or `alembic upgrade` fails
- Log database connection failures with full tracebacks
- Log migration errors in the SSE configuring status endpoint
- Log errors in `save_database()` controller action
- Replace silent `except Exception` blocks with debug-level logging for expected pre-migration cases (`is_setup_complete`, `is_site_configured`, `is_theme_configured`)
- Stop discarding migration error in `get_first_incomplete_step()` — now logs at ERROR level

## Release version
`0.1.0a52` -> `0.1.0a53`