### PR TITLE
Release v0.1.0a65 — OG image fallback & Twitter Card support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "skrift"
-version = "0.1.0a64"
+version = "0.1.0a65"
 description = "A lightweight async Python CMS for crafting modern websites"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/skrift/controllers/page_type_factory.py
+++ b/skrift/controllers/page_type_factory.py
@@ -117,11 +117,7 @@ def create_public_page_type_controller(
             site_name = get_cached_site_name()
             base_url = get_cached_site_base_url() or str(request.base_url).rstrip("/")
             seo_meta = await get_page_seo_meta(page, site_name, base_url)
-            og_meta = await get_page_og_meta(page, site_name, base_url)
-
-            # Use featured image as og:image fallback
-            if not og_meta.image and featured_image_url:
-                og_meta.image = featured_image_url
+            og_meta = await get_page_og_meta(page, site_name, base_url, featured_image_url=featured_image_url)
 
             template = Template(
                 type_name, slug,

--- a/skrift/controllers/web.py
+++ b/skrift/controllers/web.py
@@ -8,8 +8,10 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from skrift.auth.session_keys import SESSION_USER_ID
 from skrift.controllers.helpers import get_user_context, resolve_theme
 from skrift.db.services import page_service
+from skrift.db.services.asset_service import get_asset_url
 from skrift.db.services.setting_service import get_cached_site_name, get_cached_site_base_url
 from skrift.lib.seo import get_page_seo_meta, get_page_og_meta
+from skrift.lib.storage import StorageManager
 from skrift.lib.template import Template
 
 TEMPLATE_DIR = Path(__file__).parent.parent.parent / "templates"
@@ -61,11 +63,17 @@ class WebController(Controller):
         flash = request.session.pop("flash", None)
         theme_name = await resolve_theme(request)
 
+        # Resolve featured asset URL
+        featured_image_url = None
+        if page.featured_asset:
+            storage: StorageManager = request.app.state.storage_manager
+            featured_image_url = await get_asset_url(storage, page.featured_asset)
+
         # Get SEO metadata
         site_name = get_cached_site_name()
         base_url = get_cached_site_base_url() or str(request.base_url).rstrip("/")
         seo_meta = await get_page_seo_meta(page, site_name, base_url)
-        og_meta = await get_page_og_meta(page, site_name, base_url)
+        og_meta = await get_page_og_meta(page, site_name, base_url, featured_image_url=featured_image_url)
 
         template = Template(
             "page", *slugs,
@@ -75,6 +83,7 @@ class WebController(Controller):
                 "page": page,
                 "seo_meta": seo_meta,
                 "og_meta": og_meta,
+                "featured_image_url": featured_image_url,
             }
         )
         return template.render(TEMPLATE_DIR, theme_name=theme_name, flash=flash, **user_ctx)

--- a/skrift/lib/imaging.py
+++ b/skrift/lib/imaging.py
@@ -12,6 +12,7 @@ IMAGE_SIZES: dict[str, tuple[int, int | None]] = {
     "small": (400, None),
     "medium": (800, None),
     "cover": (1200, None),
+    "og": (1200, 630),
 }
 
 _FORMAT_TO_CONTENT_TYPE = {

--- a/skrift/lib/seo.py
+++ b/skrift/lib/seo.py
@@ -50,6 +50,7 @@ class OpenGraphMeta:
     url: str
     site_name: str
     type: str = "website"
+    twitter_card: str = "summary_large_image"
 
     def __html__(self) -> str:
         parts = [
@@ -62,6 +63,9 @@ class OpenGraphMeta:
             parts.append(_og_tag("og:description", self.description))
         if self.image:
             parts.append(_og_tag("og:image", self.image))
+        parts.append(_meta_tag("twitter:card", self.twitter_card))
+        if self.image:
+            parts.append(_meta_tag("twitter:image", self.image))
         return Markup("\n    ".join(parts))
 
 
@@ -104,6 +108,7 @@ async def get_page_og_meta(
     page: "Page",
     site_name: str,
     base_url: str,
+    featured_image_url: str | None = None,
 ) -> OpenGraphMeta:
     """Generate OpenGraph metadata for a page.
 
@@ -111,6 +116,7 @@ async def get_page_og_meta(
         page: The page to generate metadata for
         site_name: The site name
         base_url: Base URL for URL generation
+        featured_image_url: Optional fallback image URL from the page's featured asset
 
     Returns:
         OpenGraphMeta dataclass with the metadata
@@ -122,11 +128,12 @@ async def get_page_og_meta(
     # Use og_* fields if set, otherwise fall back to page fields
     og_title = page.og_title or page.title
     og_description = page.og_description or page.meta_description
+    image = page.og_image or featured_image_url
 
     meta = OpenGraphMeta(
         title=og_title,
         description=og_description,
-        image=page.og_image,
+        image=image,
         url=url,
         site_name=site_name,
     )

--- a/skrift/templates/base.html
+++ b/skrift/templates/base.html
@@ -21,10 +21,16 @@
     {% if og_meta %}
     <meta property="og:title" content="{{ og_meta.title }}">
     {% if og_meta.description %}<meta property="og:description" content="{{ og_meta.description }}">{% endif %}
-    {% if og_meta.image %}<meta property="og:image" content="{{ og_meta.image }}">{% endif %}
+    {% if og_meta.image %}
+    <meta property="og:image" content="{{ og_meta.image | sized('og') }}">
+    <meta property="og:image:width" content="1200">
+    <meta property="og:image:height" content="630">
+    {% endif %}
     <meta property="og:url" content="{{ og_meta.url }}">
     <meta property="og:site_name" content="{{ og_meta.site_name }}">
     <meta property="og:type" content="{{ og_meta.type }}">
+    <meta name="twitter:card" content="{{ og_meta.twitter_card }}">
+    {% if og_meta.image %}<meta name="twitter:image" content="{{ og_meta.image | sized('og') }}">{% endif %}
     {% endif %}
     {% endblock %}
 

--- a/tests/test_seo.py
+++ b/tests/test_seo.py
@@ -177,6 +177,56 @@ class TestGetPageOgMeta:
         assert meta.type == "article"
 
     @pytest.mark.asyncio
+    async def test_featured_image_url_fallback(self, mock_page, clean_hooks):
+        """Test that featured_image_url is used when og_image is None."""
+        mock_page.og_image = None
+        meta = await get_page_og_meta(
+            mock_page, "My Site", "https://example.com",
+            featured_image_url="https://example.com/featured.jpg",
+        )
+
+        assert meta.image == "https://example.com/featured.jpg"
+
+    @pytest.mark.asyncio
+    async def test_og_image_takes_precedence_over_featured(self, mock_page, clean_hooks):
+        """Test that og_image takes precedence over featured_image_url."""
+        mock_page.og_image = "https://example.com/og-specific.jpg"
+        meta = await get_page_og_meta(
+            mock_page, "My Site", "https://example.com",
+            featured_image_url="https://example.com/featured.jpg",
+        )
+
+        assert meta.image == "https://example.com/og-specific.jpg"
+
+    @pytest.mark.asyncio
+    async def test_twitter_card_in_html(self, mock_page, clean_hooks):
+        """Test that __html__() emits twitter:card meta tag."""
+        meta = await get_page_og_meta(mock_page, "My Site", "https://example.com")
+        html = meta.__html__()
+
+        assert 'name="twitter:card"' in html
+        assert 'content="summary_large_image"' in html
+
+    @pytest.mark.asyncio
+    async def test_twitter_image_in_html(self, mock_page, clean_hooks):
+        """Test that __html__() emits twitter:image when image is set."""
+        mock_page.og_image = "https://example.com/image.jpg"
+        meta = await get_page_og_meta(mock_page, "My Site", "https://example.com")
+        html = meta.__html__()
+
+        assert 'name="twitter:image"' in html
+        assert 'content="https://example.com/image.jpg"' in html
+
+    @pytest.mark.asyncio
+    async def test_twitter_image_not_in_html_when_no_image(self, mock_page, clean_hooks):
+        """Test that __html__() omits twitter:image when no image is set."""
+        mock_page.og_image = None
+        meta = await get_page_og_meta(mock_page, "My Site", "https://example.com")
+        html = meta.__html__()
+
+        assert 'name="twitter:image"' not in html
+
+    @pytest.mark.asyncio
     async def test_canonical_url_generation_with_trailing_slash(self, mock_page, clean_hooks):
         """Test canonical URL generation handles trailing slashes correctly."""
         meta = await get_page_seo_meta(mock_page, "My Site", "https://example.com/")


### PR DESCRIPTION
## Summary
Adds OG image fallback from featured assets, Twitter Card meta tags, and a platform-optimized `og` image size for social sharing.

## Changes

### New Features
- Twitter Card meta tags (`twitter:card`, `twitter:image`) emitted in `<head>`
- New `og` image size (1200×630) for social platform-optimized images
- `og:image:width` and `og:image:height` dimension hints in templates

### Bug Fixes
- Pages served via the catch-all `web.py` route now resolve `featured_asset` as OG image fallback (previously only `page_type_factory.py` did this)
- Add missing model imports to Alembic env.py

### Improvements
- OG image fallback logic moved into `get_page_og_meta()` via `featured_image_url` parameter — eliminates manual post-hoc patching in controllers
- Simplify codebase: deduplicate helpers, reduce redundancy, improve efficiency

## Release version
`0.1.0a64` -> `0.1.0a65`