### PR TITLE
Release v0.1.0a66 — Fully qualify OG image URLs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "skrift"
-version = "0.1.0a65"
+version = "0.1.0a66"
 description = "A lightweight async Python CMS for crafting modern websites"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/skrift/lib/seo.py
+++ b/skrift/lib/seo.py
@@ -129,6 +129,8 @@ async def get_page_og_meta(
     og_title = page.og_title or page.title
     og_description = page.og_description or page.meta_description
     image = page.og_image or featured_image_url
+    if image and not image.startswith(("http://", "https://")):
+        image = f"{base_url.rstrip('/')}/{image.lstrip('/')}"
 
     meta = OpenGraphMeta(
         title=og_title,

--- a/tests/test_seo.py
+++ b/tests/test_seo.py
@@ -199,6 +199,27 @@ class TestGetPageOgMeta:
         assert meta.image == "https://example.com/og-specific.jpg"
 
     @pytest.mark.asyncio
+    async def test_relative_image_url_becomes_absolute(self, mock_page, clean_hooks):
+        """Test that a relative image URL is made fully qualified."""
+        mock_page.og_image = None
+        meta = await get_page_og_meta(
+            mock_page, "My Site", "https://example.com",
+            featured_image_url="/storage/default/abc123",
+        )
+
+        assert meta.image == "https://example.com/storage/default/abc123"
+
+    @pytest.mark.asyncio
+    async def test_absolute_image_url_unchanged(self, mock_page, clean_hooks):
+        """Test that an already-absolute image URL is not modified."""
+        mock_page.og_image = "https://cdn.example.com/image.jpg"
+        meta = await get_page_og_meta(
+            mock_page, "My Site", "https://example.com",
+        )
+
+        assert meta.image == "https://cdn.example.com/image.jpg"
+
+    @pytest.mark.asyncio
     async def test_twitter_card_in_html(self, mock_page, clean_hooks):
         """Test that __html__() emits twitter:card meta tag."""
         meta = await get_page_og_meta(mock_page, "My Site", "https://example.com")


### PR DESCRIPTION
## Summary
Ensures OG image URLs are fully qualified absolute URLs (e.g. `https://domain.com/path/to/image`) so social platforms can fetch them. Relative paths from local storage are now prefixed with the site's base URL.

## Changes

### Bug Fixes
- Relative image URLs (e.g. `/storage/default/abc123`) are now converted to absolute URLs in `get_page_og_meta()` using the site's `base_url`
- Already-absolute URLs (http/https) are left unchanged

## Release version
`0.1.0a65` -> `0.1.0a66`