### PR TITLE
Simplify codebase: deduplicate helpers, reduce redundancy, improve efficiency

### DIFF
--- a/skrift/admin/helpers.py
+++ b/skrift/admin/helpers.py
@@ -147,7 +147,7 @@ async def check_page_access(
 
     # Check ownership for users with only the 'own' permission
     if own_permission in permissions.permissions:
-        if await page_service.check_page_ownership(db_session, page.id, UUID(user_id)):
+        if page.user_id == UUID(user_id):
             return
 
     raise NotAuthorizedException("You don't have permission to access this page")

--- a/skrift/admin/media.py
+++ b/skrift/admin/media.py
@@ -58,10 +58,10 @@ class MediaAdminController(Controller):
         total = await count_assets(db_session, store=store)
 
         storage: StorageManager = request.app.state.storage_manager
-        asset_urls = {}
-        for asset in assets:
-            backend = await storage.get(asset.store)
-            asset_urls[str(asset.id)] = await backend.get_url(asset.key)
+        asset_urls = {
+            str(asset.id): await get_asset_url(storage, asset)
+            for asset in assets
+        }
 
         total_pages = max(1, (total + per_page - 1) // per_page)
 
@@ -209,10 +209,10 @@ class MediaAdminController(Controller):
         total = await count_assets(db_session)
 
         storage: StorageManager = request.app.state.storage_manager
-        asset_urls = {}
-        for asset in assets:
-            backend = await storage.get(asset.store)
-            asset_urls[str(asset.id)] = await backend.get_url(asset.key)
+        asset_urls = {
+            str(asset.id): await get_asset_url(storage, asset)
+            for asset in assets
+        }
 
         total_pages = max(1, (total + per_page - 1) // per_page)
 

--- a/skrift/auth/services.py
+++ b/skrift/auth/services.py
@@ -38,6 +38,7 @@ async def get_user_permissions(
     Results are cached with a TTL for performance.
     """
     user_id_str = str(user_id)
+    user_id_uuid = user_id if isinstance(user_id, UUID) else UUID(user_id)
 
     # Check cache
     if user_id_str in _permission_cache:
@@ -50,7 +51,7 @@ async def get_user_permissions(
 
     result = await session.execute(
         select(User)
-        .where(User.id == (UUID(user_id_str) if isinstance(user_id, str) else user_id))
+        .where(User.id == user_id_uuid)
         .options(selectinload(User.roles).selectinload(Role.permissions))
     )
     user = result.scalar_one_or_none()

--- a/skrift/controllers/auth.py
+++ b/skrift/controllers/auth.py
@@ -34,6 +34,7 @@ from skrift.auth.session_keys import (
     SESSION_USER_PICTURE_URL,
 )
 from skrift.forms import verify_csrf
+from skrift.lib.flash import flash_error, flash_info, flash_success
 from skrift.setup.providers import DUMMY_PROVIDER_KEY, OAUTH_PROVIDERS, get_provider_info
 
 logger = logging.getLogger(__name__)
@@ -266,7 +267,7 @@ class AuthController(Controller):
             raise NotFoundException(f"Unknown provider: {provider}")
 
         if error:
-            request.session["flash"] = f"OAuth error: {error}"
+            flash_error(request, f"OAuth error: {error}")
             return Redirect(path="/auth/login")
 
         # Verify CSRF state
@@ -296,7 +297,7 @@ class AuthController(Controller):
         )
         await db_session.commit()
 
-        request.session["flash"] = "Successfully logged in!"
+        flash_success(request, "Successfully logged in!")
         _set_login_session(request, login_result.user)
 
         return Redirect(path=_get_safe_redirect_url(request, settings.auth.allowed_redirect_domains))
@@ -348,7 +349,7 @@ class AuthController(Controller):
             raise NotFoundException("Dummy provider not configured")
 
         if not await verify_csrf(request):
-            request.session["flash"] = "Invalid request. Please try again."
+            flash_error(request, "Invalid request. Please try again.")
             return Redirect(path="/auth/dummy/login")
 
         form_data = await request.form()
@@ -356,7 +357,7 @@ class AuthController(Controller):
         name = form_data.get("name", "").strip()
 
         if not email:
-            request.session["flash"] = "Email is required"
+            flash_error(request, "Email is required")
             return Redirect(path="/auth/dummy/login")
 
         if not name:
@@ -374,7 +375,7 @@ class AuthController(Controller):
         )
         await db_session.commit()
 
-        request.session["flash"] = "Successfully logged in!"
+        flash_success(request, "Successfully logged in!")
         _set_login_session(request, login_result.user)
 
         return Redirect(path=_get_safe_redirect_url(request, settings.auth.allowed_redirect_domains))

--- a/skrift/controllers/helpers.py
+++ b/skrift/controllers/helpers.py
@@ -1,0 +1,29 @@
+"""Shared helpers for public-facing controllers."""
+
+from uuid import UUID
+
+from litestar import Request
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from skrift.auth.session_keys import SESSION_USER_ID
+from skrift.db.models.user import User
+from skrift.db.services.setting_service import get_cached_site_theme
+from skrift.lib.hooks import RESOLVE_THEME, apply_filters
+
+
+async def get_user_context(request: Request, db_session: AsyncSession) -> dict:
+    """Get user data for template context if logged in."""
+    user_id = request.session.get(SESSION_USER_ID)
+    if not user_id:
+        return {"user": None}
+
+    result = await db_session.execute(select(User).where(User.id == UUID(user_id)))
+    user = result.scalar_one_or_none()
+    return {"user": user}
+
+
+async def resolve_theme(request: Request) -> str:
+    """Resolve the active theme for this request via filter hook."""
+    theme_name = get_cached_site_theme()
+    return await apply_filters(RESOLVE_THEME, theme_name, request)

--- a/skrift/lib/hooks.py
+++ b/skrift/lib/hooks.py
@@ -31,7 +31,6 @@ Usage:
 import asyncio
 from collections import defaultdict
 from dataclasses import dataclass, field
-from functools import wraps
 from typing import Any, Callable, TypeVar
 
 T = TypeVar("T")
@@ -250,12 +249,7 @@ def action(hook_name: str, priority: int = 10) -> Callable[[Callable], Callable]
 
     def decorator(func: Callable) -> Callable:
         hooks.add_action(hook_name, func, priority)
-
-        @wraps(func)
-        def wrapper(*args: Any, **kwargs: Any) -> Any:
-            return func(*args, **kwargs)
-
-        return wrapper
+        return func
 
     return decorator
 
@@ -272,12 +266,7 @@ def filter(hook_name: str, priority: int = 10) -> Callable[[Callable], Callable]
 
     def decorator(func: Callable) -> Callable:
         hooks.add_filter(hook_name, func, priority)
-
-        @wraps(func)
-        def wrapper(*args: Any, **kwargs: Any) -> Any:
-            return func(*args, **kwargs)
-
-        return wrapper
+        return func
 
     return decorator
 

--- a/skrift/lib/imaging.py
+++ b/skrift/lib/imaging.py
@@ -53,20 +53,19 @@ def resize_image(
     """
     img = Image.open(io.BytesIO(data))
     orig_format = img.format or "PNG"
+    content_type = _FORMAT_TO_CONTENT_TYPE.get(orig_format, "image/png")
 
     orig_w, orig_h = img.size
 
     if max_height is not None:
         # Fit within box — don't upscale
         if orig_w <= max_width and orig_h <= max_height:
-            content_type = _FORMAT_TO_CONTENT_TYPE.get(orig_format, "image/png")
             return data, content_type
 
         img.thumbnail((max_width, max_height), Image.LANCZOS)
     else:
         # Width-constrained only — don't upscale
         if orig_w <= max_width:
-            content_type = _FORMAT_TO_CONTENT_TYPE.get(orig_format, "image/png")
             return data, content_type
 
         ratio = max_width / orig_w
@@ -84,7 +83,6 @@ def resize_image(
         save_kwargs["quality"] = 85
 
     img.save(buf, format=orig_format, **save_kwargs)
-    content_type = _FORMAT_TO_CONTENT_TYPE.get(orig_format, "image/png")
     return buf.getvalue(), content_type
 
 

--- a/skrift/middleware/helpers.py
+++ b/skrift/middleware/helpers.py
@@ -1,0 +1,13 @@
+"""Shared helpers for ASGI middleware."""
+
+from litestar.types import Send
+
+
+async def send_not_found(send: Send) -> None:
+    """Send a plain-text 404 response."""
+    await send({
+        "type": "http.response.start",
+        "status": 404,
+        "headers": [(b"content-type", b"text/plain")],
+    })
+    await send({"type": "http.response.body", "body": b"Not Found"})

--- a/tests/test_permission_tiers.py
+++ b/tests/test_permission_tiers.py
@@ -164,13 +164,12 @@ class TestCheckPageAccess:
         mock_request.session = {"user_id": str(user_id)}
         mock_page = MagicMock()
         mock_page.id = uuid4()
+        mock_page.user_id = user_id  # same user owns the page
 
-        with patch("skrift.admin.helpers.get_user_permissions") as mock_get_perms, \
-             patch("skrift.admin.helpers.page_service") as mock_ps:
+        with patch("skrift.admin.helpers.get_user_permissions") as mock_get_perms:
             mock_perms = MagicMock()
             mock_perms.permissions = {"edit-own-pages"}
             mock_get_perms.return_value = mock_perms
-            mock_ps.check_page_ownership = AsyncMock(return_value=True)
 
             await check_page_access(
                 mock_session, mock_request, mock_page,
@@ -188,13 +187,12 @@ class TestCheckPageAccess:
         mock_request.session = {"user_id": str(user_id)}
         mock_page = MagicMock()
         mock_page.id = uuid4()
+        mock_page.user_id = uuid4()  # different user owns the page
 
-        with patch("skrift.admin.helpers.get_user_permissions") as mock_get_perms, \
-             patch("skrift.admin.helpers.page_service") as mock_ps:
+        with patch("skrift.admin.helpers.get_user_permissions") as mock_get_perms:
             mock_perms = MagicMock()
             mock_perms.permissions = {"edit-own-pages"}
             mock_get_perms.return_value = mock_perms
-            mock_ps.check_page_ownership = AsyncMock(return_value=False)
 
             with pytest.raises(NotAuthorizedException):
                 await check_page_access(


### PR DESCRIPTION
- Extract _finalize_admin_setup helper in setup controller, removing ~40 lines
  of duplicated admin role sync + session population between dummy and OAuth flows
- Use session key constants (SESSION_USER_ID, etc.) instead of raw strings in setup
- Extract _is_setting_configured in setup/state.py to unify is_site_configured
  and is_theme_configured (identical except for the setting key)
- Extract get_user_context and resolve_theme into controllers/helpers.py, removing
  duplicate implementations from WebController and page_type_factory
- Extract send_not_found into middleware/helpers.py, removing identical static
  methods from StaticFilesMiddleware and StorageFilesMiddleware
- Simplify hook decorators: return func directly instead of wrapping in identity
  wrapper; remove unused functools.wraps import
- Use existing get_asset_url helper instead of inline backend.get()/get_url()
  loops in media controller and page_type_factory
- Use flash_success/flash_error helpers instead of raw session["flash"] writes
  in auth controller
- Extract _published_filters helper in page_service to deduplicate the
  published-only + scheduling filter clauses
- Hoist content_type lookup in imaging.py resize_image to avoid 3x duplication
- Import _parse_source_key from notifications.py instead of redefining it in
  notification_backends.py
- Eliminate redundant DB query in load_site_settings_cache (was loading all
  settings then loading a subset again)
- Skip redundant page re-fetch in check_page_access by comparing page.user_id
  directly instead of calling check_page_ownership
- Simplify variant/fallback branching in StorageFilesMiddleware
- Fix auth UUID conversion to do it once upfront instead of inline in the query
- Update test_permission_tiers to set mock_page.user_id directly

Net: -112 lines, 14 separate simplifications, no behavior changes.

https://claude.ai/code/session_015NvHfU1gEAbgZdJ28CWjZP