### PR TITLE
Release v0.1.0a56 — Fix template resolution priority

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "skrift"
-version = "0.1.0a55"
+version = "0.1.0a56"
 description = "A lightweight async Python CMS for crafting modern websites"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/skrift/lib/exceptions.py
+++ b/skrift/lib/exceptions.py
@@ -24,10 +24,11 @@ def _accepts_html(request: Request) -> bool:
 
 def _resolve_error_template(status_code: int) -> str:
     """Resolve error template with fallback, WP-style."""
-    specific_template = f"error-{status_code}.html"
-    if (TEMPLATE_DIR / specific_template).exists():
-        return specific_template
-    return "error.html"
+    from skrift.db.services.setting_service import get_cached_site_theme
+    from skrift.lib.template import Template
+    return Template("error", str(status_code)).resolve(
+        TEMPLATE_DIR, theme_name=get_cached_site_theme()
+    )
 
 
 def _get_session_from_cookie(request: Request) -> dict | None:

--- a/skrift/lib/template.py
+++ b/skrift/lib/template.py
@@ -66,9 +66,10 @@ class Template:
 
         search_dirs = get_template_directories_for_theme(theme_name)
 
-        # Search for templates in each directory
-        for template_name in self._candidates():
-            for search_dir in search_dirs:
+        # Search each directory fully (most-specific to least-specific) before
+        # moving to the next, so theme templates always beat package templates.
+        for search_dir in search_dirs:
+            for template_name in self._candidates():
                 template_path = search_dir / template_name
                 if template_path.exists():
                     self._resolved_template = template_name

--- a/tests/test_template_try_render.py
+++ b/tests/test_template_try_render.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 import jinja2
 import pytest
 
@@ -68,3 +70,63 @@ def test_try_render_falls_back_to_less_specific_template():
     t = Template("form", "contact")
     result = t.try_render(engine)
     assert result == "Generic form"
+
+
+# --- resolve() directory-priority tests ---
+
+
+def _create_template(directory, name):
+    """Create a template file in the given directory."""
+    path = directory / name
+    path.write_text(f"template: {name}")
+
+
+@patch("skrift.app_factory.get_template_directories_for_theme")
+def test_resolve_theme_specific_wins_over_package_specific(mock_get_dirs, tmp_path):
+    """Theme's specific template beats package's specific template."""
+    theme_dir = tmp_path / "theme"
+    package_dir = tmp_path / "package"
+    theme_dir.mkdir()
+    package_dir.mkdir()
+
+    _create_template(theme_dir, "page-about.html")
+    _create_template(package_dir, "page-about.html")
+
+    mock_get_dirs.return_value = [theme_dir, package_dir]
+
+    t = Template("page", "about")
+    result = t.resolve(package_dir)
+    assert result == "page-about.html"
+
+
+@patch("skrift.app_factory.get_template_directories_for_theme")
+def test_resolve_theme_generic_wins_over_package_specific(mock_get_dirs, tmp_path):
+    """Theme's generic template beats package's more-specific template."""
+    theme_dir = tmp_path / "theme"
+    package_dir = tmp_path / "package"
+    theme_dir.mkdir()
+    package_dir.mkdir()
+
+    _create_template(theme_dir, "page.html")
+    _create_template(package_dir, "page-about.html")
+
+    mock_get_dirs.return_value = [theme_dir, package_dir]
+
+    t = Template("page", "about")
+    result = t.resolve(package_dir)
+    assert result == "page.html"
+
+
+@patch("skrift.app_factory.get_template_directories_for_theme")
+def test_resolve_package_specific_wins_when_no_theme(mock_get_dirs, tmp_path):
+    """Package's specific template is used when no theme templates exist."""
+    package_dir = tmp_path / "package"
+    package_dir.mkdir()
+
+    _create_template(package_dir, "page-about.html")
+
+    mock_get_dirs.return_value = [package_dir]
+
+    t = Template("page", "about")
+    result = t.resolve(package_dir)
+    assert result == "page-about.html"

--- a/uv.lock
+++ b/uv.lock
@@ -1250,7 +1250,7 @@ wheels = [
 
 [[package]]
 name = "skrift"
-version = "0.1.0a54"
+version = "0.1.0a55"
 source = { editable = "." }
 dependencies = [
     { name = "advanced-alchemy" },


### PR DESCRIPTION
## Summary
Fix template resolution to prioritize theme directories over package directories, matching WordPress-style behavior.

## Changes

### Bug Fixes
- Fix `Template.resolve()` loop order to search each directory fully (most-specific to least-specific) before moving to the next, so theme templates always beat package templates (#71)
- Fix `_resolve_error_template()` to use `Template.resolve()` with the active theme instead of only checking the package directory

### Tests
- Add directory-priority tests for `resolve()` covering theme-specific vs package-specific, theme-generic vs package-specific, and package-only scenarios

## Release version
`0.1.0a55` -> `0.1.0a56`