### PR TITLE
Release v0.1.0a67 — Force HTTPS on all SEO/OG URLs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "skrift"
-version = "0.1.0a66"
+version = "0.1.0a67"
 description = "A lightweight async Python CMS for crafting modern websites"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/skrift/lib/seo.py
+++ b/skrift/lib/seo.py
@@ -12,6 +12,13 @@ if TYPE_CHECKING:
     from skrift.db.models import Page
 
 
+def _ensure_https(url: str) -> str:
+    """Upgrade http:// to https:// for public-facing URLs."""
+    if url.startswith("http://"):
+        return "https://" + url[7:]
+    return url
+
+
 def _meta_tag(name: str, content: str) -> str:
     return f'<meta name="{escape(name)}" content="{escape(content)}">'
 
@@ -84,6 +91,8 @@ async def get_page_seo_meta(
     Returns:
         SEOMeta dataclass with the metadata
     """
+    base_url = _ensure_https(base_url)
+
     # Build canonical URL
     slug = page.slug.strip("/")
     canonical_url = f"{base_url.rstrip('/')}/{slug}" if slug else base_url.rstrip("/")
@@ -121,6 +130,8 @@ async def get_page_og_meta(
     Returns:
         OpenGraphMeta dataclass with the metadata
     """
+    base_url = _ensure_https(base_url)
+
     # Build URL
     slug = page.slug.strip("/")
     url = f"{base_url.rstrip('/')}/{slug}" if slug else base_url.rstrip("/")
@@ -131,6 +142,8 @@ async def get_page_og_meta(
     image = page.og_image or featured_image_url
     if image and not image.startswith(("http://", "https://")):
         image = f"{base_url.rstrip('/')}/{image.lstrip('/')}"
+    elif image:
+        image = _ensure_https(image)
 
     meta = OpenGraphMeta(
         title=og_title,

--- a/tests/test_seo.py
+++ b/tests/test_seo.py
@@ -112,6 +112,13 @@ class TestGetPageSeoMeta:
         assert meta.robots == "noindex, nofollow"
 
     @pytest.mark.asyncio
+    async def test_http_canonical_url_upgraded_to_https(self, mock_page, clean_hooks):
+        """Test that http:// base_url produces https:// canonical URL."""
+        meta = await get_page_seo_meta(mock_page, "My Site", "http://example.com")
+
+        assert meta.canonical_url == "https://example.com/test-page"
+
+    @pytest.mark.asyncio
     async def test_get_page_seo_meta_with_filter(self, mock_page, clean_hooks):
         """Test that page_seo_meta filter modifies the result."""
         def modify_meta(meta, page, site_name, base_url):
@@ -218,6 +225,28 @@ class TestGetPageOgMeta:
         )
 
         assert meta.image == "https://cdn.example.com/image.jpg"
+
+    @pytest.mark.asyncio
+    async def test_http_base_url_upgraded_to_https(self, mock_page, clean_hooks):
+        """Test that http:// base_url is upgraded to https:// in OG URLs."""
+        mock_page.og_image = None
+        meta = await get_page_og_meta(
+            mock_page, "My Site", "http://example.com",
+            featured_image_url="/storage/default/abc123",
+        )
+
+        assert meta.image == "https://example.com/storage/default/abc123"
+        assert meta.url.startswith("https://")
+
+    @pytest.mark.asyncio
+    async def test_http_og_image_upgraded_to_https(self, mock_page, clean_hooks):
+        """Test that an http:// og_image is upgraded to https://."""
+        mock_page.og_image = "http://example.com/image.jpg"
+        meta = await get_page_og_meta(
+            mock_page, "My Site", "https://example.com",
+        )
+
+        assert meta.image == "https://example.com/image.jpg"
 
     @pytest.mark.asyncio
     async def test_twitter_card_in_html(self, mock_page, clean_hooks):


### PR DESCRIPTION
## Summary
All SEO and OpenGraph URLs are now forced to `https://`. Behind a reverse proxy that terminates TLS, `request.base_url` returns `http://` which caused social platform crawlers to get 404s or fail to fetch OG images.

## Changes

### Bug Fixes
- All canonical URLs, OG URLs, and OG image URLs are upgraded from `http://` to `https://` via `_ensure_https()` helper
- Applies to both `get_page_seo_meta()` and `get_page_og_meta()` — covers canonical URLs, og:url, og:image, and twitter:image

## Release version
`0.1.0a66` -> `0.1.0a67`