### PR TITLE
Fix session_maker_class KeyError when setup and main apps coexist

### DIFF
--- a/skrift/asgi.py
+++ b/skrift/asgi.py
@@ -1000,6 +1000,7 @@ def create_setup_app() -> Litestar:
             create_all=False,
             session_config=AsyncSessionConfig(expire_on_commit=False),
             engine_config=engine_config,
+            session_maker_app_state_key="setup_session_maker_class",
         )
         plugins.append(SQLAlchemyPlugin(config=db_config))
 


### PR DESCRIPTION
When both create_setup_app() and create_app() are called in
create_dispatcher(), both instantiate SQLAlchemyAsyncConfig which
uses a class-level registry to ensure unique state keys. The setup
app claims "session_maker_class" first, forcing the main app to use
"session_maker_class_1" instead. The auth guard always looks up
"session_maker_class", causing a KeyError on every permission check.

Give the setup app a distinct key ("setup_session_maker_class") so
it doesn't collide with the main app's default key.

https://claude.ai/code/session_01RAeMKmtmGSdD7rHouye6Xc