### PR TITLE
Release v0.1.0a68 — Complete OAuth2 Authorization Server

### DIFF
--- a/.claude/skills/skrift-auth/SKILL.md
+++ b/.claude/skills/skrift-auth/SKILL.md
@@ -89,10 +89,10 @@ class ArticleController(Controller):
 
 | Role | Permissions | Notes |
 |------|-------------|-------|
-| `admin` | `administrator` | Bypasses all permission checks |
-| `editor` | Can manage pages | |
-| `author` | Can view drafts | |
-| `moderator` | Can moderate content | |
+| `admin` | `administrator`, `manage-users`, `manage-pages`, `modify-site`, `manage-oauth-clients` | Bypasses all permission checks |
+| `editor` | `view-drafts`, `manage-pages`, `create-pages`, `manage-media` | Can manage all pages |
+| `author` | `view-drafts`, `edit-own-pages`, `delete-own-pages`, `create-pages`, `upload-media` | Can manage own pages |
+| `moderator` | `view-drafts`, `manage-pages`, `create-pages`, `manage-media` | Can moderate content |
 
 ## Custom Role Registration
 

--- a/.claude/skills/skrift-oauth2/SKILL.md
+++ b/.claude/skills/skrift-oauth2/SKILL.md
@@ -23,33 +23,56 @@ User clicks "Login with Skrift"
     │    ◄── { access_token, ... } ◄── Return token pair
     │
     ├──→ GET /oauth/userinfo ───────→ Validate access token
-    │    ◄── { sub, email, name } ◄── Return user claims
+    │    ◄── { sub, email, name } ◄── Return user claims (scope-filtered)
     │
     └──→ Session created on spoke
 ```
 
 ## Hub Configuration (`app.yaml`)
 
-The hub registers each spoke as an OAuth2 client:
+Enable the OAuth2 server:
 
 ```yaml
-oauth2:
-  clients:
-    - client_id: "spoke-site-1"
-      client_secret: "optional-secret"  # omit for public clients
-      redirect_uris:
-        - "https://spoke.example.com/auth/skrift/callback"
+oauth2_enabled: true
 ```
 
-Config model: `OAuth2ClientConfig`
+Clients are managed via the admin UI at `/admin/oauth-clients` (not in app.yaml). When `oauth2_enabled` is `true`:
 
-| Field | Type | Default | Notes |
-|-------|------|---------|-------|
-| `client_id` | `str` | required | Unique identifier for the spoke |
-| `client_secret` | `str` | `""` | Empty = public client (PKCE required) |
-| `redirect_uris` | `list[str]` | `[]` | Allowed callback URLs (strict match) |
+- `OAuth2Controller` is auto-registered (`skrift/asgi.py`)
+- `/oauth/token`, `/oauth/revoke`, `/oauth/introspect` are auto-excluded from CSRF
+- `/.well-known/openid-configuration` returns OIDC discovery JSON
+- The admin UI shows "OAuth Clients" in the sidebar (requires `manage-oauth-clients` permission)
 
-The `OAuth2Controller` is auto-registered when `settings.oauth2.clients` is non-empty (`skrift/asgi.py:731`). The `/oauth/token` endpoint is auto-excluded from CSRF.
+### Client Management (Admin UI)
+
+Clients are stored in the `oauth2_clients` database table, managed via `OAuth2ClientAdminController` at `/admin/oauth-clients`.
+
+| Action | Path | Method |
+|--------|------|--------|
+| List clients | `/admin/oauth-clients` | GET |
+| Create form | `/admin/oauth-clients/new` | GET |
+| Create client | `/admin/oauth-clients/new` | POST |
+| Edit form | `/admin/oauth-clients/{id}/edit` | GET |
+| Update client | `/admin/oauth-clients/{id}/edit` | POST |
+| Delete client | `/admin/oauth-clients/{id}/delete` | POST |
+| Regenerate secret | `/admin/oauth-clients/{id}/regenerate-secret` | POST |
+
+On creation, `client_id` and `client_secret` are auto-generated via `secrets.token_urlsafe()`. The secret is shown once in a flash message.
+
+### OAuth2Client Model
+
+`skrift/db/models/oauth2_client.py` — extends `Base` (UUIDAuditBase):
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `client_id` | `String(255)` | Unique, indexed, auto-generated |
+| `client_secret` | `String(255)` | Auto-generated, empty = public client |
+| `display_name` | `String(255)` | Shown on consent screen |
+| `redirect_uris` | `Text` | Newline-delimited |
+| `allowed_scopes` | `Text` | Newline-delimited; empty = all scopes allowed |
+| `is_active` | `Boolean` | Default `True`; inactive clients are rejected |
+
+Properties: `redirect_uri_list` and `allowed_scope_list` parse the text fields into `list[str]`.
 
 ## Spoke Configuration (`app.yaml`)
 
@@ -71,9 +94,29 @@ Config model: `SkriftProviderConfig`
 | Field | Type | Default | Notes |
 |-------|------|---------|-------|
 | `server_url` | `str` | required | Base URL of the hub Skrift instance |
-| `client_id` | `str` | required | Must match a hub `oauth2.clients` entry |
+| `client_id` | `str` | required | Must match a hub client's `client_id` |
 | `client_secret` | `str` | `""` | Empty = public client |
 | `scopes` | `list[str]` | `["openid", "profile", "email"]` | Requested scopes |
+
+## Scope Registry
+
+`skrift/auth/scopes.py` — dataclass + dict registry pattern (like `roles.py`):
+
+```python
+from skrift.auth.scopes import register_scope, SCOPE_DEFINITIONS, get_scope_definition
+
+# Built-in scopes (registered at import time):
+# openid  → claims: [sub]
+# profile → claims: [name, picture]
+# email   → claims: [email]
+
+# Register a custom scope:
+register_scope("custom", "Access custom data", claims=["custom_field"])
+```
+
+Scopes control two things:
+1. **Authorization**: requested scopes are validated against the client's `allowed_scopes` during `/oauth/authorize`
+2. **Claims filtering**: `/oauth/userinfo` only returns claims for the granted scopes
 
 ## Endpoints (Hub)
 
@@ -82,21 +125,47 @@ Config model: `SkriftProviderConfig`
 | `GET` | `/oauth/authorize` | Show consent screen (or redirect to login if unauthenticated) |
 | `POST` | `/oauth/authorize` | Process consent form — issue auth code via redirect |
 | `POST` | `/oauth/token` | Exchange auth code or refresh token for access/refresh tokens |
-| `GET` | `/oauth/userinfo` | Return user claims from a valid `Bearer` access token |
+| `GET` | `/oauth/userinfo` | Return scope-filtered user claims from a valid Bearer access token |
+| `POST` | `/oauth/revoke` | Revoke a token (RFC 7009 — always returns 200) |
+| `POST` | `/oauth/introspect` | Introspect a token (RFC 7662 — requires client auth) |
+| `GET` | `/.well-known/openid-configuration` | OIDC Discovery document (on `SitemapController`) |
+
+### Token Revocation (`POST /oauth/revoke`)
+
+RFC 7009 compliant. Accepts `token` in form body. Always returns 200 (even for invalid tokens). Records the token's `jti` in `revoked_tokens` table. Revoked tokens are rejected by `verify_oauth_token()`.
+
+### Token Introspection (`POST /oauth/introspect`)
+
+RFC 7662 compliant. Requires `client_id` + `client_secret` for authentication. Returns `{"active": true/false, ...}` with token metadata when active.
+
+### OIDC Discovery (`GET /.well-known/openid-configuration`)
+
+Returns 404 when `oauth2_enabled` is `false`. Otherwise returns standard discovery JSON: issuer, all endpoint URLs, supported response types/grants/scopes/claims/code challenge methods.
 
 ## Token Architecture
 
-All tokens use `base64(json_payload).base64(hmac_sha256_signature)` format. Signed with `settings.secret_key`.
+All tokens use `base64(json_payload).base64(hmac_sha256_signature)` format. Signed with `settings.secret_key`. Every token includes a unique `jti` (UUID hex) for revocation tracking.
 
 | Token | TTL | `type` field | Payload |
 |-------|-----|-------------|---------|
-| Auth code | 10 min | `"code"` | `user_id`, `email`, `name`, `picture_url`, `client_id`, `redirect_uri`, `code_challenge` |
-| Access token | 15 min | `"access"` | `user_id`, `email`, `name`, `picture_url`, `client_id` |
-| Refresh token | 30 days | `"refresh"` | `user_id`, `client_id` |
+| Auth code | 10 min | `"code"` | `user_id`, `email`, `name`, `picture_url`, `client_id`, `redirect_uri`, `scope`, `code_challenge`, `jti` |
+| Access token | 15 min | `"access"` | `user_id`, `email`, `name`, `picture_url`, `client_id`, `scope`, `jti` |
+| Refresh token | 30 days | `"refresh"` | `user_id`, `client_id`, `scope`, `jti` |
 
 The `type` field prevents cross-use — a refresh token cannot be used as an access token.
 
-Token exchange with `grant_type=refresh_token` performs **token rotation**: both access and refresh tokens are reissued.
+Token exchange with `grant_type=refresh_token` performs **token rotation**: old refresh token is revoked, both access and refresh tokens are reissued.
+
+### Token Verification
+
+`verify_oauth_token(token, secret, db_session)` in `skrift/controllers/oauth2.py`:
+1. Verifies HMAC signature and expiration (via `verify_signed_token`)
+2. Checks `jti` against `revoked_tokens` table (via `oauth2_service.is_token_revoked`)
+3. Returns payload dict or `None`
+
+Used by: `userinfo`, `_handle_refresh_token`, `introspect`.
+
+Auth codes use plain `verify_signed_token` (no revocation check — they're single-use by expiry).
 
 ## PKCE
 
@@ -113,7 +182,7 @@ Token exchange with `grant_type=refresh_token` performs **token rotation**: both
 - `requires_pkce = True` — always sends PKCE parameters
 - `resolve_url()` replaces `{server_url}` in provider URLs with the configured `server_url`
 - `build_token_data()` omits `client_secret` from POST body when empty (public client)
-- `extract_user_data()` maps hub's `sub` → `oauth_id`, plus `email`, `name`, `picture`
+- `extract_user_data()` maps hub's `sub` -> `oauth_id`, plus `email`, `name`, `picture`
 
 Provider URLs are defined in `skrift/setup/providers.py` with `{server_url}` placeholders:
 - `auth_url`: `{server_url}/oauth/authorize`
@@ -122,7 +191,7 @@ Provider URLs are defined in `skrift/setup/providers.py` with `{server_url}` pla
 
 ## Consent Template
 
-`skrift/templates/oauth/authorize.html` — extends `auth/base.html`, shows client ID and requested scopes. CSRF-protected form with Allow/Deny buttons. Customizable by overriding in project `templates/oauth/authorize.html`.
+`skrift/templates/oauth/authorize.html` — extends `auth/base.html`, shows client `display_name` (falls back to `client_id`) and scope descriptions from the scope registry. CSRF-protected form with Allow/Deny buttons. Customizable by overriding in project `templates/oauth/authorize.html`.
 
 ## Security Notes
 
@@ -131,18 +200,27 @@ Provider URLs are defined in `skrift/setup/providers.py` with `{server_url}` pla
 - Consent form uses CSRF protection (`csrf_field`)
 - The `type` field in each token prevents cross-use (code vs access vs refresh)
 - `hmac.compare_digest` used for constant-time signature comparison
+- Token revocation via `jti` tracking in database
+- Refresh token rotation: old refresh token is revoked on each use
+- Inactive clients (`is_active=False`) are rejected at all endpoints
 
 ## Key Files
 
 | File | Purpose |
 |------|---------|
-| `skrift/controllers/oauth2.py` | OAuth2Controller — authorize, token, userinfo endpoints |
-| `skrift/auth/tokens.py` | `create_signed_token()` / `verify_signed_token()` — HMAC-SHA256 |
+| `skrift/controllers/oauth2.py` | OAuth2Controller — authorize, token, userinfo, revoke, introspect |
+| `skrift/auth/tokens.py` | `create_signed_token()` / `verify_signed_token()` — HMAC-SHA256 with `jti` |
+| `skrift/auth/scopes.py` | Scope registry — `ScopeDefinition`, `register_scope()`, built-in scopes |
 | `skrift/auth/providers.py` | `SkriftProvider` class (spoke-side OAuth flow) |
-| `skrift/config.py` | `OAuth2ClientConfig`, `OAuth2Config`, `SkriftProviderConfig` |
+| `skrift/config.py` | `SkriftProviderConfig`, `oauth2_enabled` setting |
+| `skrift/db/models/oauth2_client.py` | `OAuth2Client` model |
+| `skrift/db/models/revoked_token.py` | `RevokedToken` model |
+| `skrift/db/services/oauth2_service.py` | Client CRUD, revocation, token checks |
+| `skrift/admin/oauth2_clients.py` | `OAuth2ClientAdminController` — admin UI |
+| `skrift/controllers/sitemap.py` | `/.well-known/openid-configuration` discovery endpoint |
 | `skrift/setup/providers.py` | `OAuthProviderInfo` for `skrift` (URL templates, fields) |
-| `skrift/asgi.py` | Auto-registers `OAuth2Controller` when clients configured |
+| `skrift/asgi.py` | Auto-registers `OAuth2Controller` when `oauth2_enabled` |
 | `skrift/templates/oauth/authorize.html` | Consent screen template |
-| `skrift/auth/session_keys.py` | Session key constants used in auth code payload |
-| `skrift/forms/__init__.py` | `verify_csrf()` used by consent POST |
-| `tests/test_oauth2_server.py` | OAuth2 server endpoint tests |
+| `skrift/templates/admin/oauth2/list.html` | Admin client list |
+| `skrift/templates/admin/oauth2/edit.html` | Admin client create/edit form |
+| `tests/test_oauth2_server.py` | OAuth2 server endpoint tests (42 tests) |

--- a/.claude/skills/skrift/SKILL.md
+++ b/.claude/skills/skrift/SKILL.md
@@ -171,6 +171,8 @@ class MyModel(Base):
 | `PageRevision` | `page_revisions` | Content history |
 | `Setting` | `settings` | Key-value site settings |
 | `StoredNotification` | `stored_notifications` | Persistent notifications with `mode` column (Redis/PgNotify backends) |
+| `OAuth2Client` | `oauth2_clients` | Registered OAuth2 client applications |
+| `RevokedToken` | `revoked_tokens` | Revoked token JTIs for OAuth2 server |
 
 Sessions injected via `db_session: AsyncSession` parameter in handlers.
 

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -50,6 +50,14 @@ Technical reference documentation for Skrift.
 
     [:octicons-arrow-right-24: Security Features](security-features.md)
 
+-   :material-shield-key:{ .lg .middle } **OAuth2 Server**
+
+    ---
+
+    Authorization server for hub/spoke identity federation with PKCE, token revocation, and OIDC discovery.
+
+    [:octicons-arrow-right-24: OAuth2 Server](oauth2-server.md)
+
 </div>
 
 ## Styling
@@ -88,6 +96,7 @@ Technical reference documentation for Skrift.
 | [Environment Variables](environment-variables.md) | Configuration and secrets |
 | [OAuth Providers](auth-providers.md) | Authentication setup |
 | [Security Features](security-features.md) | Security implementation details |
+| [OAuth2 Server](oauth2-server.md) | Authorization server, token revocation, OIDC discovery |
 | [CSS Framework](css-framework.md) | Styling classes and components |
 | [Sitemap & Robots.txt](sitemap-robots.md) | SEO sitemap and crawler directives |
 | [Template System](../guides/custom-templates.md) | Template hierarchy and blocks |

--- a/docs/reference/oauth2-server.md
+++ b/docs/reference/oauth2-server.md
@@ -1,0 +1,188 @@
+# OAuth2 Authorization Server
+
+Skrift can act as an OAuth2 Authorization Server, allowing other applications (including other Skrift instances) to authenticate users via the Authorization Code grant with PKCE.
+
+## Enabling the Server
+
+Add to your `app.yaml`:
+
+```yaml
+oauth2_enabled: true
+```
+
+This registers the OAuth2 endpoints and enables the admin UI for client management.
+
+## Managing Clients
+
+OAuth2 clients are managed through the admin interface at `/admin/oauth-clients`. You need the `manage-oauth-clients` permission (granted to the `admin` role by default).
+
+### Creating a Client
+
+1. Navigate to `/admin/oauth-clients/new`
+2. Enter a **Display Name** (shown on the consent screen)
+3. Add **Redirect URIs** (one per line) — these must match exactly during authorization
+4. Select **Allowed Scopes** — leave all unchecked to allow any registered scope
+5. Click **Create Client**
+
+The generated `client_id` and `client_secret` are shown in a flash message. **Save the secret immediately** — it won't be shown in full again.
+
+### Editing a Client
+
+From the client list, click **Edit** to change the display name, redirect URIs, allowed scopes, or active status. You can also regenerate the client secret (the old one stops working immediately).
+
+### Deactivating a Client
+
+Toggle the **Active** checkbox off. Inactive clients are rejected at all OAuth2 endpoints.
+
+## Endpoints
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `GET` | `/oauth/authorize` | Authorization — shows consent screen |
+| `POST` | `/oauth/authorize` | Processes consent — redirects with auth code |
+| `POST` | `/oauth/token` | Token exchange — auth code or refresh token |
+| `GET` | `/oauth/userinfo` | User claims — requires Bearer access token |
+| `POST` | `/oauth/revoke` | Token revocation (RFC 7009) |
+| `POST` | `/oauth/introspect` | Token introspection (RFC 7662) |
+| `GET` | `/.well-known/openid-configuration` | OIDC Discovery document |
+
+### Authorization (`GET /oauth/authorize`)
+
+Query parameters:
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `response_type` | Yes | Must be `code` |
+| `client_id` | Yes | Registered client ID |
+| `redirect_uri` | Yes | Must match a registered URI |
+| `scope` | No | Space-separated scope list |
+| `state` | No | Opaque state for CSRF protection |
+| `code_challenge` | Conditional | Required for public clients |
+| `code_challenge_method` | Conditional | Must be `S256` |
+
+If the user is not logged in, they are redirected to `/auth/login` with the full authorize URL preserved. After login, they return to the consent screen.
+
+### Token Exchange (`POST /oauth/token`)
+
+**Authorization Code grant** (`grant_type=authorization_code`):
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `grant_type` | Yes | `authorization_code` |
+| `code` | Yes | Authorization code from redirect |
+| `redirect_uri` | Yes | Must match the authorize request |
+| `client_id` | Yes | Client identifier |
+| `client_secret` | Conditional | Required for confidential clients |
+| `code_verifier` | Conditional | Required when PKCE was used |
+
+**Refresh Token grant** (`grant_type=refresh_token`):
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `grant_type` | Yes | `refresh_token` |
+| `refresh_token` | Yes | Current refresh token |
+| `client_id` | Yes | Client identifier |
+| `client_secret` | Conditional | Required for confidential clients |
+
+Refresh uses **token rotation** — the old refresh token is revoked and a new pair is issued.
+
+### UserInfo (`GET /oauth/userinfo`)
+
+Requires `Authorization: Bearer <access_token>` header. Returns claims filtered by the granted scopes:
+
+| Scope | Claims Returned |
+|-------|----------------|
+| `openid` | `sub` |
+| `profile` | `name`, `picture` |
+| `email` | `email` |
+
+If no scopes were specified, all claims are returned for backwards compatibility.
+
+### Revocation (`POST /oauth/revoke`)
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `token` | Yes | The token to revoke |
+
+Always returns HTTP 200, even for invalid tokens (per RFC 7009).
+
+### Introspection (`POST /oauth/introspect`)
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `token` | Yes | The token to introspect |
+| `client_id` | Yes | Authenticating client ID |
+| `client_secret` | Conditional | Required for confidential clients |
+
+Returns `{"active": true, "token_type": "...", "sub": "...", "scope": "...", "exp": ...}` for valid tokens, or `{"active": false}` for invalid/revoked tokens.
+
+## Scopes
+
+Built-in scopes:
+
+| Scope | Description | Claims |
+|-------|-------------|--------|
+| `openid` | Verify your identity | `sub` |
+| `profile` | Access your name and picture | `name`, `picture` |
+| `email` | Access your email address | `email` |
+
+### Custom Scopes
+
+Register additional scopes in your application startup:
+
+```python
+from skrift.auth.scopes import register_scope
+
+register_scope("custom", "Access custom data", claims=["custom_field"])
+```
+
+Custom scopes appear in the admin UI's scope checkboxes and are validated during authorization.
+
+## Token Architecture
+
+Tokens are HMAC-SHA256 signed JSON payloads (not JWT). Each token contains:
+
+- `type` — prevents cross-use (`code`, `access`, `refresh`)
+- `jti` — unique ID for revocation tracking
+- `exp` — expiration timestamp
+
+| Token | Lifetime |
+|-------|----------|
+| Authorization code | 10 minutes |
+| Access token | 15 minutes |
+| Refresh token | 30 days |
+
+## PKCE
+
+Only S256 is supported. Public clients (no `client_secret`) **must** use PKCE. Confidential clients may optionally use it.
+
+## Connecting a Spoke Site
+
+On the spoke Skrift instance, configure the `skrift` auth provider:
+
+```yaml
+auth:
+  redirect_base_url: "https://spoke.example.com"
+  providers:
+    skrift:
+      server_url: "https://hub.example.com"
+      client_id: "<client_id from hub>"
+      client_secret: "<client_secret from hub>"
+      scopes: ["openid", "profile", "email"]
+```
+
+The spoke will redirect users to the hub for authentication and receive user data back via the standard OAuth2 flow.
+
+## Security Considerations
+
+- Tokens are **signed, not encrypted** — do not store secrets in token payloads
+- Redirect URIs are strictly matched (no wildcards)
+- Refresh token rotation limits the window for token reuse
+- The consent form uses CSRF protection
+- Inactive clients are rejected at all endpoints
+- OIDC discovery is only served when `oauth2_enabled` is `true`
+
+## See Also
+
+- [Auth Providers](auth-providers.md) — OAuth provider configuration (client side)
+- [Security Features](security-features.md) — CSRF, rate limiting, security headers

--- a/docs/reference/security-features.md
+++ b/docs/reference/security-features.md
@@ -204,6 +204,55 @@ code_challenge = base64.urlsafe_b64encode(
 ).decode().rstrip("=")
 ```
 
+## OAuth2 Token Security
+
+### Token JTI (JWT ID)
+
+Every token created by `create_signed_token()` includes a unique `jti` field (UUID hex, 32 characters). This enables token revocation by tracking revoked JTIs in the `revoked_tokens` database table.
+
+```python
+# In skrift/auth/tokens.py:
+payload = {**payload, "jti": uuid.uuid4().hex, "exp": int(time.time()) + expires_in}
+```
+
+### Token Revocation (RFC 7009)
+
+`POST /oauth/revoke` accepts a `token` parameter and always returns HTTP 200, per RFC 7009. If the token is valid and has a `jti`, the JTI is recorded in `revoked_tokens` with the token's expiration time.
+
+```python
+# skrift/controllers/oauth2.py
+async def revoke(self, request, db_session):
+    # Parse token, extract jti, record in revoked_tokens
+    # Always returns 200 (even for invalid tokens)
+```
+
+Revoked tokens are checked by `verify_oauth_token()`, which wraps `verify_signed_token()` with a database lookup:
+
+```python
+async def verify_oauth_token(token, secret, db_session):
+    payload = verify_signed_token(token, secret)  # Crypto check
+    if payload and payload.get("jti"):
+        if await oauth2_service.is_token_revoked(db_session, payload["jti"]):
+            return None  # Token was revoked
+    return payload
+```
+
+### Refresh Token Rotation
+
+When a refresh token is used at `/oauth/token` (`grant_type=refresh_token`), the old refresh token is automatically revoked before issuing new tokens. This limits the window for token reuse attacks.
+
+### Token Introspection (RFC 7662)
+
+`POST /oauth/introspect` requires client authentication (`client_id` + `client_secret`) and returns `{"active": true/false}` with token metadata. Uses `verify_oauth_token()` so revoked tokens report as inactive.
+
+### Expired Revocation Cleanup
+
+`oauth2_service.cleanup_expired_revocations(db_session)` deletes revocation records for tokens that have already expired, preventing unbounded table growth.
+
+### OIDC Discovery
+
+`GET /.well-known/openid-configuration` returns a standard OpenID Connect discovery document when `oauth2_enabled` is `true` in `app.yaml`. Returns 404 otherwise.
+
 ## Environment Variable Interpolation
 
 ### Implementation
@@ -348,7 +397,7 @@ From `skrift/auth/roles.py`:
 ```python
 ADMIN = create_role(
     "admin",
-    "administrator", "manage-users", "manage-pages", "modify-site",
+    "administrator", "manage-users", "manage-pages", "modify-site", "manage-oauth-clients",
     display_name="Administrator",
 )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "skrift"
-version = "0.1.0a67"
+version = "0.1.0a68"
 description = "A lightweight async Python CMS for crafting modern websites"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/skrift/admin/controller.py
+++ b/skrift/admin/controller.py
@@ -15,6 +15,7 @@ from skrift.lib.flash import get_flash_messages
 from skrift.admin.users import UserAdminController  # noqa: F401
 from skrift.admin.settings import SettingsAdminController  # noqa: F401
 from skrift.admin.media import MediaAdminController  # noqa: F401
+from skrift.admin.oauth2_clients import OAuth2ClientAdminController  # noqa: F401
 
 
 class AdminController(Controller):

--- a/skrift/admin/oauth2_clients.py
+++ b/skrift/admin/oauth2_clients.py
@@ -1,0 +1,198 @@
+"""OAuth2 client management admin controller."""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from litestar import Controller, Request, get, post
+from litestar.response import Template as TemplateResponse, Redirect
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from skrift.auth.guards import auth_guard, Permission
+from skrift.auth.scopes import SCOPE_DEFINITIONS
+from skrift.admin.helpers import get_admin_context
+from skrift.admin.navigation import ADMIN_NAV_TAG
+from skrift.db.models.oauth2_client import OAuth2Client
+from skrift.db.services import oauth2_service
+from skrift.lib.flash import flash_error, flash_success, get_flash_messages
+
+
+class OAuth2ClientAdminController(Controller):
+    """Controller for managing OAuth2 clients in admin."""
+
+    path = "/admin"
+    guards = [auth_guard]
+
+    @get(
+        "/oauth-clients",
+        tags=[ADMIN_NAV_TAG],
+        guards=[auth_guard, Permission("manage-oauth-clients")],
+        opt={"label": "OAuth Clients", "icon": "key", "order": 90},
+    )
+    async def list_clients(
+        self, request: Request, db_session: AsyncSession
+    ) -> TemplateResponse:
+        """List all OAuth2 clients."""
+        ctx = await get_admin_context(request, db_session)
+        clients = await oauth2_service.list_clients(db_session)
+        flash_messages = get_flash_messages(request)
+        return TemplateResponse(
+            "admin/oauth2/list.html",
+            context={"flash_messages": flash_messages, "clients": clients, **ctx},
+        )
+
+    @get(
+        "/oauth-clients/new",
+        guards=[auth_guard, Permission("manage-oauth-clients")],
+    )
+    async def new_client_form(
+        self, request: Request, db_session: AsyncSession
+    ) -> TemplateResponse:
+        """Show create client form."""
+        ctx = await get_admin_context(request, db_session)
+        flash_messages = get_flash_messages(request)
+        return TemplateResponse(
+            "admin/oauth2/edit.html",
+            context={
+                "flash_messages": flash_messages,
+                "client": None,
+                "available_scopes": SCOPE_DEFINITIONS,
+                **ctx,
+            },
+        )
+
+    @post(
+        "/oauth-clients/new",
+        guards=[auth_guard, Permission("manage-oauth-clients")],
+    )
+    async def create_client(
+        self, request: Request, db_session: AsyncSession
+    ) -> Redirect:
+        """Create a new OAuth2 client."""
+        form_data = await request.form()
+        display_name = form_data.get("display_name", "").strip()
+
+        if not display_name:
+            flash_error(request, "Display name is required")
+            return Redirect(path="/admin/oauth-clients/new")
+
+        redirect_uris_raw = form_data.get("redirect_uris", "")
+        redirect_uris = [u.strip() for u in redirect_uris_raw.split("\n") if u.strip()]
+
+        allowed_scopes = []
+        for scope_name in SCOPE_DEFINITIONS:
+            if form_data.get(f"scope_{scope_name}") == "on":
+                allowed_scopes.append(scope_name)
+
+        client = await oauth2_service.create_client(
+            db_session, display_name, redirect_uris, allowed_scopes
+        )
+
+        flash_success(
+            request,
+            f"Client created. Client ID: {client.client_id} — Secret: {client.client_secret} "
+            f"(save this now, it won't be shown again in full)"
+        )
+        return Redirect(path="/admin/oauth-clients")
+
+    @get(
+        "/oauth-clients/{client_db_id:uuid}/edit",
+        guards=[auth_guard, Permission("manage-oauth-clients")],
+    )
+    async def edit_client_form(
+        self, request: Request, db_session: AsyncSession, client_db_id: UUID
+    ) -> TemplateResponse:
+        """Show edit client form."""
+        ctx = await get_admin_context(request, db_session)
+        result = await db_session.execute(
+            select(OAuth2Client).where(OAuth2Client.id == client_db_id)
+        )
+        client = result.scalar_one_or_none()
+        if not client:
+            flash_error(request, "Client not found")
+            return Redirect(path="/admin/oauth-clients")
+
+        flash_messages = get_flash_messages(request)
+        return TemplateResponse(
+            "admin/oauth2/edit.html",
+            context={
+                "flash_messages": flash_messages,
+                "client": client,
+                "available_scopes": SCOPE_DEFINITIONS,
+                **ctx,
+            },
+        )
+
+    @post(
+        "/oauth-clients/{client_db_id:uuid}/edit",
+        guards=[auth_guard, Permission("manage-oauth-clients")],
+    )
+    async def update_client(
+        self, request: Request, db_session: AsyncSession, client_db_id: UUID
+    ) -> Redirect:
+        """Update an existing OAuth2 client."""
+        result = await db_session.execute(
+            select(OAuth2Client).where(OAuth2Client.id == client_db_id)
+        )
+        client = result.scalar_one_or_none()
+        if not client:
+            flash_error(request, "Client not found")
+            return Redirect(path="/admin/oauth-clients")
+
+        form_data = await request.form()
+        display_name = form_data.get("display_name", "").strip()
+        redirect_uris_raw = form_data.get("redirect_uris", "")
+        redirect_uris = [u.strip() for u in redirect_uris_raw.split("\n") if u.strip()]
+        is_active = form_data.get("is_active") == "on"
+
+        allowed_scopes = []
+        for scope_name in SCOPE_DEFINITIONS:
+            if form_data.get(f"scope_{scope_name}") == "on":
+                allowed_scopes.append(scope_name)
+
+        await oauth2_service.update_client(
+            db_session, client,
+            display_name=display_name,
+            redirect_uris=redirect_uris,
+            allowed_scopes=allowed_scopes,
+            is_active=is_active,
+        )
+
+        flash_success(request, f"Client '{display_name}' updated")
+        return Redirect(path="/admin/oauth-clients")
+
+    @post(
+        "/oauth-clients/{client_db_id:uuid}/delete",
+        guards=[auth_guard, Permission("manage-oauth-clients")],
+    )
+    async def delete_client(
+        self, request: Request, db_session: AsyncSession, client_db_id: UUID
+    ) -> Redirect:
+        """Delete an OAuth2 client."""
+        await oauth2_service.delete_client(db_session, client_db_id)
+        flash_success(request, "Client deleted")
+        return Redirect(path="/admin/oauth-clients")
+
+    @post(
+        "/oauth-clients/{client_db_id:uuid}/regenerate-secret",
+        guards=[auth_guard, Permission("manage-oauth-clients")],
+    )
+    async def regenerate_secret(
+        self, request: Request, db_session: AsyncSession, client_db_id: UUID
+    ) -> Redirect:
+        """Regenerate a client's secret."""
+        result = await db_session.execute(
+            select(OAuth2Client).where(OAuth2Client.id == client_db_id)
+        )
+        client = result.scalar_one_or_none()
+        if not client:
+            flash_error(request, "Client not found")
+            return Redirect(path="/admin/oauth-clients")
+
+        new_secret = await oauth2_service.regenerate_client_secret(db_session, client)
+        flash_success(
+            request,
+            f"New secret for '{client.display_name}': {new_secret} (save this now)"
+        )
+        return Redirect(path=f"/admin/oauth-clients/{client_db_id}/edit")

--- a/skrift/alembic/versions/20260304_add_oauth2_server_tables.py
+++ b/skrift/alembic/versions/20260304_add_oauth2_server_tables.py
@@ -1,0 +1,54 @@
+"""Add OAuth2 server tables (oauth2_clients, revoked_tokens).
+
+Revision ID: s1t2u3v4w5x6
+Revises: m7n8o9p0q1r2
+Create Date: 2026-03-04
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "s1t2u3v4w5x6"
+down_revision = "m7n8o9p0q1r2"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "oauth2_clients",
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("client_id", sa.String(255), nullable=False),
+        sa.Column("client_secret", sa.String(255), nullable=False, server_default=""),
+        sa.Column("display_name", sa.String(255), nullable=False),
+        sa.Column("redirect_uris", sa.Text(), nullable=False, server_default=""),
+        sa.Column("allowed_scopes", sa.Text(), nullable=False, server_default=""),
+        sa.Column("is_active", sa.Boolean(), nullable=False, server_default=sa.text("1")),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.Column("sa_orm_sentinel", sa.Integer(), nullable=True),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("ix_oauth2_clients_client_id", "oauth2_clients", ["client_id"], unique=True)
+
+    op.create_table(
+        "revoked_tokens",
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("jti", sa.String(64), nullable=False),
+        sa.Column("token_type", sa.String(20), nullable=False),
+        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.Column("sa_orm_sentinel", sa.Integer(), nullable=True),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("ix_revoked_tokens_jti", "revoked_tokens", ["jti"], unique=True)
+    op.create_index("ix_revoked_tokens_expires_at", "revoked_tokens", ["expires_at"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_revoked_tokens_expires_at", table_name="revoked_tokens")
+    op.drop_index("ix_revoked_tokens_jti", table_name="revoked_tokens")
+    op.drop_table("revoked_tokens")
+    op.drop_index("ix_oauth2_clients_client_id", table_name="oauth2_clients")
+    op.drop_table("oauth2_clients")

--- a/skrift/asgi.py
+++ b/skrift/asgi.py
@@ -154,7 +154,7 @@ def load_controllers() -> list:
 
         # Auto-expand AdminController to include split sub-controllers
         if class_name == "AdminController" and module_path == "skrift.admin.controller":
-            for sub_name in ("UserAdminController", "SettingsAdminController", "MediaAdminController"):
+            for sub_name in ("UserAdminController", "SettingsAdminController", "MediaAdminController", "OAuth2ClientAdminController"):
                 sub_class = getattr(module, sub_name, None)
                 if sub_class and sub_class not in controllers:
                     controllers.append(sub_class)
@@ -807,13 +807,15 @@ def create_app() -> ASGIApp:
     from skrift.lib.notification_backends import InMemoryBackend, load_backend
     from skrift.lib.notifications import notifications as notification_service
 
-    # OAuth2 controller — only registered when clients are configured
+    # OAuth2 controller — only registered when oauth2 is enabled
     oauth2_handlers: list = []
-    if settings.oauth2.clients:
+    if settings.oauth2_enabled:
         oauth2_handlers.append(OAuth2Controller)
-        # Exempt token endpoint from CSRF since it's called by external clients
+        # Exempt OAuth2 API endpoints from CSRF since they're called by external clients
         if settings.csrf is not None:
             settings.csrf.exclude.append("/oauth/token")
+            settings.csrf.exclude.append("/oauth/revoke")
+            settings.csrf.exclude.append("/oauth/introspect")
 
     # Webhook controller — only registered when a secret is configured
     webhook_handlers: list = []

--- a/skrift/auth/roles.py
+++ b/skrift/auth/roles.py
@@ -49,6 +49,7 @@ ADMIN = create_role(
     "manage-users",
     "manage-pages",
     "modify-site",
+    "manage-oauth-clients",
     display_name="Administrator",
     description="Full system access with all permissions",
 )

--- a/skrift/auth/scopes.py
+++ b/skrift/auth/scopes.py
@@ -1,0 +1,45 @@
+"""OAuth2 scope definitions for the authorization server."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass
+class ScopeDefinition:
+    """Definition of an OAuth2 scope with its associated claims."""
+
+    name: str
+    description: str
+    claims: list[str] = field(default_factory=list)
+
+
+# Registry of all scope definitions
+SCOPE_DEFINITIONS: dict[str, ScopeDefinition] = {}
+
+
+def register_scope(name: str, description: str, claims: list[str] | None = None) -> ScopeDefinition:
+    """Register a scope definition.
+
+    Args:
+        name: The scope identifier (e.g., "openid", "profile")
+        description: Human-readable description of what this scope grants
+        claims: List of claim names included when this scope is granted
+
+    Returns:
+        The registered ScopeDefinition instance
+    """
+    scope = ScopeDefinition(name=name, description=description, claims=claims or [])
+    SCOPE_DEFINITIONS[scope.name] = scope
+    return scope
+
+
+def get_scope_definition(name: str) -> ScopeDefinition | None:
+    """Get a scope definition by name."""
+    return SCOPE_DEFINITIONS.get(name)
+
+
+# Built-in scopes
+register_scope("openid", "Verify your identity", claims=["sub"])
+register_scope("profile", "Access your name and picture", claims=["name", "picture"])
+register_scope("email", "Access your email address", claims=["email"])

--- a/skrift/auth/tokens.py
+++ b/skrift/auth/tokens.py
@@ -8,6 +8,7 @@ import hashlib
 import hmac
 import json
 import time
+import uuid
 
 
 def create_signed_token(payload: dict, secret: str, expires_in: int) -> str:
@@ -21,7 +22,7 @@ def create_signed_token(payload: dict, secret: str, expires_in: int) -> str:
     Returns:
         URL-safe base64 string: ``base64(json_payload).base64(signature)``
     """
-    payload = {**payload, "exp": int(time.time()) + expires_in}
+    payload = {**payload, "jti": uuid.uuid4().hex, "exp": int(time.time()) + expires_in}
     payload_bytes = json.dumps(payload, separators=(",", ":")).encode()
     payload_b64 = base64.urlsafe_b64encode(payload_bytes).decode()
 

--- a/skrift/claude_skill/skrift-auth/SKILL.md
+++ b/skrift/claude_skill/skrift-auth/SKILL.md
@@ -89,10 +89,10 @@ class ArticleController(Controller):
 
 | Role | Permissions | Notes |
 |------|-------------|-------|
-| `admin` | `administrator` | Bypasses all permission checks |
-| `editor` | Can manage pages | |
-| `author` | Can view drafts | |
-| `moderator` | Can moderate content | |
+| `admin` | `administrator`, `manage-users`, `manage-pages`, `modify-site`, `manage-oauth-clients` | Bypasses all permission checks |
+| `editor` | `view-drafts`, `manage-pages`, `create-pages`, `manage-media` | Can manage all pages |
+| `author` | `view-drafts`, `edit-own-pages`, `delete-own-pages`, `create-pages`, `upload-media` | Can manage own pages |
+| `moderator` | `view-drafts`, `manage-pages`, `create-pages`, `manage-media` | Can moderate content |
 
 ## Custom Role Registration
 

--- a/skrift/claude_skill/skrift-oauth2/SKILL.md
+++ b/skrift/claude_skill/skrift-oauth2/SKILL.md
@@ -23,33 +23,56 @@ User clicks "Login with Skrift"
     │    ◄── { access_token, ... } ◄── Return token pair
     │
     ├──→ GET /oauth/userinfo ───────→ Validate access token
-    │    ◄── { sub, email, name } ◄── Return user claims
+    │    ◄── { sub, email, name } ◄── Return user claims (scope-filtered)
     │
     └──→ Session created on spoke
 ```
 
 ## Hub Configuration (`app.yaml`)
 
-The hub registers each spoke as an OAuth2 client:
+Enable the OAuth2 server:
 
 ```yaml
-oauth2:
-  clients:
-    - client_id: "spoke-site-1"
-      client_secret: "optional-secret"  # omit for public clients
-      redirect_uris:
-        - "https://spoke.example.com/auth/skrift/callback"
+oauth2_enabled: true
 ```
 
-Config model: `OAuth2ClientConfig`
+Clients are managed via the admin UI at `/admin/oauth-clients` (not in app.yaml). When `oauth2_enabled` is `true`:
 
-| Field | Type | Default | Notes |
-|-------|------|---------|-------|
-| `client_id` | `str` | required | Unique identifier for the spoke |
-| `client_secret` | `str` | `""` | Empty = public client (PKCE required) |
-| `redirect_uris` | `list[str]` | `[]` | Allowed callback URLs (strict match) |
+- `OAuth2Controller` is auto-registered (`skrift/asgi.py`)
+- `/oauth/token`, `/oauth/revoke`, `/oauth/introspect` are auto-excluded from CSRF
+- `/.well-known/openid-configuration` returns OIDC discovery JSON
+- The admin UI shows "OAuth Clients" in the sidebar (requires `manage-oauth-clients` permission)
 
-The `OAuth2Controller` is auto-registered when `settings.oauth2.clients` is non-empty (`skrift/asgi.py:731`). The `/oauth/token` endpoint is auto-excluded from CSRF.
+### Client Management (Admin UI)
+
+Clients are stored in the `oauth2_clients` database table, managed via `OAuth2ClientAdminController` at `/admin/oauth-clients`.
+
+| Action | Path | Method |
+|--------|------|--------|
+| List clients | `/admin/oauth-clients` | GET |
+| Create form | `/admin/oauth-clients/new` | GET |
+| Create client | `/admin/oauth-clients/new` | POST |
+| Edit form | `/admin/oauth-clients/{id}/edit` | GET |
+| Update client | `/admin/oauth-clients/{id}/edit` | POST |
+| Delete client | `/admin/oauth-clients/{id}/delete` | POST |
+| Regenerate secret | `/admin/oauth-clients/{id}/regenerate-secret` | POST |
+
+On creation, `client_id` and `client_secret` are auto-generated via `secrets.token_urlsafe()`. The secret is shown once in a flash message.
+
+### OAuth2Client Model
+
+`skrift/db/models/oauth2_client.py` — extends `Base` (UUIDAuditBase):
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `client_id` | `String(255)` | Unique, indexed, auto-generated |
+| `client_secret` | `String(255)` | Auto-generated, empty = public client |
+| `display_name` | `String(255)` | Shown on consent screen |
+| `redirect_uris` | `Text` | Newline-delimited |
+| `allowed_scopes` | `Text` | Newline-delimited; empty = all scopes allowed |
+| `is_active` | `Boolean` | Default `True`; inactive clients are rejected |
+
+Properties: `redirect_uri_list` and `allowed_scope_list` parse the text fields into `list[str]`.
 
 ## Spoke Configuration (`app.yaml`)
 
@@ -71,9 +94,29 @@ Config model: `SkriftProviderConfig`
 | Field | Type | Default | Notes |
 |-------|------|---------|-------|
 | `server_url` | `str` | required | Base URL of the hub Skrift instance |
-| `client_id` | `str` | required | Must match a hub `oauth2.clients` entry |
+| `client_id` | `str` | required | Must match a hub client's `client_id` |
 | `client_secret` | `str` | `""` | Empty = public client |
 | `scopes` | `list[str]` | `["openid", "profile", "email"]` | Requested scopes |
+
+## Scope Registry
+
+`skrift/auth/scopes.py` — dataclass + dict registry pattern (like `roles.py`):
+
+```python
+from skrift.auth.scopes import register_scope, SCOPE_DEFINITIONS, get_scope_definition
+
+# Built-in scopes (registered at import time):
+# openid  → claims: [sub]
+# profile → claims: [name, picture]
+# email   → claims: [email]
+
+# Register a custom scope:
+register_scope("custom", "Access custom data", claims=["custom_field"])
+```
+
+Scopes control two things:
+1. **Authorization**: requested scopes are validated against the client's `allowed_scopes` during `/oauth/authorize`
+2. **Claims filtering**: `/oauth/userinfo` only returns claims for the granted scopes
 
 ## Endpoints (Hub)
 
@@ -82,21 +125,47 @@ Config model: `SkriftProviderConfig`
 | `GET` | `/oauth/authorize` | Show consent screen (or redirect to login if unauthenticated) |
 | `POST` | `/oauth/authorize` | Process consent form — issue auth code via redirect |
 | `POST` | `/oauth/token` | Exchange auth code or refresh token for access/refresh tokens |
-| `GET` | `/oauth/userinfo` | Return user claims from a valid `Bearer` access token |
+| `GET` | `/oauth/userinfo` | Return scope-filtered user claims from a valid Bearer access token |
+| `POST` | `/oauth/revoke` | Revoke a token (RFC 7009 — always returns 200) |
+| `POST` | `/oauth/introspect` | Introspect a token (RFC 7662 — requires client auth) |
+| `GET` | `/.well-known/openid-configuration` | OIDC Discovery document (on `SitemapController`) |
+
+### Token Revocation (`POST /oauth/revoke`)
+
+RFC 7009 compliant. Accepts `token` in form body. Always returns 200 (even for invalid tokens). Records the token's `jti` in `revoked_tokens` table. Revoked tokens are rejected by `verify_oauth_token()`.
+
+### Token Introspection (`POST /oauth/introspect`)
+
+RFC 7662 compliant. Requires `client_id` + `client_secret` for authentication. Returns `{"active": true/false, ...}` with token metadata when active.
+
+### OIDC Discovery (`GET /.well-known/openid-configuration`)
+
+Returns 404 when `oauth2_enabled` is `false`. Otherwise returns standard discovery JSON: issuer, all endpoint URLs, supported response types/grants/scopes/claims/code challenge methods.
 
 ## Token Architecture
 
-All tokens use `base64(json_payload).base64(hmac_sha256_signature)` format. Signed with `settings.secret_key`.
+All tokens use `base64(json_payload).base64(hmac_sha256_signature)` format. Signed with `settings.secret_key`. Every token includes a unique `jti` (UUID hex) for revocation tracking.
 
 | Token | TTL | `type` field | Payload |
 |-------|-----|-------------|---------|
-| Auth code | 10 min | `"code"` | `user_id`, `email`, `name`, `picture_url`, `client_id`, `redirect_uri`, `code_challenge` |
-| Access token | 15 min | `"access"` | `user_id`, `email`, `name`, `picture_url`, `client_id` |
-| Refresh token | 30 days | `"refresh"` | `user_id`, `client_id` |
+| Auth code | 10 min | `"code"` | `user_id`, `email`, `name`, `picture_url`, `client_id`, `redirect_uri`, `scope`, `code_challenge`, `jti` |
+| Access token | 15 min | `"access"` | `user_id`, `email`, `name`, `picture_url`, `client_id`, `scope`, `jti` |
+| Refresh token | 30 days | `"refresh"` | `user_id`, `client_id`, `scope`, `jti` |
 
 The `type` field prevents cross-use — a refresh token cannot be used as an access token.
 
-Token exchange with `grant_type=refresh_token` performs **token rotation**: both access and refresh tokens are reissued.
+Token exchange with `grant_type=refresh_token` performs **token rotation**: old refresh token is revoked, both access and refresh tokens are reissued.
+
+### Token Verification
+
+`verify_oauth_token(token, secret, db_session)` in `skrift/controllers/oauth2.py`:
+1. Verifies HMAC signature and expiration (via `verify_signed_token`)
+2. Checks `jti` against `revoked_tokens` table (via `oauth2_service.is_token_revoked`)
+3. Returns payload dict or `None`
+
+Used by: `userinfo`, `_handle_refresh_token`, `introspect`.
+
+Auth codes use plain `verify_signed_token` (no revocation check — they're single-use by expiry).
 
 ## PKCE
 
@@ -113,7 +182,7 @@ Token exchange with `grant_type=refresh_token` performs **token rotation**: both
 - `requires_pkce = True` — always sends PKCE parameters
 - `resolve_url()` replaces `{server_url}` in provider URLs with the configured `server_url`
 - `build_token_data()` omits `client_secret` from POST body when empty (public client)
-- `extract_user_data()` maps hub's `sub` → `oauth_id`, plus `email`, `name`, `picture`
+- `extract_user_data()` maps hub's `sub` -> `oauth_id`, plus `email`, `name`, `picture`
 
 Provider URLs are defined in `skrift/setup/providers.py` with `{server_url}` placeholders:
 - `auth_url`: `{server_url}/oauth/authorize`
@@ -122,7 +191,7 @@ Provider URLs are defined in `skrift/setup/providers.py` with `{server_url}` pla
 
 ## Consent Template
 
-`skrift/templates/oauth/authorize.html` — extends `auth/base.html`, shows client ID and requested scopes. CSRF-protected form with Allow/Deny buttons. Customizable by overriding in project `templates/oauth/authorize.html`.
+`skrift/templates/oauth/authorize.html` — extends `auth/base.html`, shows client `display_name` (falls back to `client_id`) and scope descriptions from the scope registry. CSRF-protected form with Allow/Deny buttons. Customizable by overriding in project `templates/oauth/authorize.html`.
 
 ## Security Notes
 
@@ -131,18 +200,27 @@ Provider URLs are defined in `skrift/setup/providers.py` with `{server_url}` pla
 - Consent form uses CSRF protection (`csrf_field`)
 - The `type` field in each token prevents cross-use (code vs access vs refresh)
 - `hmac.compare_digest` used for constant-time signature comparison
+- Token revocation via `jti` tracking in database
+- Refresh token rotation: old refresh token is revoked on each use
+- Inactive clients (`is_active=False`) are rejected at all endpoints
 
 ## Key Files
 
 | File | Purpose |
 |------|---------|
-| `skrift/controllers/oauth2.py` | OAuth2Controller — authorize, token, userinfo endpoints |
-| `skrift/auth/tokens.py` | `create_signed_token()` / `verify_signed_token()` — HMAC-SHA256 |
+| `skrift/controllers/oauth2.py` | OAuth2Controller — authorize, token, userinfo, revoke, introspect |
+| `skrift/auth/tokens.py` | `create_signed_token()` / `verify_signed_token()` — HMAC-SHA256 with `jti` |
+| `skrift/auth/scopes.py` | Scope registry — `ScopeDefinition`, `register_scope()`, built-in scopes |
 | `skrift/auth/providers.py` | `SkriftProvider` class (spoke-side OAuth flow) |
-| `skrift/config.py` | `OAuth2ClientConfig`, `OAuth2Config`, `SkriftProviderConfig` |
+| `skrift/config.py` | `SkriftProviderConfig`, `oauth2_enabled` setting |
+| `skrift/db/models/oauth2_client.py` | `OAuth2Client` model |
+| `skrift/db/models/revoked_token.py` | `RevokedToken` model |
+| `skrift/db/services/oauth2_service.py` | Client CRUD, revocation, token checks |
+| `skrift/admin/oauth2_clients.py` | `OAuth2ClientAdminController` — admin UI |
+| `skrift/controllers/sitemap.py` | `/.well-known/openid-configuration` discovery endpoint |
 | `skrift/setup/providers.py` | `OAuthProviderInfo` for `skrift` (URL templates, fields) |
-| `skrift/asgi.py` | Auto-registers `OAuth2Controller` when clients configured |
+| `skrift/asgi.py` | Auto-registers `OAuth2Controller` when `oauth2_enabled` |
 | `skrift/templates/oauth/authorize.html` | Consent screen template |
-| `skrift/auth/session_keys.py` | Session key constants used in auth code payload |
-| `skrift/forms/__init__.py` | `verify_csrf()` used by consent POST |
-| `tests/test_oauth2_server.py` | OAuth2 server endpoint tests |
+| `skrift/templates/admin/oauth2/list.html` | Admin client list |
+| `skrift/templates/admin/oauth2/edit.html` | Admin client create/edit form |
+| `tests/test_oauth2_server.py` | OAuth2 server endpoint tests (42 tests) |

--- a/skrift/claude_skill/skrift/SKILL.md
+++ b/skrift/claude_skill/skrift/SKILL.md
@@ -86,7 +86,7 @@ Skrift is a lightweight async Python CMS built on Litestar, featuring WordPress-
 .env (loaded early) → app.yaml (with $VAR interpolation) → Settings (Pydantic)
 ```
 
-Environment-specific: `app.yaml` (production), `app.dev.yaml` (development), `app.test.yaml` (testing). Set via `SKRIFT_ENV`.
+Environment-specific: `app.yaml` (production), `app.dev.yaml` (development), `app.test.yaml` (testing). Set via `SKRIFT_ENV` or overridden with `skrift -f <path>`. Config files can set `environment: <name>` to propagate `SKRIFT_ENV`.
 
 ```yaml
 db:
@@ -136,11 +136,14 @@ middleware:
 ```bash
 skrift serve --reload --port 8080
 skrift serve --subdomain blog --port 8081  # serve single subdomain site
+skrift -f custom.yaml serve --reload       # use a specific config file
 skrift secret --write .env
 skrift db upgrade head
 skrift db downgrade -1
 skrift db revision -m "desc" --autogenerate
 ```
+
+Global option `-f`/`--config-file` overrides `SKRIFT_ENV`-based config file selection. Applies to all subcommands.
 
 ## Database Layer
 
@@ -168,6 +171,8 @@ class MyModel(Base):
 | `PageRevision` | `page_revisions` | Content history |
 | `Setting` | `settings` | Key-value site settings |
 | `StoredNotification` | `stored_notifications` | Persistent notifications with `mode` column (Redis/PgNotify backends) |
+| `OAuth2Client` | `oauth2_clients` | Registered OAuth2 client applications |
+| `RevokedToken` | `revoked_tokens` | Revoked token JTIs for OAuth2 server |
 
 Sessions injected via `db_session: AsyncSession` parameter in handlers.
 

--- a/skrift/config.py
+++ b/skrift/config.py
@@ -204,20 +204,6 @@ class SkriftProviderConfig(BaseModel):
 ProviderConfig = OAuthProviderConfig | DummyProviderConfig | SkriftProviderConfig
 
 
-class OAuth2ClientConfig(BaseModel):
-    """A registered OAuth2 client (spoke site)."""
-
-    client_id: str
-    client_secret: str = ""
-    redirect_uris: list[str] = []
-
-
-class OAuth2Config(BaseModel):
-    """OAuth2 Authorization Server configuration."""
-
-    clients: list[OAuth2ClientConfig] = []
-
-
 class SecurityHeadersConfig(BaseModel):
     """Security response headers configuration.
 
@@ -414,8 +400,8 @@ class Settings(BaseSettings):
     # Auth config (loaded from app.yaml)
     auth: AuthConfig = AuthConfig()
 
-    # OAuth2 Authorization Server config (loaded from app.yaml)
-    oauth2: OAuth2Config = OAuth2Config()
+    # OAuth2 Authorization Server enabled flag
+    oauth2_enabled: bool = False
 
     # Session config (loaded from app.yaml)
     session: SessionConfig = SessionConfig()
@@ -537,11 +523,8 @@ def get_settings() -> Settings:
     if "logfire" in app_config:
         kwargs["logfire"] = LogfireConfig(**app_config["logfire"])
 
-    if "oauth2" in app_config:
-        oauth2_data = app_config["oauth2"]
-        kwargs["oauth2"] = OAuth2Config(
-            clients=[OAuth2ClientConfig(**c) for c in oauth2_data.get("clients", [])]
-        )
+    if "oauth2_enabled" in app_config:
+        kwargs["oauth2_enabled"] = app_config["oauth2_enabled"]
 
     if "storage" in app_config:
         storage_data = app_config["storage"]

--- a/skrift/controllers/oauth2.py
+++ b/skrift/controllers/oauth2.py
@@ -1,34 +1,30 @@
 """OAuth2 Authorization Server controller.
 
-Provides ``/oauth/authorize``, ``/oauth/token``, and ``/oauth/userinfo``
-endpoints so a Skrift instance can act as an identity hub for spoke sites.
+Provides ``/oauth/authorize``, ``/oauth/token``, ``/oauth/userinfo``,
+``/oauth/revoke``, and ``/oauth/introspect`` endpoints so a Skrift
+instance can act as an identity hub for spoke sites.
 """
 
 import base64
 import hashlib
+from datetime import datetime, timezone
 from urllib.parse import urlencode
 
 from litestar import Controller, Request, get, post
 from litestar.response import Redirect, Response, Template as TemplateResponse
+from sqlalchemy.ext.asyncio import AsyncSession
 
+from skrift.auth.scopes import SCOPE_DEFINITIONS
 from skrift.auth.session_keys import SESSION_USER_EMAIL, SESSION_USER_ID, SESSION_USER_NAME, SESSION_USER_PICTURE_URL
 from skrift.auth.tokens import create_signed_token, verify_signed_token
 from skrift.config import get_settings
+from skrift.db.services import oauth2_service
 from skrift.forms import verify_csrf
 
 # Token lifetimes
 AUTH_CODE_TTL = 600        # 10 minutes
 ACCESS_TOKEN_TTL = 900     # 15 minutes
 REFRESH_TOKEN_TTL = 2592000  # 30 days
-
-
-def _find_client(client_id: str):
-    """Look up a registered OAuth2 client by client_id."""
-    settings = get_settings()
-    for client in settings.oauth2.clients:
-        if client.client_id == client_id:
-            return client
-    return None
 
 
 def _json_error(error: str, description: str, status_code: int = 400) -> Response:
@@ -47,11 +43,27 @@ def _verify_pkce(code_verifier: str, code_challenge: str) -> bool:
     return computed == code_challenge
 
 
+async def verify_oauth_token(token: str, secret: str, db_session: AsyncSession) -> dict | None:
+    """Verify a signed token and check revocation status.
+
+    Returns the payload dict if valid and not revoked, or None.
+    """
+    payload = verify_signed_token(token, secret)
+    if payload is None:
+        return None
+
+    jti = payload.get("jti")
+    if jti and await oauth2_service.is_token_revoked(db_session, jti):
+        return None
+
+    return payload
+
+
 class OAuth2Controller(Controller):
     path = "/oauth"
 
     @get("/authorize")
-    async def authorize_get(self, request: Request) -> TemplateResponse | Redirect:
+    async def authorize_get(self, request: Request, db_session: AsyncSession) -> TemplateResponse | Redirect | Response:
         """Authorization endpoint — show consent screen or redirect to login."""
         params = request.query_params
         client_id = params.get("client_id", "")
@@ -67,12 +79,12 @@ class OAuth2Controller(Controller):
             return _json_error("unsupported_response_type", "Only response_type=code is supported")
 
         # Validate client
-        client = _find_client(client_id)
+        client = await oauth2_service.get_client_by_client_id(db_session, client_id)
         if not client:
             return _json_error("invalid_request", "Unknown client_id")
 
         # Validate redirect_uri
-        if redirect_uri not in client.redirect_uris:
+        if redirect_uri not in client.redirect_uri_list:
             return _json_error("invalid_request", "redirect_uri not registered for this client")
 
         # Public clients must use PKCE
@@ -81,6 +93,15 @@ class OAuth2Controller(Controller):
 
         if code_challenge and code_challenge_method != "S256":
             return _json_error("invalid_request", "Only code_challenge_method=S256 is supported")
+
+        # Validate requested scopes
+        requested_scopes = scope.split() if scope else []
+        allowed = client.allowed_scope_list
+        for s in requested_scopes:
+            if s not in SCOPE_DEFINITIONS:
+                return _json_error("invalid_scope", f"Unknown scope: {s}")
+            if allowed and s not in allowed:
+                return _json_error("invalid_scope", f"Scope not allowed for this client: {s}")
 
         # Check if user is logged in
         user_id = request.session.get(SESSION_USER_ID)
@@ -107,19 +128,28 @@ class OAuth2Controller(Controller):
             "code_challenge": code_challenge,
         }
 
-        scopes = scope.split() if scope else []
+        # Build scope descriptions for the consent screen
+        scope_descriptions = []
+        for s in requested_scopes:
+            defn = SCOPE_DEFINITIONS.get(s)
+            if defn:
+                scope_descriptions.append({"name": s, "description": defn.description})
+            else:
+                scope_descriptions.append({"name": s, "description": s})
 
         return TemplateResponse(
             "oauth/authorize.html",
             context={
                 "client_id": client_id,
-                "scopes": scopes,
+                "display_name": client.display_name,
+                "scopes": requested_scopes,
+                "scope_descriptions": scope_descriptions,
                 "request": request,
             },
         )
 
     @post("/authorize")
-    async def authorize_post(self, request: Request) -> Redirect | Response:
+    async def authorize_post(self, request: Request, db_session: AsyncSession) -> Redirect | Response:
         """Consent form submission — issue authorization code."""
         if not await verify_csrf(request):
             return _json_error("invalid_request", "Invalid CSRF token")
@@ -135,6 +165,7 @@ class OAuth2Controller(Controller):
         client_id = authorize_data["client_id"]
         redirect_uri = authorize_data["redirect_uri"]
         state = authorize_data["state"]
+        scope = authorize_data.get("scope", "")
         code_challenge = authorize_data.get("code_challenge", "")
 
         # User denied
@@ -157,6 +188,7 @@ class OAuth2Controller(Controller):
             "picture_url": request.session.get(SESSION_USER_PICTURE_URL, ""),
             "client_id": client_id,
             "redirect_uri": redirect_uri,
+            "scope": scope,
             "code_challenge": code_challenge,
         }
 
@@ -167,19 +199,19 @@ class OAuth2Controller(Controller):
         return Redirect(path=callback_url)
 
     @post("/token")
-    async def token_exchange(self, request: Request) -> Response:
+    async def token_exchange(self, request: Request, db_session: AsyncSession) -> Response:
         """Token endpoint — exchange auth code or refresh token for access token."""
         form_data = await request.form()
         grant_type = form_data.get("grant_type", "")
 
         if grant_type == "authorization_code":
-            return await self._handle_authorization_code(form_data)
+            return await self._handle_authorization_code(form_data, db_session)
         elif grant_type == "refresh_token":
-            return await self._handle_refresh_token(form_data)
+            return await self._handle_refresh_token(form_data, db_session)
         else:
             return _json_error("unsupported_grant_type", f"Unsupported grant_type: {grant_type}")
 
-    async def _handle_authorization_code(self, form_data) -> Response:
+    async def _handle_authorization_code(self, form_data, db_session: AsyncSession) -> Response:
         """Handle grant_type=authorization_code."""
         settings = get_settings()
 
@@ -189,7 +221,7 @@ class OAuth2Controller(Controller):
         client_secret = form_data.get("client_secret", "")
         code_verifier = form_data.get("code_verifier", "")
 
-        # Verify auth code
+        # Verify auth code (no revocation check needed — codes are single-use by expiry)
         payload = verify_signed_token(code, settings.secret_key)
         if not payload or payload.get("type") != "code":
             return _json_error("invalid_grant", "Invalid or expired authorization code")
@@ -201,7 +233,7 @@ class OAuth2Controller(Controller):
             return _json_error("invalid_grant", "redirect_uri mismatch")
 
         # Look up client
-        client = _find_client(client_id)
+        client = await oauth2_service.get_client_by_client_id(db_session, client_id)
         if not client:
             return _json_error("invalid_client", "Unknown client_id")
 
@@ -218,6 +250,8 @@ class OAuth2Controller(Controller):
             if not _verify_pkce(code_verifier, stored_challenge):
                 return _json_error("invalid_grant", "PKCE verification failed")
 
+        scope = payload.get("scope", "")
+
         # Issue tokens
         access_payload = {
             "type": "access",
@@ -226,11 +260,13 @@ class OAuth2Controller(Controller):
             "name": payload["name"],
             "picture_url": payload["picture_url"],
             "client_id": client_id,
+            "scope": scope,
         }
         refresh_payload = {
             "type": "refresh",
             "user_id": payload["user_id"],
             "client_id": client_id,
+            "scope": scope,
         }
 
         access_token = create_signed_token(access_payload, settings.secret_key, ACCESS_TOKEN_TTL)
@@ -242,12 +278,13 @@ class OAuth2Controller(Controller):
                 "refresh_token": refresh_token,
                 "token_type": "bearer",
                 "expires_in": ACCESS_TOKEN_TTL,
+                "scope": scope,
             },
             status_code=200,
             media_type="application/json",
         )
 
-    async def _handle_refresh_token(self, form_data) -> Response:
+    async def _handle_refresh_token(self, form_data, db_session: AsyncSession) -> Response:
         """Handle grant_type=refresh_token."""
         settings = get_settings()
 
@@ -255,8 +292,8 @@ class OAuth2Controller(Controller):
         client_id = form_data.get("client_id", "")
         client_secret = form_data.get("client_secret", "")
 
-        # Verify refresh token
-        payload = verify_signed_token(refresh_token_str, settings.secret_key)
+        # Verify refresh token (with revocation check)
+        payload = await verify_oauth_token(refresh_token_str, settings.secret_key, db_session)
         if not payload or payload.get("type") != "refresh":
             return _json_error("invalid_grant", "Invalid or expired refresh token")
 
@@ -264,7 +301,7 @@ class OAuth2Controller(Controller):
             return _json_error("invalid_grant", "client_id mismatch")
 
         # Look up client
-        client = _find_client(client_id)
+        client = await oauth2_service.get_client_by_client_id(db_session, client_id)
         if not client:
             return _json_error("invalid_client", "Unknown client_id")
 
@@ -272,6 +309,14 @@ class OAuth2Controller(Controller):
         if client.client_secret:
             if client_secret != client.client_secret:
                 return _json_error("invalid_client", "Invalid client_secret")
+
+        scope = payload.get("scope", "")
+
+        # Revoke the old refresh token
+        old_jti = payload.get("jti")
+        if old_jti:
+            expires_at = datetime.fromtimestamp(payload["exp"], tz=timezone.utc)
+            await oauth2_service.revoke_token(db_session, old_jti, "refresh", expires_at)
 
         # Issue new access + refresh tokens (token rotation)
         access_payload = {
@@ -281,11 +326,13 @@ class OAuth2Controller(Controller):
             "name": "",
             "picture_url": "",
             "client_id": client_id,
+            "scope": scope,
         }
         refresh_payload = {
             "type": "refresh",
             "user_id": payload["user_id"],
             "client_id": client_id,
+            "scope": scope,
         }
 
         access_token = create_signed_token(access_payload, settings.secret_key, ACCESS_TOKEN_TTL)
@@ -297,13 +344,14 @@ class OAuth2Controller(Controller):
                 "refresh_token": new_refresh_token,
                 "token_type": "bearer",
                 "expires_in": ACCESS_TOKEN_TTL,
+                "scope": scope,
             },
             status_code=200,
             media_type="application/json",
         )
 
     @get("/userinfo")
-    async def userinfo(self, request: Request) -> Response:
+    async def userinfo(self, request: Request, db_session: AsyncSession) -> Response:
         """UserInfo endpoint — return user data from a valid access token."""
         settings = get_settings()
 
@@ -312,17 +360,97 @@ class OAuth2Controller(Controller):
             return _json_error("invalid_token", "Missing or invalid Bearer token", status_code=401)
 
         token = auth_header[7:]  # Strip "Bearer "
-        payload = verify_signed_token(token, settings.secret_key)
+        payload = await verify_oauth_token(token, settings.secret_key, db_session)
         if not payload or payload.get("type") != "access":
             return _json_error("invalid_token", "Invalid or expired access token", status_code=401)
 
+        # Build claims based on granted scopes
+        scope_str = payload.get("scope", "")
+        granted_scopes = scope_str.split() if scope_str else []
+
+        # Collect allowed claims from scope definitions
+        allowed_claims: set[str] = set()
+        for s in granted_scopes:
+            defn = SCOPE_DEFINITIONS.get(s)
+            if defn:
+                allowed_claims.update(defn.claims)
+
+        # If no scopes specified, return all claims (backwards compatibility)
+        if not granted_scopes:
+            allowed_claims = {"sub", "email", "name", "picture"}
+
+        # Always include sub
+        claims: dict = {"sub": payload["user_id"]}
+
+        if "email" in allowed_claims:
+            claims["email"] = payload.get("email", "")
+        if "name" in allowed_claims:
+            claims["name"] = payload.get("name", "")
+        if "picture" in allowed_claims:
+            claims["picture"] = payload.get("picture_url", "")
+
         return Response(
-            content={
-                "sub": payload["user_id"],
-                "email": payload.get("email", ""),
-                "name": payload.get("name", ""),
-                "picture": payload.get("picture_url", ""),
-            },
+            content=claims,
             status_code=200,
             media_type="application/json",
         )
+
+    @post("/revoke")
+    async def revoke(self, request: Request, db_session: AsyncSession) -> Response:
+        """Token revocation endpoint (RFC 7009). Always returns 200."""
+        form_data = await request.form()
+        token_str = form_data.get("token", "")
+
+        if not token_str:
+            return Response(content={}, status_code=200, media_type="application/json")
+
+        settings = get_settings()
+        payload = verify_signed_token(token_str, settings.secret_key)
+
+        if payload and payload.get("jti"):
+            expires_at = datetime.fromtimestamp(payload["exp"], tz=timezone.utc)
+            await oauth2_service.revoke_token(
+                db_session, payload["jti"], payload.get("type", "unknown"), expires_at
+            )
+
+        # RFC 7009: always return 200, even if token was invalid
+        return Response(content={}, status_code=200, media_type="application/json")
+
+    @post("/introspect")
+    async def introspect(self, request: Request, db_session: AsyncSession) -> Response:
+        """Token introspection endpoint (RFC 7662). Requires client auth."""
+        form_data = await request.form()
+        token_str = form_data.get("token", "")
+        client_id = form_data.get("client_id", "")
+        client_secret = form_data.get("client_secret", "")
+
+        # Require client authentication
+        if not client_id:
+            return _json_error("invalid_client", "client_id required")
+
+        client = await oauth2_service.get_client_by_client_id(db_session, client_id)
+        if not client:
+            return _json_error("invalid_client", "Unknown client_id")
+
+        if client.client_secret and client_secret != client.client_secret:
+            return _json_error("invalid_client", "Invalid client_secret")
+
+        if not token_str:
+            return Response(content={"active": False}, status_code=200, media_type="application/json")
+
+        settings = get_settings()
+        payload = await verify_oauth_token(token_str, settings.secret_key, db_session)
+
+        if not payload:
+            return Response(content={"active": False}, status_code=200, media_type="application/json")
+
+        result = {
+            "active": True,
+            "token_type": payload.get("type", ""),
+            "client_id": payload.get("client_id", ""),
+            "sub": payload.get("user_id", ""),
+            "scope": payload.get("scope", ""),
+            "exp": payload.get("exp"),
+        }
+
+        return Response(content=result, status_code=200, media_type="application/json")

--- a/skrift/controllers/sitemap.py
+++ b/skrift/controllers/sitemap.py
@@ -126,6 +126,38 @@ Sitemap: {sitemap_url}
             headers={"Content-Type": "text/plain; charset=utf-8"},
         )
 
+    @get("/.well-known/openid-configuration")
+    async def openid_configuration(self, request: Request) -> Response:
+        """OIDC Discovery document."""
+        from skrift.config import get_settings
+
+        settings = get_settings()
+        if not settings.oauth2_enabled:
+            raise NotFoundException()
+
+        issuer = str(request.base_url).rstrip("/")
+
+        discovery = {
+            "issuer": issuer,
+            "authorization_endpoint": f"{issuer}/oauth/authorize",
+            "token_endpoint": f"{issuer}/oauth/token",
+            "userinfo_endpoint": f"{issuer}/oauth/userinfo",
+            "revocation_endpoint": f"{issuer}/oauth/revoke",
+            "introspection_endpoint": f"{issuer}/oauth/introspect",
+            "response_types_supported": ["code"],
+            "grant_types_supported": ["authorization_code", "refresh_token"],
+            "scopes_supported": ["openid", "profile", "email"],
+            "claims_supported": ["sub", "name", "email", "picture"],
+            "code_challenge_methods_supported": ["S256"],
+            "token_endpoint_auth_methods_supported": ["client_secret_post", "none"],
+        }
+
+        return Response(
+            content=discovery,
+            status_code=200,
+            media_type="application/json",
+        )
+
     @get("/.well-known/security.txt")
     async def security_txt(self, request: Request) -> Response:
         """Serve security.txt per RFC 9116."""

--- a/skrift/db/models/__init__.py
+++ b/skrift/db/models/__init__.py
@@ -1,11 +1,13 @@
 from skrift.db.models.asset import Asset
 from skrift.db.models.notification import DismissedNotification, StoredNotification
+from skrift.db.models.oauth2_client import OAuth2Client
 from skrift.db.models.oauth_account import OAuthAccount
 from skrift.db.models.page import Page
 from skrift.db.models.page_asset import page_assets
 from skrift.db.models.page_revision import PageRevision
+from skrift.db.models.revoked_token import RevokedToken
 from skrift.db.models.role import Role, RolePermission, user_roles
 from skrift.db.models.setting import Setting
 from skrift.db.models.user import User
 
-__all__ = ["Asset", "DismissedNotification", "OAuthAccount", "Page", "PageRevision", "Role", "RolePermission", "Setting", "StoredNotification", "User", "page_assets", "user_roles"]
+__all__ = ["Asset", "DismissedNotification", "OAuth2Client", "OAuthAccount", "Page", "PageRevision", "RevokedToken", "Role", "RolePermission", "Setting", "StoredNotification", "User", "page_assets", "user_roles"]

--- a/skrift/db/models/oauth2_client.py
+++ b/skrift/db/models/oauth2_client.py
@@ -1,0 +1,29 @@
+"""OAuth2 client model for the authorization server."""
+
+from sqlalchemy import String, Text, Boolean
+from sqlalchemy.orm import Mapped, mapped_column
+
+from skrift.db.base import Base
+
+
+class OAuth2Client(Base):
+    """A registered OAuth2 client application."""
+
+    __tablename__ = "oauth2_clients"
+
+    client_id: Mapped[str] = mapped_column(String(255), unique=True, index=True, nullable=False)
+    client_secret: Mapped[str] = mapped_column(String(255), default="", nullable=False)
+    display_name: Mapped[str] = mapped_column(String(255), nullable=False)
+    redirect_uris: Mapped[str] = mapped_column(Text, default="", nullable=False)
+    allowed_scopes: Mapped[str] = mapped_column(Text, default="", nullable=False)
+    is_active: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)
+
+    @property
+    def redirect_uri_list(self) -> list[str]:
+        """Parse newline-delimited redirect_uris into a list."""
+        return [uri.strip() for uri in self.redirect_uris.split("\n") if uri.strip()]
+
+    @property
+    def allowed_scope_list(self) -> list[str]:
+        """Parse newline-delimited allowed_scopes into a list."""
+        return [s.strip() for s in self.allowed_scopes.split("\n") if s.strip()]

--- a/skrift/db/models/revoked_token.py
+++ b/skrift/db/models/revoked_token.py
@@ -1,0 +1,18 @@
+"""Revoked token model for OAuth2 token revocation."""
+
+from datetime import datetime
+
+from sqlalchemy import String, DateTime
+from sqlalchemy.orm import Mapped, mapped_column
+
+from skrift.db.base import Base
+
+
+class RevokedToken(Base):
+    """A revoked OAuth2 token tracked by its JTI."""
+
+    __tablename__ = "revoked_tokens"
+
+    jti: Mapped[str] = mapped_column(String(64), unique=True, index=True, nullable=False)
+    token_type: Mapped[str] = mapped_column(String(20), nullable=False)
+    expires_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), index=True, nullable=False)

--- a/skrift/db/services/oauth2_service.py
+++ b/skrift/db/services/oauth2_service.py
@@ -1,0 +1,119 @@
+"""OAuth2 authorization server database service."""
+
+import secrets
+from datetime import datetime
+from uuid import UUID
+
+from sqlalchemy import select, delete
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from skrift.db.models.oauth2_client import OAuth2Client
+from skrift.db.models.revoked_token import RevokedToken
+
+
+async def get_client_by_client_id(db_session: AsyncSession, client_id: str) -> OAuth2Client | None:
+    """Look up an active OAuth2 client by its client_id string."""
+    result = await db_session.execute(
+        select(OAuth2Client).where(
+            OAuth2Client.client_id == client_id,
+            OAuth2Client.is_active == True,  # noqa: E712
+        )
+    )
+    return result.scalar_one_or_none()
+
+
+async def list_clients(db_session: AsyncSession) -> list[OAuth2Client]:
+    """List all OAuth2 clients."""
+    result = await db_session.execute(
+        select(OAuth2Client).order_by(OAuth2Client.created_at.desc())
+    )
+    return list(result.scalars().all())
+
+
+async def create_client(
+    db_session: AsyncSession,
+    display_name: str,
+    redirect_uris: list[str],
+    allowed_scopes: list[str],
+) -> OAuth2Client:
+    """Create a new OAuth2 client with auto-generated credentials."""
+    client = OAuth2Client(
+        client_id=secrets.token_urlsafe(24),
+        client_secret=secrets.token_urlsafe(48),
+        display_name=display_name,
+        redirect_uris="\n".join(redirect_uris),
+        allowed_scopes="\n".join(allowed_scopes),
+    )
+    db_session.add(client)
+    await db_session.flush()
+    return client
+
+
+async def update_client(
+    db_session: AsyncSession,
+    client: OAuth2Client,
+    display_name: str | None = None,
+    redirect_uris: list[str] | None = None,
+    allowed_scopes: list[str] | None = None,
+    is_active: bool | None = None,
+) -> OAuth2Client:
+    """Update an existing OAuth2 client."""
+    if display_name is not None:
+        client.display_name = display_name
+    if redirect_uris is not None:
+        client.redirect_uris = "\n".join(redirect_uris)
+    if allowed_scopes is not None:
+        client.allowed_scopes = "\n".join(allowed_scopes)
+    if is_active is not None:
+        client.is_active = is_active
+    await db_session.flush()
+    return client
+
+
+async def delete_client(db_session: AsyncSession, client_id: UUID) -> None:
+    """Delete an OAuth2 client by its database UUID."""
+    result = await db_session.execute(
+        select(OAuth2Client).where(OAuth2Client.id == client_id)
+    )
+    client = result.scalar_one_or_none()
+    if client:
+        await db_session.delete(client)
+        await db_session.flush()
+
+
+async def regenerate_client_secret(db_session: AsyncSession, client: OAuth2Client) -> str:
+    """Regenerate a client's secret and return the new value."""
+    new_secret = secrets.token_urlsafe(48)
+    client.client_secret = new_secret
+    await db_session.flush()
+    return new_secret
+
+
+async def revoke_token(
+    db_session: AsyncSession,
+    jti: str,
+    token_type: str,
+    expires_at: datetime,
+) -> None:
+    """Record a token revocation."""
+    revoked = RevokedToken(jti=jti, token_type=token_type, expires_at=expires_at)
+    db_session.add(revoked)
+    await db_session.flush()
+
+
+async def is_token_revoked(db_session: AsyncSession, jti: str) -> bool:
+    """Check if a token has been revoked."""
+    result = await db_session.execute(
+        select(RevokedToken.id).where(RevokedToken.jti == jti)
+    )
+    return result.scalar_one_or_none() is not None
+
+
+async def cleanup_expired_revocations(db_session: AsyncSession) -> int:
+    """Delete revocation records for tokens that have already expired."""
+    now = datetime.now(tz=datetime.now().astimezone().tzinfo)
+    result = await db_session.execute(
+        delete(RevokedToken).where(RevokedToken.expires_at < now)
+    )
+    await db_session.flush()
+    return result.rowcount

--- a/skrift/templates/admin/oauth2/edit.html
+++ b/skrift/templates/admin/oauth2/edit.html
@@ -1,0 +1,71 @@
+{% extends "admin/base.html" %}
+
+{% block title %}{{ "Edit" if client else "New" }} OAuth Client - Admin - {{ site_name() }}{% endblock %}
+
+{% block admin_content %}
+<hgroup>
+    <h1>{{ "Edit" if client else "New" }} OAuth Client</h1>
+    <p>{{ "Update client settings" if client else "Register a new OAuth2 client application" }}</p>
+</hgroup>
+
+{% if client %}
+<div style="margin-bottom: 1.5rem; padding: 1rem; background: var(--sk-color-bg-subtle, #f8f9fa); border-radius: 0.5rem;">
+    <p><strong>Client ID:</strong> <code>{{ client.client_id }}</code></p>
+    <p><strong>Client Secret:</strong> <code>{{ client.client_secret[:8] }}••••••••</code></p>
+    <form method="post" action="/admin/oauth-clients/{{ client.id }}/regenerate-secret" style="display: inline;">
+        {{ csrf_field(request) }}
+        <button type="submit" class="sk-btn-outline sk-btn-small" onclick="return confirm('Regenerate secret? The old secret will stop working immediately.')">Regenerate Secret</button>
+    </form>
+</div>
+{% endif %}
+
+<form method="post" action="/admin/oauth-clients/{{ client.id ~ '/edit' if client else 'new' }}">
+    {{ csrf_field(request) }}
+
+    <label>
+        Display Name
+        <input type="text" name="display_name" value="{{ client.display_name if client else '' }}" required placeholder="My Application">
+    </label>
+
+    <label>
+        Redirect URIs <small class="sk-text-muted">(one per line)</small>
+        <textarea name="redirect_uris" rows="4" placeholder="https://example.com/callback">{{ client.redirect_uris if client else '' }}</textarea>
+    </label>
+
+    <fieldset>
+        <legend>Allowed Scopes</legend>
+        {% for scope_name, scope_def in available_scopes.items() %}
+        <label>
+            <input type="checkbox" name="scope_{{ scope_name }}" {% if client and scope_name in client.allowed_scope_list %}checked{% endif %}>
+            <span>
+                <strong>{{ scope_name }}</strong>
+                <small class="sk-text-muted"> — {{ scope_def.description }}</small>
+            </span>
+        </label>
+        {% endfor %}
+    </fieldset>
+
+    {% if client %}
+    <label>
+        <input type="checkbox" name="is_active" {% if client.is_active %}checked{% endif %}>
+        Active
+    </label>
+    {% endif %}
+
+    <div class="sk-form-actions">
+        <button type="submit">{{ "Update Client" if client else "Create Client" }}</button>
+        <a href="/admin/oauth-clients" role="button" class="sk-btn-outline">Cancel</a>
+    </div>
+</form>
+
+{% if client %}
+<hr>
+<details>
+    <summary>Danger Zone</summary>
+    <form method="post" action="/admin/oauth-clients/{{ client.id }}/delete" style="margin-top: 1rem;">
+        {{ csrf_field(request) }}
+        <button type="submit" class="sk-btn-danger" onclick="return confirm('Delete this client? This cannot be undone.')">Delete Client</button>
+    </form>
+</details>
+{% endif %}
+{% endblock %}

--- a/skrift/templates/admin/oauth2/list.html
+++ b/skrift/templates/admin/oauth2/list.html
@@ -1,0 +1,49 @@
+{% extends "admin/base.html" %}
+
+{% block title %}OAuth Clients - Admin - {{ site_name() }}{% endblock %}
+
+{% block admin_content %}
+<hgroup>
+    <h1>OAuth Clients</h1>
+    <p>Manage registered OAuth2 client applications</p>
+</hgroup>
+
+<div class="sk-form-actions" style="margin-bottom: 1rem;">
+    <a href="/admin/oauth-clients/new" role="button">New Client</a>
+</div>
+
+<table class="sk-admin-table">
+    <thead>
+        <tr>
+            <th>Display Name</th>
+            <th>Client ID</th>
+            <th>Redirect URIs</th>
+            <th>Status</th>
+            <th>Actions</th>
+        </tr>
+    </thead>
+    <tbody>
+        {% for client in clients %}
+        <tr>
+            <td>{{ client.display_name }}</td>
+            <td><code>{{ client.client_id[:16] }}...</code></td>
+            <td>{{ client.redirect_uri_list | length }} URI{{ "s" if client.redirect_uri_list | length != 1 }}</td>
+            <td>
+                {% if client.is_active %}
+                    <span class="sk-role-badge">Active</span>
+                {% else %}
+                    <span class="sk-text-muted">Inactive</span>
+                {% endif %}
+            </td>
+            <td>
+                <a href="/admin/oauth-clients/{{ client.id }}/edit" role="button" class="sk-btn-outline sk-btn-small">Edit</a>
+            </td>
+        </tr>
+        {% endfor %}
+    </tbody>
+</table>
+
+{% if not clients %}
+<p class="sk-no-items">No OAuth2 clients registered.</p>
+{% endif %}
+{% endblock %}

--- a/skrift/templates/oauth/authorize.html
+++ b/skrift/templates/oauth/authorize.html
@@ -78,11 +78,18 @@
         </header>
 
         <p>
-            <span class="client-name">{{ client_id }}</span>
+            <span class="client-name">{{ display_name or client_id }}</span>
             wants to access your account.
         </p>
 
-        {% if scopes %}
+        {% if scope_descriptions %}
+        <p>This will allow the application to:</p>
+        <ul class="scope-list">
+            {% for scope in scope_descriptions %}
+            <li>{{ scope.description }}</li>
+            {% endfor %}
+        </ul>
+        {% elif scopes %}
         <p>This will allow the application to:</p>
         <ul class="scope-list">
             {% for scope in scopes %}

--- a/tests/test_oauth2_server.py
+++ b/tests/test_oauth2_server.py
@@ -7,33 +7,45 @@ from unittest.mock import MagicMock, patch, AsyncMock
 import pytest
 from litestar.response import Redirect, Template as TemplateResponse
 
-from skrift.auth.tokens import create_signed_token
+from skrift.auth.scopes import SCOPE_DEFINITIONS, register_scope, get_scope_definition
+from skrift.auth.tokens import create_signed_token, verify_signed_token
 from skrift.controllers.oauth2 import (
     OAuth2Controller,
-    _find_client,
     _verify_pkce,
     _json_error,
+    verify_oauth_token,
     AUTH_CODE_TTL,
     ACCESS_TOKEN_TTL,
     REFRESH_TOKEN_TTL,
 )
 
 
-def _make_settings(clients=None):
-    """Create a mock settings object with OAuth2 clients."""
+SECRET = "test-secret-key"
+
+
+def _make_settings():
+    """Create a mock settings object."""
     settings = MagicMock()
-    settings.secret_key = "test-secret-key"
-    if clients is None:
-        clients = []
-    mock_clients = []
-    for c in clients:
-        mc = MagicMock()
-        mc.client_id = c["client_id"]
-        mc.client_secret = c.get("client_secret", "")
-        mc.redirect_uris = c.get("redirect_uris", [])
-        mock_clients.append(mc)
-    settings.oauth2.clients = mock_clients
+    settings.secret_key = SECRET
     return settings
+
+
+def _mock_client(
+    client_id="abc",
+    client_secret="secret",
+    redirect_uris=None,
+    allowed_scopes=None,
+    is_active=True,
+):
+    """Create a mock OAuth2Client model."""
+    mc = MagicMock()
+    mc.client_id = client_id
+    mc.client_secret = client_secret
+    mc.display_name = f"Test App ({client_id})"
+    mc.is_active = is_active
+    mc.redirect_uri_list = redirect_uris or ["http://localhost/cb"]
+    mc.allowed_scope_list = allowed_scopes or []
+    return mc
 
 
 def _generate_pkce():
@@ -42,20 +54,6 @@ def _generate_pkce():
     digest = hashlib.sha256(code_verifier.encode()).digest()
     code_challenge = base64.urlsafe_b64encode(digest).decode().rstrip("=")
     return code_verifier, code_challenge
-
-
-class TestFindClient:
-    def test_finds_existing_client(self):
-        with patch("skrift.controllers.oauth2.get_settings", return_value=_make_settings([
-            {"client_id": "abc", "client_secret": "secret", "redirect_uris": ["http://localhost/cb"]},
-        ])):
-            client = _find_client("abc")
-            assert client is not None
-            assert client.client_id == "abc"
-
-    def test_returns_none_for_unknown(self):
-        with patch("skrift.controllers.oauth2.get_settings", return_value=_make_settings([])):
-            assert _find_client("unknown") is None
 
 
 class TestVerifyPkce:
@@ -76,6 +74,52 @@ class TestJsonError:
         assert resp.content["error_description"] == "Bad thing happened"
 
 
+class TestJti:
+    def test_tokens_include_jti(self):
+        token = create_signed_token({"type": "access"}, SECRET, 300)
+        payload = verify_signed_token(token, SECRET)
+        assert "jti" in payload
+        assert len(payload["jti"]) == 32  # uuid4().hex
+
+    def test_each_token_has_unique_jti(self):
+        t1 = create_signed_token({"type": "access"}, SECRET, 300)
+        t2 = create_signed_token({"type": "access"}, SECRET, 300)
+        p1 = verify_signed_token(t1, SECRET)
+        p2 = verify_signed_token(t2, SECRET)
+        assert p1["jti"] != p2["jti"]
+
+
+class TestVerifyOAuthToken:
+    @pytest.mark.asyncio
+    async def test_valid_token(self):
+        token = create_signed_token({"type": "access"}, SECRET, 300)
+        db_session = AsyncMock()
+
+        with patch("skrift.controllers.oauth2.oauth2_service") as mock_svc:
+            mock_svc.is_token_revoked = AsyncMock(return_value=False)
+            payload = await verify_oauth_token(token, SECRET, db_session)
+
+        assert payload is not None
+        assert payload["type"] == "access"
+
+    @pytest.mark.asyncio
+    async def test_revoked_token(self):
+        token = create_signed_token({"type": "access"}, SECRET, 300)
+        db_session = AsyncMock()
+
+        with patch("skrift.controllers.oauth2.oauth2_service") as mock_svc:
+            mock_svc.is_token_revoked = AsyncMock(return_value=True)
+            payload = await verify_oauth_token(token, SECRET, db_session)
+
+        assert payload is None
+
+    @pytest.mark.asyncio
+    async def test_invalid_token(self):
+        db_session = AsyncMock()
+        payload = await verify_oauth_token("bogus", SECRET, db_session)
+        assert payload is None
+
+
 class TestAuthorizeGet:
     @pytest.mark.asyncio
     async def test_requires_code_response_type(self):
@@ -83,8 +127,9 @@ class TestAuthorizeGet:
         request = MagicMock()
         request.query_params = {"response_type": "token", "client_id": "abc"}
         request.session = {}
+        db_session = AsyncMock()
 
-        result = await OAuth2Controller.authorize_get.fn(controller, request)
+        result = await OAuth2Controller.authorize_get.fn(controller, request, db_session)
         assert result.status_code == 400
 
     @pytest.mark.asyncio
@@ -97,9 +142,11 @@ class TestAuthorizeGet:
             "redirect_uri": "http://localhost/cb",
         }
         request.session = {}
+        db_session = AsyncMock()
 
-        with patch("skrift.controllers.oauth2.get_settings", return_value=_make_settings([])):
-            result = await OAuth2Controller.authorize_get.fn(controller, request)
+        with patch("skrift.controllers.oauth2.oauth2_service") as mock_svc:
+            mock_svc.get_client_by_client_id = AsyncMock(return_value=None)
+            result = await OAuth2Controller.authorize_get.fn(controller, request, db_session)
         assert result.status_code == 400
 
     @pytest.mark.asyncio
@@ -112,11 +159,12 @@ class TestAuthorizeGet:
             "redirect_uri": "http://evil.com/cb",
         }
         request.session = {}
+        db_session = AsyncMock()
+        client = _mock_client(redirect_uris=["http://localhost/cb"])
 
-        with patch("skrift.controllers.oauth2.get_settings", return_value=_make_settings([
-            {"client_id": "abc", "redirect_uris": ["http://localhost/cb"]},
-        ])):
-            result = await OAuth2Controller.authorize_get.fn(controller, request)
+        with patch("skrift.controllers.oauth2.oauth2_service") as mock_svc:
+            mock_svc.get_client_by_client_id = AsyncMock(return_value=client)
+            result = await OAuth2Controller.authorize_get.fn(controller, request, db_session)
         assert result.status_code == 400
 
     @pytest.mark.asyncio
@@ -133,12 +181,60 @@ class TestAuthorizeGet:
             "code_challenge_method": "",
         }
         request.session = {}
+        db_session = AsyncMock()
+        client = _mock_client(client_secret="", redirect_uris=["http://localhost/cb"])
 
-        with patch("skrift.controllers.oauth2.get_settings", return_value=_make_settings([
-            {"client_id": "abc", "client_secret": "", "redirect_uris": ["http://localhost/cb"]},
-        ])):
-            result = await OAuth2Controller.authorize_get.fn(controller, request)
+        with patch("skrift.controllers.oauth2.oauth2_service") as mock_svc:
+            mock_svc.get_client_by_client_id = AsyncMock(return_value=client)
+            result = await OAuth2Controller.authorize_get.fn(controller, request, db_session)
         assert result.status_code == 400
+
+    @pytest.mark.asyncio
+    async def test_rejects_unknown_scope(self):
+        controller = OAuth2Controller(owner=MagicMock())
+        request = MagicMock()
+        request.query_params = {
+            "response_type": "code",
+            "client_id": "abc",
+            "redirect_uri": "http://localhost/cb",
+            "state": "xyz",
+            "scope": "openid bogus_scope",
+            "code_challenge": "challenge",
+            "code_challenge_method": "S256",
+        }
+        request.session = {}
+        db_session = AsyncMock()
+        client = _mock_client(redirect_uris=["http://localhost/cb"])
+
+        with patch("skrift.controllers.oauth2.oauth2_service") as mock_svc:
+            mock_svc.get_client_by_client_id = AsyncMock(return_value=client)
+            result = await OAuth2Controller.authorize_get.fn(controller, request, db_session)
+        assert result.status_code == 400
+        assert "Unknown scope" in result.content["error_description"]
+
+    @pytest.mark.asyncio
+    async def test_rejects_disallowed_scope(self):
+        controller = OAuth2Controller(owner=MagicMock())
+        request = MagicMock()
+        request.query_params = {
+            "response_type": "code",
+            "client_id": "abc",
+            "redirect_uri": "http://localhost/cb",
+            "state": "xyz",
+            "scope": "openid email",
+            "code_challenge": "challenge",
+            "code_challenge_method": "S256",
+        }
+        request.session = {}
+        db_session = AsyncMock()
+        # Client only allows openid scope
+        client = _mock_client(redirect_uris=["http://localhost/cb"], allowed_scopes=["openid"])
+
+        with patch("skrift.controllers.oauth2.oauth2_service") as mock_svc:
+            mock_svc.get_client_by_client_id = AsyncMock(return_value=client)
+            result = await OAuth2Controller.authorize_get.fn(controller, request, db_session)
+        assert result.status_code == 400
+        assert "not allowed" in result.content["error_description"]
 
     @pytest.mark.asyncio
     async def test_redirects_to_login_if_not_authenticated(self):
@@ -154,11 +250,12 @@ class TestAuthorizeGet:
             "code_challenge_method": "S256",
         }
         request.session = {}  # No user_id
+        db_session = AsyncMock()
+        client = _mock_client(redirect_uris=["http://localhost/cb"])
 
-        with patch("skrift.controllers.oauth2.get_settings", return_value=_make_settings([
-            {"client_id": "abc", "redirect_uris": ["http://localhost/cb"]},
-        ])):
-            result = await OAuth2Controller.authorize_get.fn(controller, request)
+        with patch("skrift.controllers.oauth2.oauth2_service") as mock_svc:
+            mock_svc.get_client_by_client_id = AsyncMock(return_value=client)
+            result = await OAuth2Controller.authorize_get.fn(controller, request, db_session)
 
         assert isinstance(result, Redirect)
         assert "/auth/login" in result.url
@@ -178,11 +275,12 @@ class TestAuthorizeGet:
         }
         session = {"user_id": "user-123"}
         request.session = session
+        db_session = AsyncMock()
+        client = _mock_client(redirect_uris=["http://localhost/cb"])
 
-        with patch("skrift.controllers.oauth2.get_settings", return_value=_make_settings([
-            {"client_id": "abc", "redirect_uris": ["http://localhost/cb"]},
-        ])):
-            result = await OAuth2Controller.authorize_get.fn(controller, request)
+        with patch("skrift.controllers.oauth2.oauth2_service") as mock_svc:
+            mock_svc.get_client_by_client_id = AsyncMock(return_value=client)
+            result = await OAuth2Controller.authorize_get.fn(controller, request, db_session)
 
         assert isinstance(result, TemplateResponse)
         assert result.template_name == "oauth/authorize.html"
@@ -192,9 +290,6 @@ class TestAuthorizeGet:
 class TestAuthorizePost:
     @pytest.mark.asyncio
     async def test_deny_redirects_with_error(self):
-        settings = _make_settings([
-            {"client_id": "abc", "client_secret": "secret", "redirect_uris": ["http://localhost/cb"]},
-        ])
         controller = OAuth2Controller(owner=MagicMock())
         request = MagicMock()
         request.session = {
@@ -203,25 +298,23 @@ class TestAuthorizePost:
                 "client_id": "abc",
                 "redirect_uri": "http://localhost/cb",
                 "state": "xyz",
+                "scope": "openid",
                 "code_challenge": "",
             },
         }
-
         form_data = {"action": "deny"}
         request.form = AsyncMock(return_value=form_data)
+        db_session = AsyncMock()
 
-        with patch("skrift.controllers.oauth2.verify_csrf", new_callable=AsyncMock, return_value=True), \
-             patch("skrift.controllers.oauth2.get_settings", return_value=settings):
-            result = await OAuth2Controller.authorize_post.fn(controller, request)
+        with patch("skrift.controllers.oauth2.verify_csrf", new_callable=AsyncMock, return_value=True):
+            result = await OAuth2Controller.authorize_post.fn(controller, request, db_session)
 
         assert isinstance(result, Redirect)
         assert "error=access_denied" in result.url
 
     @pytest.mark.asyncio
     async def test_approve_returns_code(self):
-        settings = _make_settings([
-            {"client_id": "abc", "client_secret": "secret", "redirect_uris": ["http://localhost/cb"]},
-        ])
+        settings = _make_settings()
         controller = OAuth2Controller(owner=MagicMock())
         request = MagicMock()
         request.session = {
@@ -233,16 +326,17 @@ class TestAuthorizePost:
                 "client_id": "abc",
                 "redirect_uri": "http://localhost/cb",
                 "state": "xyz",
+                "scope": "openid",
                 "code_challenge": "",
             },
         }
-
         form_data = {"action": "allow"}
         request.form = AsyncMock(return_value=form_data)
+        db_session = AsyncMock()
 
         with patch("skrift.controllers.oauth2.verify_csrf", new_callable=AsyncMock, return_value=True), \
              patch("skrift.controllers.oauth2.get_settings", return_value=settings):
-            result = await OAuth2Controller.authorize_post.fn(controller, request)
+            result = await OAuth2Controller.authorize_post.fn(controller, request, db_session)
 
         assert isinstance(result, Redirect)
         assert "code=" in result.url
@@ -252,9 +346,7 @@ class TestAuthorizePost:
 class TestTokenExchange:
     @pytest.mark.asyncio
     async def test_authorization_code_grant(self):
-        settings = _make_settings([
-            {"client_id": "abc", "client_secret": "secret", "redirect_uris": ["http://localhost/cb"]},
-        ])
+        settings = _make_settings()
         code = create_signed_token({
             "type": "code",
             "user_id": "user-123",
@@ -263,9 +355,11 @@ class TestTokenExchange:
             "picture_url": "",
             "client_id": "abc",
             "redirect_uri": "http://localhost/cb",
+            "scope": "openid",
             "code_challenge": "",
-        }, settings.secret_key, AUTH_CODE_TTL)
+        }, SECRET, AUTH_CODE_TTL)
 
+        client = _mock_client()
         controller = OAuth2Controller(owner=MagicMock())
         request = MagicMock()
         request.form = AsyncMock(return_value={
@@ -276,9 +370,12 @@ class TestTokenExchange:
             "client_secret": "secret",
             "code_verifier": "",
         })
+        db_session = AsyncMock()
 
-        with patch("skrift.controllers.oauth2.get_settings", return_value=settings):
-            result = await OAuth2Controller.token_exchange.fn(controller, request)
+        with patch("skrift.controllers.oauth2.get_settings", return_value=settings), \
+             patch("skrift.controllers.oauth2.oauth2_service") as mock_svc:
+            mock_svc.get_client_by_client_id = AsyncMock(return_value=client)
+            result = await OAuth2Controller.token_exchange.fn(controller, request, db_session)
 
         assert result.status_code == 200
         body = result.content
@@ -286,13 +383,11 @@ class TestTokenExchange:
         assert "refresh_token" in body
         assert body["token_type"] == "bearer"
         assert body["expires_in"] == ACCESS_TOKEN_TTL
+        assert body["scope"] == "openid"
 
     @pytest.mark.asyncio
     async def test_invalid_code_rejected(self):
-        settings = _make_settings([
-            {"client_id": "abc", "client_secret": "secret", "redirect_uris": ["http://localhost/cb"]},
-        ])
-
+        settings = _make_settings()
         controller = OAuth2Controller(owner=MagicMock())
         request = MagicMock()
         request.form = AsyncMock(return_value={
@@ -303,53 +398,17 @@ class TestTokenExchange:
             "client_secret": "secret",
             "code_verifier": "",
         })
+        db_session = AsyncMock()
 
         with patch("skrift.controllers.oauth2.get_settings", return_value=settings):
-            result = await OAuth2Controller.token_exchange.fn(controller, request)
-
-        assert result.status_code == 400
-
-    @pytest.mark.asyncio
-    async def test_pkce_required_for_public_client(self):
-        settings = _make_settings([
-            {"client_id": "abc", "client_secret": "", "redirect_uris": ["http://localhost/cb"]},
-        ])
-        _, challenge = _generate_pkce()
-
-        code = create_signed_token({
-            "type": "code",
-            "user_id": "user-123",
-            "email": "test@test.com",
-            "name": "Test",
-            "picture_url": "",
-            "client_id": "abc",
-            "redirect_uri": "http://localhost/cb",
-            "code_challenge": challenge,
-        }, settings.secret_key, AUTH_CODE_TTL)
-
-        controller = OAuth2Controller(owner=MagicMock())
-        request = MagicMock()
-
-        # Missing code_verifier
-        request.form = AsyncMock(return_value={
-            "grant_type": "authorization_code",
-            "code": code,
-            "redirect_uri": "http://localhost/cb",
-            "client_id": "abc",
-            "client_secret": "",
-            "code_verifier": "",
-        })
-
-        with patch("skrift.controllers.oauth2.get_settings", return_value=settings):
-            result = await OAuth2Controller.token_exchange.fn(controller, request)
+            result = await OAuth2Controller.token_exchange.fn(controller, request, db_session)
         assert result.status_code == 400
 
     @pytest.mark.asyncio
     async def test_pkce_exchange_succeeds(self):
-        settings = _make_settings([
-            {"client_id": "abc", "client_secret": "", "redirect_uris": ["http://localhost/cb"]},
-        ])
+        settings = _make_settings()
         verifier, challenge = _generate_pkce()
+        client = _mock_client(client_secret="")
 
         code = create_signed_token({
             "type": "code",
@@ -359,8 +418,9 @@ class TestTokenExchange:
             "picture_url": "",
             "client_id": "abc",
             "redirect_uri": "http://localhost/cb",
+            "scope": "openid",
             "code_challenge": challenge,
-        }, settings.secret_key, AUTH_CODE_TTL)
+        }, SECRET, AUTH_CODE_TTL)
 
         controller = OAuth2Controller(owner=MagicMock())
         request = MagicMock()
@@ -372,58 +432,28 @@ class TestTokenExchange:
             "client_secret": "",
             "code_verifier": verifier,
         })
+        db_session = AsyncMock()
 
-        with patch("skrift.controllers.oauth2.get_settings", return_value=settings):
-            result = await OAuth2Controller.token_exchange.fn(controller, request)
+        with patch("skrift.controllers.oauth2.get_settings", return_value=settings), \
+             patch("skrift.controllers.oauth2.oauth2_service") as mock_svc:
+            mock_svc.get_client_by_client_id = AsyncMock(return_value=client)
+            result = await OAuth2Controller.token_exchange.fn(controller, request, db_session)
 
         assert result.status_code == 200
-        body = result.content
-        assert "access_token" in body
-        assert "refresh_token" in body
-
-    @pytest.mark.asyncio
-    async def test_client_id_mismatch_rejected(self):
-        settings = _make_settings([
-            {"client_id": "abc", "client_secret": "secret", "redirect_uris": ["http://localhost/cb"]},
-        ])
-        code = create_signed_token({
-            "type": "code",
-            "user_id": "user-123",
-            "email": "test@test.com",
-            "name": "Test",
-            "picture_url": "",
-            "client_id": "abc",
-            "redirect_uri": "http://localhost/cb",
-            "code_challenge": "",
-        }, settings.secret_key, AUTH_CODE_TTL)
-
-        controller = OAuth2Controller(owner=MagicMock())
-        request = MagicMock()
-        request.form = AsyncMock(return_value={
-            "grant_type": "authorization_code",
-            "code": code,
-            "redirect_uri": "http://localhost/cb",
-            "client_id": "different-client",
-            "client_secret": "secret",
-            "code_verifier": "",
-        })
-
-        with patch("skrift.controllers.oauth2.get_settings", return_value=settings):
-            result = await OAuth2Controller.token_exchange.fn(controller, request)
-        assert result.status_code == 400
+        assert "access_token" in result.content
 
 
 class TestRefreshTokenGrant:
     @pytest.mark.asyncio
     async def test_valid_refresh(self):
-        settings = _make_settings([
-            {"client_id": "abc", "client_secret": "secret", "redirect_uris": ["http://localhost/cb"]},
-        ])
+        settings = _make_settings()
+        client = _mock_client()
         refresh = create_signed_token({
             "type": "refresh",
             "user_id": "user-123",
             "client_id": "abc",
-        }, settings.secret_key, REFRESH_TOKEN_TTL)
+            "scope": "openid",
+        }, SECRET, REFRESH_TOKEN_TTL)
 
         controller = OAuth2Controller(owner=MagicMock())
         request = MagicMock()
@@ -433,69 +463,52 @@ class TestRefreshTokenGrant:
             "client_id": "abc",
             "client_secret": "secret",
         })
+        db_session = AsyncMock()
 
-        with patch("skrift.controllers.oauth2.get_settings", return_value=settings):
-            result = await OAuth2Controller.token_exchange.fn(controller, request)
+        with patch("skrift.controllers.oauth2.get_settings", return_value=settings), \
+             patch("skrift.controllers.oauth2.oauth2_service") as mock_svc:
+            mock_svc.is_token_revoked = AsyncMock(return_value=False)
+            mock_svc.get_client_by_client_id = AsyncMock(return_value=client)
+            mock_svc.revoke_token = AsyncMock()
+            result = await OAuth2Controller.token_exchange.fn(controller, request, db_session)
 
         assert result.status_code == 200
         body = result.content
         assert "access_token" in body
         assert "refresh_token" in body
-        # New refresh token should be a valid token
-        from skrift.auth.tokens import verify_signed_token
-        new_payload = verify_signed_token(body["refresh_token"], settings.secret_key)
-        assert new_payload is not None
-        assert new_payload["type"] == "refresh"
-        assert new_payload["user_id"] == "user-123"
+        # Verify old refresh token was revoked
+        mock_svc.revoke_token.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_invalid_refresh_token_rejected(self):
-        settings = _make_settings([
-            {"client_id": "abc", "client_secret": "secret", "redirect_uris": ["http://localhost/cb"]},
-        ])
-
-        controller = OAuth2Controller(owner=MagicMock())
-        request = MagicMock()
-        request.form = AsyncMock(return_value={
-            "grant_type": "refresh_token",
-            "refresh_token": "bogus-token",
-            "client_id": "abc",
-            "client_secret": "secret",
-        })
-
-        with patch("skrift.controllers.oauth2.get_settings", return_value=settings):
-            result = await OAuth2Controller.token_exchange.fn(controller, request)
-        assert result.status_code == 400
-
-    @pytest.mark.asyncio
-    async def test_access_token_rejected_as_refresh(self):
-        """Type field prevents using access token as refresh token."""
-        settings = _make_settings([
-            {"client_id": "abc", "client_secret": "secret", "redirect_uris": ["http://localhost/cb"]},
-        ])
-        access = create_signed_token({
-            "type": "access",
+    async def test_revoked_refresh_token_rejected(self):
+        settings = _make_settings()
+        refresh = create_signed_token({
+            "type": "refresh",
             "user_id": "user-123",
             "client_id": "abc",
-        }, settings.secret_key, ACCESS_TOKEN_TTL)
+        }, SECRET, REFRESH_TOKEN_TTL)
 
         controller = OAuth2Controller(owner=MagicMock())
         request = MagicMock()
         request.form = AsyncMock(return_value={
             "grant_type": "refresh_token",
-            "refresh_token": access,  # Wrong type!
+            "refresh_token": refresh,
             "client_id": "abc",
             "client_secret": "secret",
         })
+        db_session = AsyncMock()
 
-        with patch("skrift.controllers.oauth2.get_settings", return_value=settings):
-            result = await OAuth2Controller.token_exchange.fn(controller, request)
+        with patch("skrift.controllers.oauth2.get_settings", return_value=settings), \
+             patch("skrift.controllers.oauth2.oauth2_service") as mock_svc:
+            mock_svc.is_token_revoked = AsyncMock(return_value=True)
+            result = await OAuth2Controller.token_exchange.fn(controller, request, db_session)
+
         assert result.status_code == 400
 
 
 class TestUserInfo:
     @pytest.mark.asyncio
-    async def test_valid_access_token(self):
+    async def test_valid_access_token_all_scopes(self):
         settings = _make_settings()
         access = create_signed_token({
             "type": "access",
@@ -504,14 +517,18 @@ class TestUserInfo:
             "name": "Test User",
             "picture_url": "https://pic.url",
             "client_id": "abc",
-        }, settings.secret_key, ACCESS_TOKEN_TTL)
+            "scope": "openid profile email",
+        }, SECRET, ACCESS_TOKEN_TTL)
 
         controller = OAuth2Controller(owner=MagicMock())
         request = MagicMock()
         request.headers = {"authorization": f"Bearer {access}"}
+        db_session = AsyncMock()
 
-        with patch("skrift.controllers.oauth2.get_settings", return_value=settings):
-            result = await OAuth2Controller.userinfo.fn(controller, request)
+        with patch("skrift.controllers.oauth2.get_settings", return_value=settings), \
+             patch("skrift.controllers.oauth2.oauth2_service") as mock_svc:
+            mock_svc.is_token_revoked = AsyncMock(return_value=False)
+            result = await OAuth2Controller.userinfo.fn(controller, request, db_session)
 
         assert result.status_code == 200
         body = result.content
@@ -521,39 +538,274 @@ class TestUserInfo:
         assert body["picture"] == "https://pic.url"
 
     @pytest.mark.asyncio
+    async def test_scope_filtering_openid_only(self):
+        """With only openid scope, only sub is returned."""
+        settings = _make_settings()
+        access = create_signed_token({
+            "type": "access",
+            "user_id": "user-123",
+            "email": "test@test.com",
+            "name": "Test User",
+            "picture_url": "https://pic.url",
+            "client_id": "abc",
+            "scope": "openid",
+        }, SECRET, ACCESS_TOKEN_TTL)
+
+        controller = OAuth2Controller(owner=MagicMock())
+        request = MagicMock()
+        request.headers = {"authorization": f"Bearer {access}"}
+        db_session = AsyncMock()
+
+        with patch("skrift.controllers.oauth2.get_settings", return_value=settings), \
+             patch("skrift.controllers.oauth2.oauth2_service") as mock_svc:
+            mock_svc.is_token_revoked = AsyncMock(return_value=False)
+            result = await OAuth2Controller.userinfo.fn(controller, request, db_session)
+
+        assert result.status_code == 200
+        body = result.content
+        assert body["sub"] == "user-123"
+        assert "email" not in body
+        assert "name" not in body
+
+    @pytest.mark.asyncio
     async def test_missing_bearer_token(self):
         controller = OAuth2Controller(owner=MagicMock())
         request = MagicMock()
         request.headers = {}
+        db_session = AsyncMock()
 
         with patch("skrift.controllers.oauth2.get_settings", return_value=_make_settings()):
-            result = await OAuth2Controller.userinfo.fn(controller, request)
+            result = await OAuth2Controller.userinfo.fn(controller, request, db_session)
         assert result.status_code == 401
 
     @pytest.mark.asyncio
-    async def test_invalid_token(self):
-        controller = OAuth2Controller(owner=MagicMock())
-        request = MagicMock()
-        request.headers = {"authorization": "Bearer invalid-token"}
-
-        with patch("skrift.controllers.oauth2.get_settings", return_value=_make_settings()):
-            result = await OAuth2Controller.userinfo.fn(controller, request)
-        assert result.status_code == 401
-
-    @pytest.mark.asyncio
-    async def test_refresh_token_rejected_as_access(self):
-        """Type field prevents using refresh token at userinfo endpoint."""
+    async def test_revoked_access_token(self):
         settings = _make_settings()
-        refresh = create_signed_token({
-            "type": "refresh",
+        access = create_signed_token({
+            "type": "access",
             "user_id": "user-123",
             "client_id": "abc",
-        }, settings.secret_key, REFRESH_TOKEN_TTL)
+        }, SECRET, ACCESS_TOKEN_TTL)
 
         controller = OAuth2Controller(owner=MagicMock())
         request = MagicMock()
-        request.headers = {"authorization": f"Bearer {refresh}"}
+        request.headers = {"authorization": f"Bearer {access}"}
+        db_session = AsyncMock()
+
+        with patch("skrift.controllers.oauth2.get_settings", return_value=settings), \
+             patch("skrift.controllers.oauth2.oauth2_service") as mock_svc:
+            mock_svc.is_token_revoked = AsyncMock(return_value=True)
+            result = await OAuth2Controller.userinfo.fn(controller, request, db_session)
+        assert result.status_code == 401
+
+
+class TestRevoke:
+    @pytest.mark.asyncio
+    async def test_revoke_valid_token(self):
+        settings = _make_settings()
+        token = create_signed_token({
+            "type": "access",
+            "user_id": "user-123",
+            "client_id": "abc",
+        }, SECRET, ACCESS_TOKEN_TTL)
+
+        controller = OAuth2Controller(owner=MagicMock())
+        request = MagicMock()
+        request.form = AsyncMock(return_value={"token": token})
+        db_session = AsyncMock()
+
+        with patch("skrift.controllers.oauth2.get_settings", return_value=settings), \
+             patch("skrift.controllers.oauth2.oauth2_service") as mock_svc:
+            mock_svc.revoke_token = AsyncMock()
+            result = await OAuth2Controller.revoke.fn(controller, request, db_session)
+
+        assert result.status_code == 200
+        mock_svc.revoke_token.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_revoke_invalid_token_still_200(self):
+        """RFC 7009: always return 200 even for invalid tokens."""
+        settings = _make_settings()
+        controller = OAuth2Controller(owner=MagicMock())
+        request = MagicMock()
+        request.form = AsyncMock(return_value={"token": "invalid-token"})
+        db_session = AsyncMock()
 
         with patch("skrift.controllers.oauth2.get_settings", return_value=settings):
-            result = await OAuth2Controller.userinfo.fn(controller, request)
-        assert result.status_code == 401
+            result = await OAuth2Controller.revoke.fn(controller, request, db_session)
+        assert result.status_code == 200
+
+    @pytest.mark.asyncio
+    async def test_revoke_empty_token(self):
+        controller = OAuth2Controller(owner=MagicMock())
+        request = MagicMock()
+        request.form = AsyncMock(return_value={"token": ""})
+        db_session = AsyncMock()
+
+        result = await OAuth2Controller.revoke.fn(controller, request, db_session)
+        assert result.status_code == 200
+
+
+class TestIntrospect:
+    @pytest.mark.asyncio
+    async def test_active_token(self):
+        settings = _make_settings()
+        token = create_signed_token({
+            "type": "access",
+            "user_id": "user-123",
+            "client_id": "abc",
+            "scope": "openid",
+        }, SECRET, ACCESS_TOKEN_TTL)
+        client = _mock_client()
+
+        controller = OAuth2Controller(owner=MagicMock())
+        request = MagicMock()
+        request.form = AsyncMock(return_value={
+            "token": token,
+            "client_id": "abc",
+            "client_secret": "secret",
+        })
+        db_session = AsyncMock()
+
+        with patch("skrift.controllers.oauth2.get_settings", return_value=settings), \
+             patch("skrift.controllers.oauth2.oauth2_service") as mock_svc:
+            mock_svc.get_client_by_client_id = AsyncMock(return_value=client)
+            mock_svc.is_token_revoked = AsyncMock(return_value=False)
+            result = await OAuth2Controller.introspect.fn(controller, request, db_session)
+
+        assert result.status_code == 200
+        body = result.content
+        assert body["active"] is True
+        assert body["sub"] == "user-123"
+        assert body["scope"] == "openid"
+
+    @pytest.mark.asyncio
+    async def test_inactive_token(self):
+        settings = _make_settings()
+        client = _mock_client()
+
+        controller = OAuth2Controller(owner=MagicMock())
+        request = MagicMock()
+        request.form = AsyncMock(return_value={
+            "token": "bogus-token",
+            "client_id": "abc",
+            "client_secret": "secret",
+        })
+        db_session = AsyncMock()
+
+        with patch("skrift.controllers.oauth2.get_settings", return_value=settings), \
+             patch("skrift.controllers.oauth2.oauth2_service") as mock_svc:
+            mock_svc.get_client_by_client_id = AsyncMock(return_value=client)
+            mock_svc.is_token_revoked = AsyncMock(return_value=False)
+            result = await OAuth2Controller.introspect.fn(controller, request, db_session)
+
+        assert result.status_code == 200
+        assert result.content["active"] is False
+
+    @pytest.mark.asyncio
+    async def test_requires_client_auth(self):
+        controller = OAuth2Controller(owner=MagicMock())
+        request = MagicMock()
+        request.form = AsyncMock(return_value={
+            "token": "some-token",
+            "client_id": "",
+            "client_secret": "",
+        })
+        db_session = AsyncMock()
+
+        result = await OAuth2Controller.introspect.fn(controller, request, db_session)
+        assert result.status_code == 400
+
+    @pytest.mark.asyncio
+    async def test_wrong_client_secret(self):
+        settings = _make_settings()
+        client = _mock_client()
+
+        controller = OAuth2Controller(owner=MagicMock())
+        request = MagicMock()
+        request.form = AsyncMock(return_value={
+            "token": "some-token",
+            "client_id": "abc",
+            "client_secret": "wrong-secret",
+        })
+        db_session = AsyncMock()
+
+        with patch("skrift.controllers.oauth2.get_settings", return_value=settings), \
+             patch("skrift.controllers.oauth2.oauth2_service") as mock_svc:
+            mock_svc.get_client_by_client_id = AsyncMock(return_value=client)
+            result = await OAuth2Controller.introspect.fn(controller, request, db_session)
+
+        assert result.status_code == 400
+        assert result.content["error"] == "invalid_client"
+
+
+class TestScopeRegistry:
+    def test_builtin_scopes_registered(self):
+        assert "openid" in SCOPE_DEFINITIONS
+        assert "profile" in SCOPE_DEFINITIONS
+        assert "email" in SCOPE_DEFINITIONS
+
+    def test_openid_scope_claims(self):
+        defn = SCOPE_DEFINITIONS["openid"]
+        assert defn.claims == ["sub"]
+
+    def test_profile_scope_claims(self):
+        defn = SCOPE_DEFINITIONS["profile"]
+        assert "name" in defn.claims
+        assert "picture" in defn.claims
+
+    def test_email_scope_claims(self):
+        defn = SCOPE_DEFINITIONS["email"]
+        assert "email" in defn.claims
+
+    def test_register_custom_scope(self):
+        register_scope("custom", "Custom scope", claims=["custom_claim"])
+        defn = get_scope_definition("custom")
+        assert defn is not None
+        assert defn.name == "custom"
+        assert defn.claims == ["custom_claim"]
+        # Cleanup
+        del SCOPE_DEFINITIONS["custom"]
+
+    def test_get_unknown_scope(self):
+        assert get_scope_definition("nonexistent") is None
+
+
+class TestDiscovery:
+    @pytest.mark.asyncio
+    async def test_discovery_when_enabled(self):
+        from skrift.controllers.sitemap import SitemapController
+
+        settings = MagicMock()
+        settings.oauth2_enabled = True
+
+        controller = SitemapController(owner=MagicMock())
+        request = MagicMock()
+        request.base_url = "http://localhost:8000/"
+
+        with patch("skrift.config.get_settings", return_value=settings):
+            result = await SitemapController.openid_configuration.fn(controller, request)
+
+        assert result.status_code == 200
+        body = result.content
+        assert body["issuer"] == "http://localhost:8000"
+        assert "/oauth/authorize" in body["authorization_endpoint"]
+        assert "/oauth/token" in body["token_endpoint"]
+        assert "/oauth/revoke" in body["revocation_endpoint"]
+        assert "/oauth/introspect" in body["introspection_endpoint"]
+        assert "S256" in body["code_challenge_methods_supported"]
+
+    @pytest.mark.asyncio
+    async def test_discovery_when_disabled(self):
+        from litestar.exceptions import NotFoundException
+        from skrift.controllers.sitemap import SitemapController
+
+        settings = MagicMock()
+        settings.oauth2_enabled = False
+
+        controller = SitemapController(owner=MagicMock())
+        request = MagicMock()
+
+        with patch("skrift.config.get_settings", return_value=settings), \
+             pytest.raises(NotFoundException):
+            await SitemapController.openid_configuration.fn(controller, request)


### PR DESCRIPTION
## Summary
Complete OAuth2 Authorization Server with database-backed client management, token revocation, introspection, scope enforcement, and OIDC discovery.

## Changes

### New Features
- Database-backed OAuth2 client management (replaces static YAML config)
- Admin UI for OAuth2 clients at `/admin/oauth-clients` (CRUD + secret regeneration)
- OAuth2 scope registry (`skrift/auth/scopes.py`) with built-in `openid`, `profile`, `email` scopes
- Token revocation endpoint `POST /oauth/revoke` (RFC 7009)
- Token introspection endpoint `POST /oauth/introspect` (RFC 7662)
- OIDC Discovery at `GET /.well-known/openid-configuration`
- Scope-based claim filtering on `/oauth/userinfo`
- `jti` (unique token ID) on all tokens for revocation tracking
- Refresh token rotation with automatic old-token revocation

### Improvements
- Raise immediately on duplicate controller registration
- Consent screen shows client display name and scope descriptions
- `manage-oauth-clients` permission added to admin role
- Updated skills: skrift-oauth2, skrift-auth, skrift
- New reference doc: `docs/reference/oauth2-server.md`

### Breaking Changes
- `OAuth2ClientConfig` and `OAuth2Config` removed from `skrift/config.py`
- `oauth2.clients` YAML config replaced with `oauth2_enabled: true` boolean
- Clients must be created via admin UI (database) instead of YAML

## Release version
`0.1.0a67` -> `0.1.0a68`