### PR TITLE
Release v0.1.0a63

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "skrift"
-version = "0.1.0a62"
+version = "0.1.0a63"
 description = "A lightweight async Python CMS for crafting modern websites"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/skrift/controllers/auth.py
+++ b/skrift/controllers/auth.py
@@ -7,6 +7,7 @@ Also supports a development-only "dummy" provider for testing.
 import base64
 import fnmatch
 import hashlib
+import logging
 import secrets
 from typing import Annotated
 from urllib.parse import urlencode, urlparse
@@ -34,6 +35,8 @@ from skrift.auth.session_keys import (
 )
 from skrift.forms import verify_csrf
 from skrift.setup.providers import DUMMY_PROVIDER_KEY, OAUTH_PROVIDERS, get_provider_info
+
+logger = logging.getLogger(__name__)
 
 
 def _is_safe_redirect_url(url: str, allowed_domains: list[str]) -> bool:
@@ -269,6 +272,12 @@ class AuthController(Controller):
         # Verify CSRF state
         stored_state = request.session.pop(SESSION_OAUTH_STATE, None)
         if not oauth_state or oauth_state != stored_state:
+            logger.warning(
+                "OAuth state mismatch: stored=%s, received=%s, session_keys=%s",
+                stored_state,
+                oauth_state,
+                list(request.session.keys()),
+            )
             raise HTTPException(status_code=400, detail="Invalid OAuth state")
 
         if not code:

--- a/tests/test_stale_session_cookie.py
+++ b/tests/test_stale_session_cookie.py
@@ -1,24 +1,23 @@
-"""Tests for stale session cookie cleanup.
+"""Tests for hostname-scoped session cookie cleanup.
 
 When cookie_domain is configured (e.g. .example.com), session cookies
 previously set without a domain (scoped to the exact hostname) can shadow
-the domain cookie.  The custom session backend in app_factory detects
-undecryptable cookies and expires them on the exact hostname.
+the domain cookie.  The custom session backend always emits a clear
+cookie without a Domain attribute to expire any hostname-scoped cookie.
 """
 
 import hashlib
 import time
 from base64 import b64encode
 from os import urandom
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import MagicMock
 
 import pytest
 from cryptography.hazmat.primitives.ciphers.aead import AESGCM
-from litestar.datastructures.cookie import Cookie
 from litestar.middleware.session.client_side import AAD, NONCE_SIZE
 from litestar.serialization import encode_json
 
-from skrift.app_factory import _SessionBackend, _SessionConfig, _STALE_SESSION_KEY
+from skrift.app_factory import _SessionBackend, _SessionConfig
 
 
 def _make_config(secret: bytes, domain: str | None = ".example.com"):
@@ -50,106 +49,13 @@ def _make_connection(cookies: dict, scope_extras: dict | None = None):
     return conn
 
 
-class TestStaleSessionDetection:
-    """Tests for _SessionBackend.load_from_connection."""
-
-    @pytest.mark.asyncio
-    async def test_valid_cookie_loads_normally(self):
-        secret = hashlib.sha256(b"test-key").digest()
-        config = _make_config(secret)
-        backend = _SessionBackend(config)
-
-        cookie_value = _encrypt_session(secret, {"user_id": "123"})
-        conn = _make_connection({"session": cookie_value})
-
-        result = await backend.load_from_connection(conn)
-
-        assert result == {"user_id": "123"}
-        assert _STALE_SESSION_KEY not in conn.scope
-
-    @pytest.mark.asyncio
-    async def test_corrupt_cookie_flags_stale(self):
-        secret = hashlib.sha256(b"test-key").digest()
-        config = _make_config(secret)
-        backend = _SessionBackend(config)
-
-        conn = _make_connection({"session": "totally-corrupt-garbage-data!!"})
-
-        result = await backend.load_from_connection(conn)
-
-        assert result == {}
-        assert conn.scope.get(_STALE_SESSION_KEY) is True
-
-    @pytest.mark.asyncio
-    async def test_wrong_key_cookie_flags_stale(self):
-        old_secret = hashlib.sha256(b"old-key").digest()
-        new_secret = hashlib.sha256(b"new-key").digest()
-        config = _make_config(new_secret)
-        backend = _SessionBackend(config)
-
-        cookie_value = _encrypt_session(old_secret, {"user_id": "123"})
-        conn = _make_connection({"session": cookie_value})
-
-        result = await backend.load_from_connection(conn)
-
-        assert result == {}
-        assert conn.scope.get(_STALE_SESSION_KEY) is True
-
-    @pytest.mark.asyncio
-    async def test_no_cookie_no_flag(self):
-        secret = hashlib.sha256(b"test-key").digest()
-        config = _make_config(secret)
-        backend = _SessionBackend(config)
-
-        conn = _make_connection({})
-
-        result = await backend.load_from_connection(conn)
-
-        assert result == {}
-        assert _STALE_SESSION_KEY not in conn.scope
-
-
-class TestStaleCookieCleanup:
+class TestHostnameCookieCleanup:
     """Tests for _SessionBackend.store_in_message."""
 
     @pytest.mark.asyncio
-    async def test_stale_cookie_cleared_without_domain(self):
-        """When a stale cookie is detected, a clear cookie without Domain should be added."""
-        secret = hashlib.sha256(b"test-key").digest()
-        config = _make_config(secret, domain=".example.com")
-        backend = _SessionBackend(config)
-
-        message = {"type": "http.response.start", "headers": []}
-        conn = _make_connection(
-            {"session": "corrupt"},
-            scope_extras={_STALE_SESSION_KEY: True},
-        )
-
-        # Store empty session (like what happens after failed decryption)
-        await backend.store_in_message({}, message, conn)
-
-        # Parse out all Set-Cookie headers
-        set_cookies = [
-            v.decode() if isinstance(v, bytes) else v
-            for k, v in message["headers"]
-            if (k.decode() if isinstance(k, bytes) else k).lower() == "set-cookie"
-        ]
-
-        # Should have at least two Set-Cookie headers:
-        # 1. The normal clear with Domain=.example.com (from parent class)
-        # 2. The hostname-scoped clear without Domain (from our override)
-        domain_clears = [c for c in set_cookies if "domain=" in c.lower()]
-        no_domain_clears = [c for c in set_cookies if "domain=" not in c.lower()]
-
-        assert len(domain_clears) >= 1, f"Expected domain clear cookie, got: {set_cookies}"
-        assert len(no_domain_clears) >= 1, f"Expected no-domain clear cookie, got: {set_cookies}"
-
-        # The no-domain clear should expire the cookie
-        assert any("expires=" in c.lower() or "max-age=0" in c.lower() for c in no_domain_clears)
-
-    @pytest.mark.asyncio
-    async def test_no_extra_clear_when_cookie_is_valid(self):
-        """When the cookie decrypts fine, no extra clear headers should be added."""
+    async def test_clears_hostname_cookie_when_domain_configured(self):
+        """When domain is configured and a session cookie is present,
+        a clear cookie without Domain should be emitted."""
         secret = hashlib.sha256(b"test-key").digest()
         config = _make_config(secret, domain=".example.com")
         backend = _SessionBackend(config)
@@ -166,26 +72,79 @@ class TestStaleCookieCleanup:
             if (k.decode() if isinstance(k, bytes) else k).lower() == "set-cookie"
         ]
 
-        # All set-cookie headers should have the configured domain
+        # Should have domain-scoped cookie AND a hostname clear
+        domain_cookies = [c for c in set_cookies if "domain=" in c.lower()]
         no_domain_clears = [
             c for c in set_cookies
-            if "session" in c.lower() and "domain=" not in c.lower() and "null" in c.lower()
+            if "domain=" not in c.lower() and "null" in c.lower()
         ]
-        assert len(no_domain_clears) == 0, f"Unexpected no-domain clear: {no_domain_clears}"
+
+        assert len(domain_cookies) >= 1, f"Expected domain cookie, got: {set_cookies}"
+        assert len(no_domain_clears) >= 1, f"Expected no-domain clear, got: {set_cookies}"
 
     @pytest.mark.asyncio
-    async def test_no_extra_clear_when_no_domain_configured(self):
+    async def test_no_clear_when_no_domain_configured(self):
         """When cookie_domain is None, no extra clear is needed."""
         secret = hashlib.sha256(b"test-key").digest()
         config = _make_config(secret, domain=None)
         backend = _SessionBackend(config)
 
+        cookie_value = _encrypt_session(secret, {"user_id": "123"})
         message = {"type": "http.response.start", "headers": []}
-        conn = _make_connection(
-            {"session": "corrupt"},
-            scope_extras={_STALE_SESSION_KEY: True},
-        )
+        conn = _make_connection({"session": cookie_value})
 
+        await backend.store_in_message({"user_id": "123"}, message, conn)
+
+        set_cookies = [
+            v.decode() if isinstance(v, bytes) else v
+            for k, v in message["headers"]
+            if (k.decode() if isinstance(k, bytes) else k).lower() == "set-cookie"
+        ]
+
+        # No hostname clear should be emitted
+        null_no_domain = [
+            c for c in set_cookies
+            if "domain=" not in c.lower() and "null" in c.lower()
+        ]
+        assert len(null_no_domain) == 0, f"Unexpected hostname clear: {null_no_domain}"
+
+    @pytest.mark.asyncio
+    async def test_no_clear_when_no_cookie_in_request(self):
+        """When no session cookie was in the request, no clear is needed."""
+        secret = hashlib.sha256(b"test-key").digest()
+        config = _make_config(secret, domain=".example.com")
+        backend = _SessionBackend(config)
+
+        message = {"type": "http.response.start", "headers": []}
+        conn = _make_connection({})  # No cookies in request
+
+        await backend.store_in_message({"user_id": "123"}, message, conn)
+
+        set_cookies = [
+            v.decode() if isinstance(v, bytes) else v
+            for k, v in message["headers"]
+            if (k.decode() if isinstance(k, bytes) else k).lower() == "set-cookie"
+        ]
+
+        # Should set the domain cookie but no hostname clear
+        null_no_domain = [
+            c for c in set_cookies
+            if "domain=" not in c.lower() and "null" in c.lower()
+        ]
+        assert len(null_no_domain) == 0, f"Unexpected hostname clear: {null_no_domain}"
+
+    @pytest.mark.asyncio
+    async def test_clears_on_logout(self):
+        """On logout (empty session), hostname cookie should also be cleared."""
+        secret = hashlib.sha256(b"test-key").digest()
+        config = _make_config(secret, domain=".example.com")
+        backend = _SessionBackend(config)
+
+        cookie_value = _encrypt_session(secret, {"user_id": "123"})
+        message = {"type": "http.response.start", "headers": []}
+        conn = _make_connection({"session": cookie_value})
+
+        # Empty session = logout
         await backend.store_in_message({}, message, conn)
 
         set_cookies = [
@@ -194,28 +153,12 @@ class TestStaleCookieCleanup:
             if (k.decode() if isinstance(k, bytes) else k).lower() == "set-cookie"
         ]
 
-        # Should only have the normal clears (without domain since none configured)
-        # No EXTRA clears from our override
-        null_cookies = [c for c in set_cookies if "null" in c.lower()]
-        # The parent class will emit one clear — we should not add another
-        assert len(null_cookies) <= 1
-
-    @pytest.mark.asyncio
-    async def test_flag_is_consumed(self):
-        """The stale session flag should be popped (consumed) after store_in_message."""
-        secret = hashlib.sha256(b"test-key").digest()
-        config = _make_config(secret, domain=".example.com")
-        backend = _SessionBackend(config)
-
-        message = {"type": "http.response.start", "headers": []}
-        conn = _make_connection(
-            {"session": "corrupt"},
-            scope_extras={_STALE_SESSION_KEY: True},
-        )
-
-        await backend.store_in_message({}, message, conn)
-
-        assert _STALE_SESSION_KEY not in conn.scope
+        # Should have both domain clear and hostname clear
+        no_domain_clears = [
+            c for c in set_cookies
+            if "domain=" not in c.lower() and "null" in c.lower()
+        ]
+        assert len(no_domain_clears) >= 1, f"Expected hostname clear on logout, got: {set_cookies}"
 
 
 class TestSessionConfigUsesCustomBackend:
@@ -228,5 +171,4 @@ class TestSessionConfigUsesCustomBackend:
     def test_middleware_creates_custom_backend(self):
         config = _make_config(hashlib.sha256(b"test").digest())
         middleware_def = config.middleware
-        # The DefineMiddleware kwargs should reference our backend
         assert middleware_def.kwargs["backend"].__class__ is _SessionBackend

--- a/uv.lock
+++ b/uv.lock
@@ -1672,7 +1672,7 @@ wheels = [
 
 [[package]]
 name = "skrift"
-version = "0.1.0a61"
+version = "0.1.0a63"
 source = { editable = "." }
 dependencies = [
     { name = "advanced-alchemy" },


### PR DESCRIPTION
## Summary
- Simplified stale session cookie cleanup — always expire hostname-scoped cookies when `cookie_domain` is configured, instead of trying to detect decryption failures
- Added diagnostic logging on OAuth state mismatch to help debug session continuity issues
- Updated tests to match simplified backend

## Test plan
- [x] Tests updated to match new behavior
- [ ] Verify stale hostname-scoped cookies are cleared on responses when `cookie_domain` is set
- [ ] Verify OAuth state mismatch logs include session key dump

🤖 Generated with [Claude Code](https://claude.com/claude-code)