### PR TITLE
Release v0.1.0a72 — Inline OAuth2 client secret with copy button

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "skrift"
-version = "0.1.0a71"
+version = "0.1.0a72"
 description = "A lightweight async Python CMS for crafting modern websites"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/skrift/admin/oauth2_clients.py
+++ b/skrift/admin/oauth2_clients.py
@@ -89,12 +89,9 @@ class OAuth2ClientAdminController(Controller):
             db_session, display_name, redirect_uris, allowed_scopes
         )
 
-        flash_success(
-            request,
-            f"Client created. Client ID: {client.client_id} — Secret: {client.client_secret} "
-            f"(save this now, it won't be shown again in full)"
-        )
-        return Redirect(path="/admin/oauth-clients")
+        request.session["new_secret"] = client.client_secret
+        flash_success(request, f"Client '{display_name}' created")
+        return Redirect(path=f"/admin/oauth-clients/{client.id}/edit")
 
     @get(
         "/oauth-clients/{client_db_id:uuid}/edit",
@@ -113,6 +110,7 @@ class OAuth2ClientAdminController(Controller):
             flash_error(request, "Client not found")
             return Redirect(path="/admin/oauth-clients")
 
+        new_secret = request.session.pop("new_secret", None)
         flash_messages = get_flash_messages(request)
         return TemplateResponse(
             "admin/oauth2/edit.html",
@@ -120,6 +118,7 @@ class OAuth2ClientAdminController(Controller):
                 "flash_messages": flash_messages,
                 "client": client,
                 "available_scopes": SCOPE_DEFINITIONS,
+                "new_secret": new_secret,
                 **ctx,
             },
         )
@@ -191,8 +190,6 @@ class OAuth2ClientAdminController(Controller):
             return Redirect(path="/admin/oauth-clients")
 
         new_secret = await oauth2_service.regenerate_client_secret(db_session, client)
-        flash_success(
-            request,
-            f"New secret for '{client.display_name}': {new_secret} (save this now)"
-        )
+        request.session["new_secret"] = new_secret
+        flash_success(request, f"Secret regenerated for '{client.display_name}'")
         return Redirect(path=f"/admin/oauth-clients/{client_db_id}/edit")

--- a/skrift/templates/admin/oauth2/edit.html
+++ b/skrift/templates/admin/oauth2/edit.html
@@ -8,15 +8,58 @@
     <p>{{ "Update client settings" if client else "Register a new OAuth2 client application" }}</p>
 </hgroup>
 
+{% if new_secret %}
+<style nonce="{{ csp_nonce() }}">
+.sk-secret-reveal {
+    margin-bottom: 1.5rem;
+    padding: 1rem;
+    background: #fff8e1;
+    border: 1px solid #ffe082;
+    border-radius: 0.5rem;
+}
+.sk-secret-reveal p { margin: 0 0 0.5rem; }
+.sk-secret-row {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+.sk-secret-masked {
+    font-size: 0.95rem;
+    padding: 0.25rem 0.5rem;
+    background: var(--sk-color-bg-subtle, #f8f9fa);
+    border-radius: 0.25rem;
+}
+</style>
+<div class="sk-secret-reveal">
+    <p><strong>Client Secret</strong> — save this now, it won't be shown again</p>
+    <div class="sk-secret-row">
+        <code class="sk-secret-masked">{{ new_secret[:8] }}••••••••••••</code>
+        <span hidden id="sk-secret-full">{{ new_secret }}</span>
+        <button type="button" class="sk-btn-outline sk-btn-small" onclick="copyValue(this, document.getElementById('sk-secret-full').textContent)">Copy</button>
+    </div>
+</div>
+{% endif %}
+
 {% if client %}
 <div style="margin-bottom: 1.5rem; padding: 1rem; background: var(--sk-color-bg-subtle, #f8f9fa); border-radius: 0.5rem;">
-    <p><strong>Client ID:</strong> <code>{{ client.client_id }}</code></p>
+    <p><strong>Client ID:</strong> <code>{{ client.client_id }}</code>
+        <button type="button" class="sk-btn-outline sk-btn-small" onclick="copyValue(this, '{{ client.client_id }}')">Copy</button>
+    </p>
     <p><strong>Client Secret:</strong> <code>{{ client.client_secret[:8] }}••••••••</code></p>
     <form method="post" action="/admin/oauth-clients/{{ client.id }}/regenerate-secret" style="display: inline;">
         {{ csrf_field() }}
         <button type="submit" class="sk-btn-outline sk-btn-small" onclick="return confirm('Regenerate secret? The old secret will stop working immediately.')">Regenerate Secret</button>
     </form>
 </div>
+<script nonce="{{ csp_nonce() }}">
+function copyValue(btn, text) {
+    navigator.clipboard.writeText(text).then(function() {
+        var orig = btn.textContent;
+        btn.textContent = 'Copied!';
+        setTimeout(function() { btn.textContent = orig; }, 2000);
+    });
+}
+</script>
 {% endif %}
 
 <form method="post" action="/admin/oauth-clients/{{ client.id ~ '/edit' if client else 'new' }}">

--- a/uv.lock
+++ b/uv.lock
@@ -1672,7 +1672,7 @@ wheels = [
 
 [[package]]
 name = "skrift"
-version = "0.1.0a64"
+version = "0.1.0a71"
 source = { editable = "." }
 dependencies = [
     { name = "advanced-alchemy" },


### PR DESCRIPTION
## Summary
Show OAuth2 client secrets inline on the edit page with a copy-to-clipboard button instead of in an auto-dismissing flash message.

## Changes

### Improvements
- OAuth2 client secret is now shown inline in an amber highlight box on the edit page after creation or regeneration
- Secret is partially masked (first 8 chars visible) with a Copy button that copies the full value
- Copy button also added to Client ID for convenience
- Secret box disappears on page reload (session-based, one-time display)
- Flash messages now show simple success text without the secret

## Release version
`0.1.0a71` -> `0.1.0a72`