### PR TITLE
Release v0.1.0a85 — Fix CSP style-src nonce replacement

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "skrift"
-version = "0.1.0a84"
+version = "0.1.0a85"
 description = "A lightweight async Python CMS for crafting modern websites"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/skrift/middleware/security.py
+++ b/skrift/middleware/security.py
@@ -4,9 +4,9 @@ Injects security response headers (CSP, HSTS, X-Frame-Options, etc.)
 into every HTTP response. Headers already set by a route handler are
 not overwritten, allowing per-route overrides.
 
-When csp_nonce is enabled, 'unsafe-inline' in the style-src directive
-is replaced with a per-request nonce value, and the nonce is appended
-to the script-src directive to allow nonced inline scripts.
+When csp_nonce is enabled, the nonce is appended to the script-src
+directive to allow nonced inline scripts. style-src is left unchanged
+because CSP nonces do not cover inline style attributes.
 """
 
 import contextvars
@@ -18,7 +18,6 @@ from litestar.types import ASGIApp, Receive, Scope, Send
 # ContextVar for template access to the current request's CSP nonce
 csp_nonce_var: contextvars.ContextVar[str] = contextvars.ContextVar("csp_nonce")
 
-_STYLE_SRC_UNSAFE_INLINE = re.compile(r"(style-src\s[^;]*)'unsafe-inline'")
 _SCRIPT_SRC = re.compile(r"(script-src\s)([^;]*)")
 
 
@@ -30,7 +29,7 @@ class SecurityHeadersMiddleware:
         headers: Pre-encoded header pairs as list of (name_bytes, value_bytes).
             Should NOT include CSP (CSP is handled separately via csp_value).
         csp_value: The raw CSP header string (or None to disable CSP).
-        csp_nonce: Whether to inject a nonce into style-src and script-src.
+        csp_nonce: Whether to inject a nonce into script-src.
         debug: Whether the application is running in debug mode.
     """
 
@@ -70,11 +69,8 @@ class SecurityHeadersMiddleware:
             csp_header: tuple[bytes, bytes] | None = None
             if self.csp_value:
                 if nonce:
-                    csp_str = _STYLE_SRC_UNSAFE_INLINE.sub(
-                        rf"\1'nonce-{nonce}'", self.csp_value
-                    )
                     csp_str = _SCRIPT_SRC.sub(
-                        rf"\1\2 'nonce-{nonce}'", csp_str
+                        rf"\1\2 'nonce-{nonce}'", self.csp_value
                     )
                 else:
                     csp_str = self.csp_value

--- a/tests/test_security_headers.py
+++ b/tests/test_security_headers.py
@@ -296,8 +296,8 @@ class TestCSPNonce:
         return send
 
     @pytest.mark.asyncio
-    async def test_csp_nonce_replaces_unsafe_inline(self, captured_messages):
-        """When csp_nonce=True, 'unsafe-inline' in style-src is replaced with nonce."""
+    async def test_csp_nonce_preserves_style_src_unsafe_inline(self, captured_messages):
+        """When csp_nonce=True, 'unsafe-inline' in style-src is preserved (nonces don't cover style attributes)."""
         csp = "default-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self'"
 
         async def app(scope, receive, send):
@@ -318,10 +318,10 @@ class TestCSPNonce:
         response_start = captured_messages[0]
         header_dict = dict(response_start["headers"])
         csp_header = header_dict[b"content-security-policy"].decode()
-        assert "'unsafe-inline'" not in csp_header
+        # style-src should keep 'unsafe-inline' untouched
+        assert "style-src 'self' 'unsafe-inline'" in csp_header
+        # script-src should have the nonce appended
         assert "'nonce-" in csp_header
-        # style-src should have the nonce
-        assert "style-src 'self' 'nonce-" in csp_header
 
     @pytest.mark.asyncio
     async def test_csp_nonce_false_keeps_unsafe_inline(self, captured_messages):

--- a/uv.lock
+++ b/uv.lock
@@ -1709,7 +1709,7 @@ wheels = [
 
 [[package]]
 name = "skrift"
-version = "0.1.0a82"
+version = "0.1.0a84"
 source = { editable = "." }
 dependencies = [
     { name = "advanced-alchemy" },


### PR DESCRIPTION
## Summary
Fix CSP nonce replacement that was blocking inline `style=""` attributes on HTML elements.

## Changes

### Bug Fixes
- Stop replacing `'unsafe-inline'` with a nonce in `style-src` — CSP nonces only cover `<style>` elements, not inline style attributes (#114)

## Release version
`0.1.0a84` -> `0.1.0a85`