### PR TITLE
Release v0.1.0a86 — Passkey auth + security-review hardening

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "skrift"
-version = "0.1.0a85"
+version = "0.1.0a86"
 description = "A lightweight async Python CMS for crafting modern websites"
 readme = "README.md"
 requires-python = ">=3.13"


### PR DESCRIPTION
## Summary

Ships the full method-agnostic primary passkey auth flow (sign-in, signup, 2FA, verify, enrollment management, delete UI) along with the multi-phase security-review hardening series (C1–C3, H1–H4, M1–M8, L1–L6) and the seven final pre-launch fixes.

## Changes

### New Features
- **Primary passkey authentication** — end-to-end sign-in, signup, and account-linking flows; delete UI with last-passkey warning; 2FA passkey verify path.
- **Method-agnostic auth** — pluggable primary-method registry (`skrift.auth.methods`) with `is_available`/`availability_note` descriptor support.
- **Second-factor framework** — enrollment, verification, pending-auth state, and registry (`skrift.auth.second_factors`).
- **Email-link auth** — magic-link login method with verification templates.
- **Trusted-proxy middleware** — bundled Cloudflare / CloudFront / Fastly CIDR lists + client-IP resolution.
- **Sliding-window rate-limiting** with Redis backend.
- **Revoked-family token tracking** — OAuth2 refresh-token reuse detection.

### Bug Fixes
- Email signup TOCTOU race replaced with DB-constraint + `IntegrityError` handler (removes enumeration signal).
- `_resolve_origin` no longer falls back to `request.base_url` — host-header spoofing defeated.
- CSRF token reseeded on login finalize.
- Passkey nicknames explicitly `|e`-escaped.
- Introspection response scoped to the issuing client.
- OAuth2 client secrets hashed at rest.
- PKCE now required; refresh-token scope narrowing enforced; authorization code replay prevented.

### Improvements
- Redirect helpers promoted to `skrift.lib.redirects` (no more cross-module underscore imports).
- Config-load-time validation of `auth.methods` / `auth.providers` / second-factor keys.
- `user_handle` documented as a deliberate WebAuthn §5.1.3 throwaway (per-credential, not per-user).
- WebAuthn attestation policy documented.
- Session idle middleware.
- Logout confirmation page.
- Client-IP guards for auth.
- Dead Litestar CSRF plumbing removed.

## Release version
`0.1.0a85` → `0.1.0a86`