### PR TITLE
Release v0.1.0a87

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "skrift"
-version = "0.1.0a86"
+version = "0.1.0a87"
 description = "A lightweight async Python CMS for crafting modern websites"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/skrift/admin/helpers.py
+++ b/skrift/admin/helpers.py
@@ -8,12 +8,12 @@ from uuid import UUID
 
 from litestar import Request
 from litestar.exceptions import NotAuthorizedException
-from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from skrift.auth.services import get_user_permissions
 from skrift.auth.session_keys import SESSION_USER_ID
 from skrift.admin.navigation import build_admin_nav
+from skrift.db.cache import get_by_pk
 from skrift.db.models.user import User
 from skrift.db.services import page_service
 
@@ -92,10 +92,7 @@ async def get_admin_context(request: Request, db_session: AsyncSession) -> dict:
     if not user_id:
         raise NotAuthorizedException("Authentication required")
 
-    result = await db_session.execute(
-        select(User).where(User.id == UUID(user_id))
-    )
-    user = result.scalar_one_or_none()
+    user = await get_by_pk(db_session, User, UUID(user_id))
     if not user:
         raise NotAuthorizedException("Invalid user session")
 

--- a/skrift/alembic.ini
+++ b/skrift/alembic.ini
@@ -22,8 +22,10 @@ revision_environment = false
 # Set to 'true' to allow running in "offline" mode
 # sourceless = false
 
-# Version path separator (os, space, :, ;)
-version_path_separator = space
+# Path separator for version_locations and prepend_sys_path (Alembic 1.16+)
+path_separator = os
+# Version path separator for Alembic 1.14/1.15 compatibility
+version_path_separator = os
 
 # Output encoding used when revision files are written from script.py.mako
 # output_encoding = utf-8

--- a/skrift/asgi.py
+++ b/skrift/asgi.py
@@ -828,6 +828,37 @@ def create_app() -> ASGIApp:
             )
         ]
 
+    # Bot detection middleware — opt-in via bot_detection.enabled. Runs
+    # after rate limiting so blocked requests never invoke detection.
+    bot_detection_middleware = []
+    bot_detection_metrics: list = []
+    bot_state_store = None
+    if settings.bot_detection.enabled:
+        from skrift.bot_detection.factory import (
+            build_bot_state_store,
+            build_initial_metrics,
+        )
+        from skrift.bot_detection.middleware import BotDetectionMiddleware
+        from skrift.bot_detection.setup import setup_honeypot_hooks
+
+        bot_state_store = build_bot_state_store(
+            settings.bot_detection, settings.redis, _redis_client
+        )
+        bot_detection_metrics = build_initial_metrics(settings.bot_detection)
+        # Register honeypot ROBOTS_TXT filter + ROBOTS_TXT_FETCHED
+        # action so the trap rule is injected and fetches are recorded.
+        setup_honeypot_hooks(
+            settings.bot_detection, bot_state_store, settings.secret_key
+        )
+        bot_detection_middleware = [
+            DefineMiddleware(
+                BotDetectionMiddleware,
+                config=settings.bot_detection,
+                store=bot_state_store,
+                metrics=bot_detection_metrics,
+            )
+        ]
+
     # Static files
     from skrift.lib.theme import get_themes_dir
     themes_dir = get_themes_dir()
@@ -878,21 +909,62 @@ def create_app() -> ASGIApp:
         return f"{url}{sep}size={size}"
 
     template_dirs = get_template_directories()
+
+    template_globals = {
+        "site_name": get_cached_site_name,
+        "site_tagline": get_cached_site_tagline,
+        "site_copyright_holder": get_cached_site_copyright_holder,
+        "site_copyright_start_year": get_cached_site_copyright_start_year,
+        "active_theme": get_cached_site_theme,
+        "themes_available": themes_available,
+        "Form": Form,
+        "csrf_field": _csrf_field_ctx,
+        "static_url": static_url,
+        "theme_url": ThemeStaticURL(static_url, get_cached_site_theme),
+        "asset_url": _asset_url,
+        "favicon_url": get_cached_favicon_url,
+    }
+
+    if (
+        settings.bot_detection.enabled
+        and settings.bot_detection.pixel_beacon.enabled
+        and settings.bot_detection.pixel_beacon.inject_pixel
+    ):
+        from skrift.bot_detection.beacon import (
+            make_pixel_token,
+            render_pixel_tag,
+        )
+
+        def _bot_detection_pixel():
+            token, signature = make_pixel_token(settings.secret_key)
+            return render_pixel_tag(
+                token,
+                signature,
+                css_beacon=settings.bot_detection.pixel_beacon.inject_css_beacon,
+            )
+
+        template_globals["bot_detection_pixel"] = _bot_detection_pixel
+
+    if (
+        settings.bot_detection.enabled
+        and settings.bot_detection.js_challenge.enabled
+    ):
+        from skrift.bot_detection.challenge import (
+            make_challenge_token,
+            render_challenge_tag,
+        )
+        from skrift.middleware.security import csp_nonce_var
+
+        def _bot_detection_challenge():
+            token, signature = make_challenge_token(settings.secret_key)
+            return render_challenge_tag(
+                token, signature, csp_nonce=csp_nonce_var.get("")
+            )
+
+        template_globals["bot_detection_challenge"] = _bot_detection_challenge
+
     engine_callback = build_template_engine_callback(
-        extra_globals={
-            "site_name": get_cached_site_name,
-            "site_tagline": get_cached_site_tagline,
-            "site_copyright_holder": get_cached_site_copyright_holder,
-            "site_copyright_start_year": get_cached_site_copyright_start_year,
-            "active_theme": get_cached_site_theme,
-            "themes_available": themes_available,
-            "Form": Form,
-            "csrf_field": _csrf_field_ctx,
-            "static_url": static_url,
-            "theme_url": ThemeStaticURL(static_url, get_cached_site_theme),
-            "asset_url": _asset_url,
-            "favicon_url": get_cached_favicon_url,
-        },
+        extra_globals=template_globals,
         extra_filters={"sized": _sized_url},
     )
     template_config = create_template_config(template_dirs, engine_callback)
@@ -927,6 +999,27 @@ def create_app() -> ASGIApp:
     webhook_handlers: list = []
     if settings.notifications.webhook_secret:
         webhook_handlers.append(NotificationsWebhookController)
+
+    # Bot detection controller — pixel + CSS beacons. Only registered
+    # when the component is enabled.
+    bot_detection_handlers: list = []
+    if settings.bot_detection.enabled:
+        from skrift.bot_detection.controllers import BotDetectionController
+
+        bot_detection_handlers.append(BotDetectionController)
+
+        # Honeypot trap — must be a real route handler so Litestar's
+        # router actually delivers requests to us. Application-level
+        # middleware does not run on unmatched routes.
+        if settings.bot_detection.robots_honeypot.enabled and bot_state_store is not None:
+            from skrift.bot_detection.trap_controller import build_trap_controller
+
+            bot_detection_handlers.append(
+                build_trap_controller(
+                    settings.bot_detection.robots_honeypot.trap_path,
+                    bot_state_store,
+                )
+            )
 
     # Notification backend setup
     if settings.notifications.backend:
@@ -972,6 +1065,14 @@ def create_app() -> ASGIApp:
             except ImportError:
                 logger.debug("pywebpush not installed, push notifications disabled")
 
+        # Apply the BOT_METRICS filter now that all hook handlers from
+        # user-loaded modules are registered. Mutates the list passed to
+        # the middleware in place.
+        if settings.bot_detection.enabled:
+            from skrift.bot_detection.factory import apply_metrics_filter
+
+            await apply_metrics_filter(bot_detection_metrics, settings.bot_detection)
+
         # Ensure local storage directories exist
         for store_cfg in settings.storage.stores.values():
             if store_cfg.backend == "local":
@@ -1006,9 +1107,9 @@ def create_app() -> ASGIApp:
     app = Litestar(
         on_startup=[on_startup],
         on_shutdown=[on_shutdown],
-        route_handlers=[NotificationsController, SitemapController, *oauth2_handlers, *api_auth_handlers, *webhook_handlers, *controllers],
+        route_handlers=[NotificationsController, SitemapController, *oauth2_handlers, *api_auth_handlers, *webhook_handlers, *bot_detection_handlers, *controllers],
         plugins=[SQLAlchemyPlugin(config=db_config)],
-        middleware=[DefineMiddleware(SessionCleanupMiddleware), *client_ip_middleware, *security_middleware, *rate_limit_middleware, session_config.middleware, *session_idle_middleware, *user_middleware],
+        middleware=[DefineMiddleware(SessionCleanupMiddleware), *client_ip_middleware, *security_middleware, *rate_limit_middleware, *bot_detection_middleware, session_config.middleware, *session_idle_middleware, *user_middleware],
         template_config=template_config,
         compression_config=CompressionConfig(backend="gzip", exclude="/notifications/stream", compression_facade=SafeGzipCompression),
         exception_handlers=EXCEPTION_HANDLERS,
@@ -1018,6 +1119,8 @@ def create_app() -> ASGIApp:
     app.state.storage_manager = storage_manager
     app.state.trusted_proxy_manager = trusted_proxy_manager
     app.state.email_backend = email_backend
+    if bot_state_store is not None:
+        app.state.bot_detection_store = bot_state_store
 
     # Install the shared failed-auth limiter on app.state so the notification
     # webhook uses the Redis-backed counter when configured.

--- a/skrift/bot_detection/__init__.py
+++ b/skrift/bot_detection/__init__.py
@@ -1,0 +1,55 @@
+"""Pluggable bot / scraper detection for Skrift.
+
+Configurable per-metric detection that attaches a structured
+verdict + per-signal evidence to ``scope["state"]["bot_detection"]``.
+End users either trust the rolled-up verdict or read raw signals to
+build their own decision logic. Route guards wrap both paths so a
+handler can be gated on the verdict, on specific signals, or on a
+mix.
+
+Public surface::
+
+    from skrift.bot_detection import (
+        BotDetectionConfig,
+        BotDetectionResult,
+        BotGuard,
+        MetricResult,
+        Signal,
+    )
+
+Hook constants are re-exported from :mod:`skrift.bot_detection.hooks`.
+"""
+
+from __future__ import annotations
+
+from skrift.bot_detection.config import BotDetectionConfig
+from skrift.bot_detection.guards import BotGuard
+from skrift.bot_detection.hooks import (
+    BOT_CHALLENGE_PASSED,
+    BOT_DETECTED,
+    BOT_DETECTION_RESULT,
+    BOT_METRICS,
+    BOT_PIXEL_LOADED,
+    BOT_TRAP_HIT,
+)
+from skrift.bot_detection.metrics.base import BotMetric
+from skrift.bot_detection.types import (
+    BotDetectionResult,
+    MetricResult,
+    Signal,
+)
+
+__all__ = [
+    "BOT_CHALLENGE_PASSED",
+    "BOT_DETECTED",
+    "BOT_DETECTION_RESULT",
+    "BOT_METRICS",
+    "BOT_PIXEL_LOADED",
+    "BOT_TRAP_HIT",
+    "BotDetectionConfig",
+    "BotDetectionResult",
+    "BotGuard",
+    "BotMetric",
+    "MetricResult",
+    "Signal",
+]

--- a/skrift/bot_detection/beacon.py
+++ b/skrift/bot_detection/beacon.py
@@ -1,0 +1,76 @@
+"""Pixel beacon helpers — token signing and HTML snippet rendering.
+
+The pixel URL embeds a short signed token so an attacker cannot
+hand-craft pixel hits for arbitrary IPs without having seen a
+genuine HTML response. Beyond that, the token is mostly cache-busting
+— each rendered page gets a fresh URL so CDN caches do not hide the
+miss when the pixel never loads.
+
+State lives in the cross-request store under
+:data:`PIXEL_LOADED_NS` keyed by client IP. A successful pixel hit
+sets the key with TTL :attr:`PixelBeaconConfig.cache_ttl`; the metric
+reads it on subsequent requests.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import secrets
+
+from markupsafe import Markup
+
+PIXEL_LOADED_NS = "pixel_loaded"
+TOKEN_BYTES = 12  # ~16 base64-url chars
+
+
+def make_pixel_token(secret: str) -> tuple[str, str]:
+    """Return ``(token, signature)`` — the parts go in the pixel URL.
+
+    The token is random, the signature is HMAC-SHA256(secret, token)
+    truncated. Both halves are url-safe base64 without padding.
+    """
+    token = base64.urlsafe_b64encode(
+        secrets.token_bytes(TOKEN_BYTES)
+    ).rstrip(b"=").decode("ascii")
+    signature = _sign(secret, token)
+    return token, signature
+
+
+def verify_pixel_token(secret: str, token: str, signature: str) -> bool:
+    """Constant-time check that ``signature`` matches ``token``."""
+    if not token or not signature:
+        return False
+    expected = _sign(secret, token)
+    return hmac.compare_digest(expected, signature)
+
+
+def _sign(secret: str, token: str) -> str:
+    digest = hmac.new(
+        secret.encode("utf-8"), token.encode("utf-8"), hashlib.sha256
+    ).digest()
+    return base64.urlsafe_b64encode(digest)[:16].decode("ascii")
+
+
+def render_pixel_tag(
+    token: str, signature: str, *, css_beacon: bool = False
+) -> Markup:
+    """Render the HTML for the pixel beacon, optionally with a CSS one too.
+
+    Output is marked safe — callers embed via ``{{ bot_detection_pixel() }}``
+    in their base template.
+    """
+    pixel = (
+        f'<img src="/_bot/p.gif?t={token}&s={signature}" '
+        'width="1" height="1" alt="" aria-hidden="true" '
+        'style="position:absolute;left:-9999px;width:1px;height:1px;">'
+    )
+    if not css_beacon:
+        return Markup(pixel)
+    css = (
+        f'<span aria-hidden="true" '
+        f'style="background-image:url(/_bot/c.gif?t={token}&s={signature});'
+        'position:absolute;left:-9999px;width:1px;height:1px;"></span>'
+    )
+    return Markup(pixel + css)

--- a/skrift/bot_detection/challenge.py
+++ b/skrift/bot_detection/challenge.py
@@ -1,0 +1,106 @@
+"""JS challenge — token signing, indicator scoring, render helper.
+
+Every rendered HTML page that calls ``bot_detection_challenge()``
+embeds a signed challenge token. The page's bundled
+``challenge.js`` collects automation indicators in the browser and
+posts them to ``/_bot/verify`` with the token. The server verifies
+the token, applies :func:`evaluate_indicators` to derive a pass/fail
+verdict, and writes the result to the cross-request store.
+
+Token signing reuses the same HMAC-SHA256 pattern as the pixel
+beacon — different namespace so a pixel token cannot be replayed at
+the verify endpoint.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import secrets
+from dataclasses import dataclass
+from typing import Any
+
+from markupsafe import Markup
+
+from skrift.bot_detection.config import JSChallengeConfig
+
+JS_CHALLENGE_NS = "js_challenge"
+TOKEN_BYTES = 12
+
+
+def make_challenge_token(secret: str) -> tuple[str, str]:
+    """Return ``(token, signature)`` to embed in the page."""
+    token = base64.urlsafe_b64encode(
+        secrets.token_bytes(TOKEN_BYTES)
+    ).rstrip(b"=").decode("ascii")
+    return token, _sign(secret, token)
+
+
+def verify_challenge_token(secret: str, token: str, signature: str) -> bool:
+    """Constant-time check of the challenge signature."""
+    if not token or not signature:
+        return False
+    return hmac.compare_digest(_sign(secret, token), signature)
+
+
+def _sign(secret: str, token: str) -> str:
+    digest = hmac.new(
+        secret.encode("utf-8"),
+        f"js-challenge-{token}".encode("utf-8"),
+        hashlib.sha256,
+    ).digest()
+    return base64.urlsafe_b64encode(digest)[:16].decode("ascii")
+
+
+@dataclass(frozen=True)
+class ChallengeVerdict:
+    """Verdict + reason from evaluating browser indicators."""
+
+    passed: bool
+    reason: str
+
+
+def evaluate_indicators(
+    indicators: dict[str, Any], user_agent: str | None
+) -> ChallengeVerdict:
+    """Score the indicator payload reported by the browser.
+
+    Any one of these explicit fail indicators marks the challenge as
+    failed:
+
+    - ``navigator.webdriver === true`` (Puppeteer / Playwright /
+      Selenium default)
+    - canvas API unavailable or threw
+    - claims to be Chrome / Edge but ``window.chrome`` is missing
+
+    Otherwise the challenge passes.
+    """
+    if indicators.get("webdriver") is True:
+        return ChallengeVerdict(False, "navigator.webdriver = true")
+
+    canvas = indicators.get("canvas", 0)
+    if not isinstance(canvas, int) or canvas <= 0:
+        return ChallengeVerdict(False, "canvas API unavailable")
+
+    ua = (user_agent or "").lower()
+    is_chromium = "chrome/" in ua or "edg/" in ua
+    if is_chromium and indicators.get("chrome") is not True:
+        return ChallengeVerdict(False, "Chromium UA without window.chrome")
+
+    return ChallengeVerdict(True, "challenge passed")
+
+
+def render_challenge_tag(
+    token: str, signature: str, *, csp_nonce: str = ""
+) -> Markup:
+    """Render the ``<script>`` tag that loads challenge.js with token data.
+
+    Caller passes the per-request CSP nonce so the script is allowed
+    under the strict-script-src CSP policy.
+    """
+    nonce_attr = f' nonce="{csp_nonce}"' if csp_nonce else ""
+    return Markup(
+        f'<script src="/static/bot_detection/challenge.js"{nonce_attr} '
+        f'data-token="{token}" data-signature="{signature}" defer></script>'
+    )

--- a/skrift/bot_detection/config.py
+++ b/skrift/bot_detection/config.py
@@ -1,0 +1,91 @@
+"""Pydantic configuration for the bot detection component.
+
+Top-level ``BotDetectionConfig`` aggregates one sub-config per metric
+plus a few shared knobs. Each metric sub-config inherits from
+:class:`MetricBaseConfig` and adds its own tunables. Layout mirrors
+:class:`skrift.config.RateLimitConfig` so the wiring in
+``skrift/config.py:get_settings`` and ``skrift/asgi.py`` looks the
+same.
+
+Phase 1 wires the top-level config and the per-metric stubs. Later
+phases populate the per-metric tunables and connect the metrics
+themselves.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel
+
+
+class MetricBaseConfig(BaseModel):
+    """Common shape every metric sub-config inherits."""
+
+    enabled: bool = True
+
+
+class HeadlessUAConfig(MetricBaseConfig):
+    """User-Agent string inspection (phase 2)."""
+
+    patterns: list[str] = [
+        "HeadlessChrome",
+        "PhantomJS",
+        "Puppeteer",
+        "Playwright",
+        "Selenium",
+    ]
+
+
+class HeaderCoherenceConfig(MetricBaseConfig):
+    """Header coherence check against the claimed UA (phase 2)."""
+
+    require_sec_fetch: bool = True
+    require_accept_language: bool = True
+
+
+class DirectRequestConfig(MetricBaseConfig):
+    """Detect requests with no navigation context (phase 2)."""
+
+    pass
+
+
+class PixelBeaconConfig(MetricBaseConfig):
+    """1x1 pixel beacon to separate HTML-only fetchers from renderers (phase 4)."""
+
+    inject_pixel: bool = True
+    inject_css_beacon: bool = True
+    cache_ttl: int = 60
+
+
+class JSChallengeConfig(MetricBaseConfig):
+    """JS-side challenge for headless detection (phase 5). Disabled by default."""
+
+    enabled: bool = False
+    block_unverified_after: int = 3
+    challenge_ttl: int = 3600
+
+
+class RobotsHoneypotConfig(MetricBaseConfig):
+    """robots.txt + trap-link honeypot (phase 3)."""
+
+    trap_path: str = "/private-area"
+    rotate_token_days: int = 7
+    log_robots_fetches: bool = True
+
+
+class BotDetectionConfig(BaseModel):
+    """Top-level configuration for the bot detection component."""
+
+    enabled: bool = False
+    cache_backend: Literal["redis", "memory"] = "redis"
+    skip_paths: list[str] = ["/static/", "/health", "/_bot/"]
+    legitimate_bot_uas: list[str] = ["Googlebot", "Bingbot", "Slackbot", "Twitterbot"]
+    on_unknown: Literal["allow", "deny"] = "allow"
+
+    headless_ua: HeadlessUAConfig = HeadlessUAConfig()
+    header_coherence: HeaderCoherenceConfig = HeaderCoherenceConfig()
+    direct_request: DirectRequestConfig = DirectRequestConfig()
+    pixel_beacon: PixelBeaconConfig = PixelBeaconConfig()
+    js_challenge: JSChallengeConfig = JSChallengeConfig()
+    robots_honeypot: RobotsHoneypotConfig = RobotsHoneypotConfig()

--- a/skrift/bot_detection/controllers.py
+++ b/skrift/bot_detection/controllers.py
@@ -1,0 +1,167 @@
+"""HTTP endpoints owned by the bot detection component.
+
+Phase 4 ships ``GET /_bot/p.gif`` and ``GET /_bot/c.gif`` (both
+identical 1x1 GIF responses; one is referenced from ``<img>`` and one
+from a CSS ``background-image`` so the metric can compare the two
+beacons). Phase 5 will add ``POST /_bot/verify`` for the JS challenge.
+
+The controller is registered conditionally from ``skrift/asgi.py``
+when ``bot_detection.enabled`` is true.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from litestar import Controller, Request, get, post
+from litestar.response import Response
+
+from skrift.bot_detection.beacon import (
+    PIXEL_LOADED_NS,
+    verify_pixel_token,
+)
+from skrift.bot_detection.challenge import (
+    JS_CHALLENGE_NS,
+    evaluate_indicators,
+    verify_challenge_token,
+)
+from skrift.bot_detection.hooks import BOT_CHALLENGE_PASSED, BOT_PIXEL_LOADED
+from skrift.lib.client_ip import get_client_ip
+from skrift.lib.hooks import hooks
+
+logger = logging.getLogger(__name__)
+
+# Smallest valid GIF — 43 bytes, 1x1 transparent.
+_PIXEL_BYTES = (
+    b"GIF89a\x01\x00\x01\x00\x80\x00\x00\xff\xff\xff\x00\x00\x00!\xf9"
+    b"\x04\x01\x00\x00\x00\x00,\x00\x00\x00\x00\x01\x00\x01\x00\x00"
+    b"\x02\x02D\x01\x00;"
+)
+
+
+class BotDetectionController(Controller):
+    """Pixel beacon endpoints for bot detection."""
+
+    path = "/_bot"
+
+    @get("/p.gif")
+    async def pixel(self, request: Request, t: str = "", s: str = "") -> Response:
+        """Image-tag pixel beacon — marks the IP as 'rendered HTML'."""
+        await self._record_load(request, t, s, source="pixel")
+        return _gif_response()
+
+    @get("/c.gif")
+    async def css_beacon(
+        self, request: Request, t: str = "", s: str = ""
+    ) -> Response:
+        """CSS-loaded beacon — same payload, separate fetch path.
+
+        Catches scrapers that load ``<img>`` tags but skip CSS, or
+        vice versa. The metric will treat either one as a positive
+        signal.
+        """
+        await self._record_load(request, t, s, source="css")
+        return _gif_response()
+
+    @post("/verify", status_code=204)
+    async def verify(self, request: Request, data: dict[str, Any]) -> None:
+        """Receive the JS challenge payload, score it, write the result."""
+        from skrift.bot_detection.config import BotDetectionConfig
+        from skrift.config import get_settings
+
+        settings = get_settings()
+        config: BotDetectionConfig = settings.bot_detection
+        if not config.js_challenge.enabled:
+            return
+
+        token = str(data.get("token", ""))
+        signature = str(data.get("signature", ""))
+        if not verify_challenge_token(settings.secret_key, token, signature):
+            logger.debug("bot_detection: challenge token verification failed")
+            return
+
+        store = _get_store(request)
+        if store is None:
+            return
+
+        ua = request.headers.get("user-agent", "")
+        verdict = evaluate_indicators(data, ua)
+        ip = get_client_ip(request.scope)
+        ttl = max(60, config.js_challenge.challenge_ttl)
+
+        record = "pass" if verdict.passed else f"fail:{verdict.reason}"
+        try:
+            await store.set(JS_CHALLENGE_NS, ip, record, ttl=ttl)
+        except Exception:
+            logger.warning(
+                "bot_detection: challenge store update failed", exc_info=True
+            )
+            return
+
+        if verdict.passed:
+            session_id = ""
+            try:
+                session = request.session
+            except Exception:
+                session = None
+            if session:
+                session_id = str(session.get("id", ""))
+            await hooks.do_action(
+                BOT_CHALLENGE_PASSED, request.scope, ip, session_id
+            )
+
+    async def _record_load(
+        self, request: Request, token: str, signature: str, *, source: str
+    ) -> None:
+        """Validate the token and write state to the bot detection store."""
+        from skrift.bot_detection.config import BotDetectionConfig
+        from skrift.config import get_settings
+
+        settings = get_settings()
+        config: BotDetectionConfig = settings.bot_detection
+        if not config.pixel_beacon.enabled:
+            return
+
+        if not verify_pixel_token(settings.secret_key, token, signature):
+            logger.debug("bot_detection: pixel token verification failed")
+            return
+
+        store = _get_store(request)
+        if store is None:
+            return
+
+        ip = get_client_ip(request.scope)
+        try:
+            await store.set(
+                PIXEL_LOADED_NS,
+                ip,
+                source,
+                ttl=max(60, config.pixel_beacon.cache_ttl * 60),
+            )
+        except Exception:
+            logger.warning(
+                "bot_detection: pixel store update failed", exc_info=True
+            )
+            return
+
+        await hooks.do_action(BOT_PIXEL_LOADED, request.scope, ip, token)
+
+
+def _gif_response() -> Response:
+    return Response(
+        content=_PIXEL_BYTES,
+        media_type="image/gif",
+        headers={
+            "Cache-Control": "no-store, no-cache, must-revalidate",
+            "Pragma": "no-cache",
+        },
+    )
+
+
+def _get_store(request: Request):
+    """Resolve the bot state store from app state."""
+    state = getattr(request.app, "state", None)
+    if state is None:
+        return None
+    return getattr(state, "bot_detection_store", None)

--- a/skrift/bot_detection/factory.py
+++ b/skrift/bot_detection/factory.py
@@ -1,0 +1,87 @@
+"""Builders that wire the bot detection middleware into Litestar.
+
+These helpers are called once during app startup
+(``skrift/asgi.py``) when ``settings.bot_detection.enabled`` is
+``True``. They construct the cross-request state store, instantiate
+the built-in metrics, run the
+:data:`~skrift.bot_detection.hooks.BOT_METRICS` startup filter so
+plugins can inject custom metrics, and produce the resolved metric
+list passed into :class:`BotDetectionMiddleware`.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from skrift.bot_detection.config import BotDetectionConfig
+from skrift.bot_detection.hooks import BOT_METRICS
+from skrift.bot_detection.metrics import BUILTIN_METRICS
+from skrift.bot_detection.metrics.base import BotMetric
+from skrift.bot_detection.store import (
+    BotStateStore,
+    InMemoryBotStateStore,
+    RedisBotStateStore,
+)
+from skrift.lib.hooks import hooks
+
+if TYPE_CHECKING:
+    from skrift.config import RedisConfig
+
+logger = logging.getLogger(__name__)
+
+
+def build_bot_state_store(
+    config: BotDetectionConfig,
+    redis_config: RedisConfig,
+    redis_client=None,
+) -> BotStateStore:
+    """Construct the cross-request state store.
+
+    Returns a :class:`RedisBotStateStore` when ``cache_backend`` is
+    ``"redis"`` and a Redis client is available, otherwise falls back
+    to :class:`InMemoryBotStateStore`.
+    """
+    if config.cache_backend == "redis" and redis_client is not None:
+        prefix = redis_config.make_key("skrift", "bot_detection")
+        return RedisBotStateStore(redis_client, prefix=prefix)
+    if config.cache_backend == "redis" and redis_client is None:
+        logger.warning(
+            "bot_detection cache_backend=redis but no Redis client; "
+            "falling back to in-memory store"
+        )
+    return InMemoryBotStateStore()
+
+
+def build_initial_metrics(
+    config: BotDetectionConfig,
+) -> list[BotMetric]:
+    """Instantiate the built-in metrics that are enabled by config.
+
+    Synchronous so it can be called during app construction. The
+    :data:`~skrift.bot_detection.hooks.BOT_METRICS` filter is applied
+    later in :func:`apply_metrics_filter` (during ``on_startup``) when
+    plugin filter handlers are guaranteed to be registered.
+    """
+    metrics: list[BotMetric] = []
+    for metric_cls in BUILTIN_METRICS:
+        instance = metric_cls(config)  # type: ignore[call-arg]
+        if instance.enabled:
+            metrics.append(instance)
+    return metrics
+
+
+async def apply_metrics_filter(
+    metrics: list[BotMetric],
+    config: BotDetectionConfig,
+) -> None:
+    """Run the :data:`BOT_METRICS` filter and update ``metrics`` in place.
+
+    Called from ``on_startup`` after Litestar has finished importing
+    user controllers (which may register filter handlers via the
+    ``@filter`` decorator). Mutates the list passed to the middleware
+    so the new entries take effect on the next request.
+    """
+    filtered = await hooks.apply_filters(BOT_METRICS, list(metrics), config)
+    metrics.clear()
+    metrics.extend(filtered)

--- a/skrift/bot_detection/guards.py
+++ b/skrift/bot_detection/guards.py
@@ -1,0 +1,109 @@
+"""Litestar route guards that read the bot detection result from scope state.
+
+Two modes:
+
+- **Default** — instantiate ``BotGuard()`` with no arguments. Blocks
+  the route when the overall verdict is ``False``. Inconclusive
+  verdicts (``None``) follow ``on_unknown``.
+
+- **Per-signal** — ``BotGuard(require_signals=["headless_ua.puppeteer", ...])``.
+  Each named signal must have ``passed=True``. Missing or inconclusive
+  signals follow ``on_unknown``.
+
+Examples::
+
+    @post("/contact", guards=[BotGuard()])
+    @get("/api", guards=[BotGuard(require_signals=["headless_ua.puppeteer"])])
+    @get("/admin", guards=[BotGuard(require_signals=["js_challenge.passed"], on_unknown="deny")])
+"""
+
+from __future__ import annotations
+
+from typing import Literal, Sequence
+
+from litestar.connection import ASGIConnection
+from litestar.exceptions import PermissionDeniedException
+from litestar.handlers import BaseRouteHandler
+
+from skrift.bot_detection.types import BotDetectionResult
+
+
+class BotGuard:
+    """Block a route when bot detection signals indicate a bot.
+
+    Args:
+        require_signals: Each entry is ``"metric.signal"``. The named
+            signal must exist and have ``passed=True``. Empty (the
+            default) means "trust the overall verdict".
+        on_unknown: What to do when the verdict / signal is ``None``.
+            ``"allow"`` lets the request through; ``"deny"`` blocks.
+            ``None`` (the default) defers to the component-level
+            config setting.
+    """
+
+    def __init__(
+        self,
+        require_signals: Sequence[str] = (),
+        on_unknown: Literal["allow", "deny"] | None = None,
+    ) -> None:
+        self.require_signals = tuple(require_signals)
+        self.on_unknown = on_unknown
+
+    def __call__(
+        self, connection: ASGIConnection, _route_handler: BaseRouteHandler
+    ) -> None:
+        result = self._get_result(connection)
+        if result is None:
+            return  # middleware not active — fail open
+
+        on_unknown = self._resolve_on_unknown(connection)
+
+        if not self.require_signals:
+            if result.verdict is False:
+                raise PermissionDeniedException(detail="Bot detection failed")
+            if result.verdict is None and on_unknown == "deny":
+                raise PermissionDeniedException(
+                    detail="Bot detection inconclusive"
+                )
+            return
+
+        for ref in self.require_signals:
+            metric_name, _, signal_name = ref.partition(".")
+            if not metric_name or not signal_name:
+                raise ValueError(
+                    f"BotGuard.require_signals entry {ref!r} must be "
+                    "'metric.signal'"
+                )
+            metric = result.metrics.get(metric_name)
+            sig = metric.signals.get(signal_name) if metric else None
+            if sig is None or sig.passed is None:
+                if on_unknown == "deny":
+                    raise PermissionDeniedException(
+                        detail=f"Bot signal unavailable: {ref}"
+                    )
+                continue
+            if sig.passed is False:
+                raise PermissionDeniedException(
+                    detail=f"Bot signal failed: {ref}"
+                )
+
+    @staticmethod
+    def _get_result(connection: ASGIConnection) -> BotDetectionResult | None:
+        state = connection.scope.get("state")
+        if not isinstance(state, dict):
+            return None
+        result = state.get("bot_detection")
+        if isinstance(result, BotDetectionResult):
+            return result
+        return None
+
+    def _resolve_on_unknown(self, connection: ASGIConnection) -> str:
+        if self.on_unknown is not None:
+            return self.on_unknown
+        # Defer to config when the guard didn't override.
+        try:
+            from skrift.config import get_settings
+
+            return get_settings().bot_detection.on_unknown
+        except Exception:
+            return "allow"

--- a/skrift/bot_detection/honeypot.py
+++ b/skrift/bot_detection/honeypot.py
@@ -1,0 +1,93 @@
+"""Robots.txt honeypot — rotating-token trap for non-compliant scrapers.
+
+Strategy:
+
+1. ``Disallow: <trap_path>/<token>`` is appended to ``robots.txt`` via
+   the :data:`~skrift.lib.hooks.ROBOTS_TXT` filter. The token rotates
+   weekly so cached crawler maps go stale.
+2. Every fetch of ``robots.txt`` records the client IP via the
+   :data:`~skrift.lib.hooks.ROBOTS_TXT_FETCHED` action. The metric
+   later reads this state to distinguish "read the rules and ignored
+   them" (strongest signal) from "did not even read robots.txt" (still
+   suspicious but lower confidence).
+3. A request that hits any path under ``trap_path/`` is recorded as a
+   trap hit. The :data:`~skrift.bot_detection.hooks.BOT_TRAP_HIT`
+   action fires so audit code can react. The middleware itself returns
+   a 404 to make the trap look like a normal block.
+
+Token rotation uses HMAC-SHA256(secret, "trap-{period}") truncated to
+16 base64 url-safe characters. The secret is the application's
+``settings.secret_key`` so it is unique per deployment. The period is
+``floor(epoch_seconds / (rotate_token_days * 86400))``.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import time
+
+from skrift.bot_detection.config import RobotsHoneypotConfig
+
+ROBOTS_READ_NS = "robots_read"
+TRAP_HIT_NS = "trap_hit"
+
+# Cross-request state lives in the store with a TTL well past the
+# rotation period so the metric still has signal a few weeks after
+# robots.txt was fetched.
+STATE_TTL_SECONDS = 30 * 86400
+
+
+def make_trap_token(secret: str, rotate_token_days: int) -> str:
+    """Generate the current trap token for ``secret`` and rotation period."""
+    period_seconds = max(1, rotate_token_days) * 86400
+    period = int(time.time() // period_seconds)
+    digest = hmac.new(
+        secret.encode("utf-8"),
+        f"bot-detection-trap-{period}".encode("utf-8"),
+        hashlib.sha256,
+    ).digest()
+    return base64.urlsafe_b64encode(digest)[:16].decode("ascii")
+
+
+def trap_url(config: RobotsHoneypotConfig, secret: str) -> str:
+    """Full URL path of the trap, with the current rotating token."""
+    token = make_trap_token(secret, config.rotate_token_days)
+    return f"{config.trap_path.rstrip('/')}/{token}"
+
+
+def is_trap_path(path: str, config: RobotsHoneypotConfig) -> bool:
+    """Return True when ``path`` lies under the configured trap prefix."""
+    prefix = config.trap_path.rstrip("/")
+    if not prefix:
+        return False
+    return path == prefix or path.startswith(prefix + "/")
+
+
+def inject_disallow_rule(content: str, trap_url_value: str) -> str:
+    """Append a ``Disallow:`` rule to robots.txt content.
+
+    Appends to the first ``User-agent: *`` block when present;
+    otherwise prepends a new block. Idempotent: if the rule already
+    exists, returns the content unchanged.
+    """
+    rule = f"Disallow: {trap_url_value}"
+    if rule in content:
+        return content
+
+    lines = content.splitlines()
+    user_agent_idx = None
+    for i, line in enumerate(lines):
+        if line.strip().lower() == "user-agent: *":
+            user_agent_idx = i
+            break
+
+    if user_agent_idx is None:
+        new_block = f"User-agent: *\n{rule}\n\n"
+        return new_block + content
+
+    # Insert the rule directly after the User-agent: * line.
+    lines.insert(user_agent_idx + 1, rule)
+    trailing_newline = "\n" if content.endswith("\n") else ""
+    return "\n".join(lines) + trailing_newline

--- a/skrift/bot_detection/hooks.py
+++ b/skrift/bot_detection/hooks.py
@@ -1,0 +1,45 @@
+"""Hook constants exposed by the bot detection component.
+
+These names are also defined in :mod:`skrift.lib.hooks` (alongside the
+other Skrift hook constants for discoverability). They live here too
+so that anything importing the component does not need to reach into
+``skrift.lib.hooks`` for the names.
+
+Filters
+-------
+``BOT_METRICS`` — startup filter. Receives ``list[BotMetric]`` (the
+built-ins for which ``enabled=True``) and returns the final list to
+run. Plugins prepend / append / replace their own metrics here.
+
+``BOT_DETECTION_RESULT`` — per-request filter. Receives the assembled
+:class:`~skrift.bot_detection.types.BotDetectionResult` after every
+metric has run, before guards see it. Plugins can override the
+verdict, add metrics, or strip signals.
+
+Actions
+-------
+``BOT_DETECTED`` — fires once per request when the overall verdict is
+``False``. Args: ``(scope, result)``. Use it for logging, banning,
+alerting.
+
+``BOT_TRAP_HIT`` — fires when the robots-honeypot trap path is hit.
+Args: ``(scope, ip, ua, token)``.
+
+``BOT_PIXEL_LOADED`` — fires when the pixel beacon is fetched. Args:
+``(scope, ip, request_id)``.
+
+``BOT_CHALLENGE_PASSED`` — fires when the JS challenge succeeds. Args:
+``(scope, ip, session_id)``.
+"""
+
+from __future__ import annotations
+
+# Filters
+BOT_METRICS = "bot_metrics"
+BOT_DETECTION_RESULT = "bot_detection_result"
+
+# Actions
+BOT_DETECTED = "bot_detected"
+BOT_TRAP_HIT = "bot_trap_hit"
+BOT_PIXEL_LOADED = "bot_pixel_loaded"
+BOT_CHALLENGE_PASSED = "bot_challenge_passed"

--- a/skrift/bot_detection/metrics/__init__.py
+++ b/skrift/bot_detection/metrics/__init__.py
@@ -1,0 +1,39 @@
+"""Built-in bot detection metrics.
+
+``BUILTIN_METRICS`` is the ordered list of metric classes the factory
+instantiates at startup. Phase 2 ships the three passive metrics
+(stateless inspection of UA + headers + cookies). Phase 3 adds the
+robots-honeypot metric, phase 4 the pixel beacon, phase 5 the JS
+challenge.
+"""
+
+from __future__ import annotations
+
+from skrift.bot_detection.metrics.base import BotMetric, get_header
+from skrift.bot_detection.metrics.direct_request import DirectRequestMetric
+from skrift.bot_detection.metrics.header_coherence import HeaderCoherenceMetric
+from skrift.bot_detection.metrics.headless_ua import HeadlessUAMetric
+from skrift.bot_detection.metrics.js_challenge import JSChallengeMetric
+from skrift.bot_detection.metrics.pixel_beacon import PixelBeaconMetric
+from skrift.bot_detection.metrics.robots_honeypot import RobotsHoneypotMetric
+
+BUILTIN_METRICS: list[type[BotMetric]] = [
+    HeadlessUAMetric,
+    HeaderCoherenceMetric,
+    DirectRequestMetric,
+    RobotsHoneypotMetric,
+    PixelBeaconMetric,
+    JSChallengeMetric,
+]
+
+__all__ = [
+    "BUILTIN_METRICS",
+    "BotMetric",
+    "DirectRequestMetric",
+    "HeaderCoherenceMetric",
+    "HeadlessUAMetric",
+    "JSChallengeMetric",
+    "PixelBeaconMetric",
+    "RobotsHoneypotMetric",
+    "get_header",
+]

--- a/skrift/bot_detection/metrics/base.py
+++ b/skrift/bot_detection/metrics/base.py
@@ -1,0 +1,54 @@
+"""Base metric protocol and small helpers.
+
+Each metric is a callable that inspects the ASGI scope (and, for
+deferred metrics, prior state stored in :class:`BotStateStore`) and
+returns a :class:`MetricResult`. The middleware runs every enabled
+metric per request and assembles their results into a
+:class:`BotDetectionResult`.
+
+End users — and the existing built-ins — implement metrics by
+subclassing :class:`BotMetric` (or any class that satisfies the
+protocol) and registering them through the ``bot_metrics`` filter or
+by listing them in code.
+"""
+
+from __future__ import annotations
+
+from typing import ClassVar, Protocol, runtime_checkable
+
+from litestar.types import Scope
+
+from skrift.bot_detection.store import BotStateStore
+from skrift.bot_detection.types import MetricResult
+
+
+@runtime_checkable
+class BotMetric(Protocol):
+    """Protocol every bot-detection metric must satisfy.
+
+    Stateless metrics (UA / header inspection) ignore ``store``.
+    Stateful metrics (pixel, JS challenge, honeypot) read prior
+    cross-request state through it.
+    """
+
+    name: ClassVar[str]
+    enabled: bool
+
+    async def check(self, scope: Scope, store: BotStateStore) -> MetricResult:
+        ...
+
+
+def get_header(scope: Scope, name: str) -> str | None:
+    """Return the first matching header value as a decoded string.
+
+    Header names are matched case-insensitively. Returns ``None`` if
+    the header is not present or cannot be decoded.
+    """
+    target = name.lower().encode()
+    for key, value in scope.get("headers", ()):
+        if key.lower() == target:
+            try:
+                return value.decode("latin-1")
+            except (UnicodeDecodeError, AttributeError):
+                return None
+    return None

--- a/skrift/bot_detection/metrics/direct_request.py
+++ b/skrift/bot_detection/metrics/direct_request.py
@@ -1,0 +1,78 @@
+"""Detect direct requests with no navigation context.
+
+Real users generally arrive at non-root URLs by navigation: the
+request carries a ``Referer`` header, an existing session cookie, and
+a ``Sec-Fetch-Site`` value other than ``none``. A request that is
+missing all of these on a deep URL is almost always a curl-style
+fetch.
+
+The metric does not run on root entry-point paths (``/`` and a few
+short variants) because those legitimately have no referrer for
+direct-link traffic.
+"""
+
+from __future__ import annotations
+
+from typing import ClassVar
+
+from litestar.types import Scope
+
+from skrift.bot_detection.config import BotDetectionConfig, DirectRequestConfig
+from skrift.bot_detection.metrics.base import get_header
+from skrift.bot_detection.store import BotStateStore
+from skrift.bot_detection.types import MetricResult, Signal, derive_verdict
+
+_ENTRY_PATHS = frozenset({"/", "/robots.txt", "/sitemap.xml", "/favicon.ico"})
+
+
+class DirectRequestMetric:
+    """Detect requests that arrive without any navigation context."""
+
+    name: ClassVar[str] = "direct_request"
+
+    def __init__(self, config: BotDetectionConfig) -> None:
+        self._config: DirectRequestConfig = config.direct_request
+
+    @property
+    def enabled(self) -> bool:
+        return self._config.enabled
+
+    async def check(
+        self, scope: Scope, store: BotStateStore
+    ) -> MetricResult:
+        path = scope.get("path", "/")
+        is_entry = path in _ENTRY_PATHS
+
+        signals = {
+            "referer": self._referer_signal(scope, is_entry),
+            "session_cookie": self._session_cookie_signal(scope),
+            "sec_fetch_site": self._sec_fetch_site_signal(scope, is_entry),
+        }
+        return MetricResult(self.name, derive_verdict(signals), signals)
+
+    @staticmethod
+    def _referer_signal(scope: Scope, is_entry: bool) -> Signal:
+        referer = get_header(scope, "referer")
+        if referer:
+            return Signal(True)
+        if is_entry:
+            return Signal(None, "no Referer (entry path)")
+        return Signal(False, "no Referer on deep URL")
+
+    @staticmethod
+    def _session_cookie_signal(scope: Scope) -> Signal:
+        cookie = get_header(scope, "cookie") or ""
+        if "session=" in cookie:
+            return Signal(True)
+        return Signal(None, "no session cookie")
+
+    @staticmethod
+    def _sec_fetch_site_signal(scope: Scope, is_entry: bool) -> Signal:
+        value = get_header(scope, "sec-fetch-site")
+        if value is None:
+            return Signal(None, "Sec-Fetch-Site not sent")
+        if value == "none":
+            if is_entry:
+                return Signal(True, "Sec-Fetch-Site: none on entry path")
+            return Signal(False, "Sec-Fetch-Site: none on deep URL")
+        return Signal(True, f"Sec-Fetch-Site: {value}")

--- a/skrift/bot_detection/metrics/header_coherence.py
+++ b/skrift/bot_detection/metrics/header_coherence.py
@@ -1,0 +1,98 @@
+"""Header coherence check — does the request match what the UA claims?
+
+Modern Chromium-based browsers (Chrome 80+, Edge 80+) reliably send
+``Sec-Fetch-*``, ``Sec-CH-UA``, ``Accept-Language`` and
+``Accept-Encoding``. A request whose User-Agent claims to be one of
+those browsers but is missing the headers is almost certainly a
+script — automation libraries and naive scrapers commonly forge the
+UA but omit everything else.
+
+Signals are inconclusive (``None``) when the UA does not claim a
+modern Chromium, since older browsers and non-Chromium clients
+legitimately omit these headers.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import ClassVar
+
+from litestar.types import Scope
+
+from skrift.bot_detection.config import BotDetectionConfig, HeaderCoherenceConfig
+from skrift.bot_detection.metrics.base import get_header
+from skrift.bot_detection.store import BotStateStore
+from skrift.bot_detection.types import MetricResult, Signal, derive_verdict
+
+# Match Chromium-based UAs that are recent enough to send Sec-* headers.
+_CHROMIUM_RE = re.compile(r"\b(?:Chrome|Edg|OPR)/(\d+)\.")
+_CHROMIUM_MIN_VERSION = 80
+
+
+class HeaderCoherenceMetric:
+    """Emit signals comparing request headers against the claimed UA."""
+
+    name: ClassVar[str] = "header_coherence"
+
+    def __init__(self, config: BotDetectionConfig) -> None:
+        self._config: HeaderCoherenceConfig = config.header_coherence
+
+    @property
+    def enabled(self) -> bool:
+        return self._config.enabled
+
+    async def check(
+        self, scope: Scope, store: BotStateStore
+    ) -> MetricResult:
+        ua = get_header(scope, "user-agent") or ""
+        match = _CHROMIUM_RE.search(ua)
+        is_modern_chromium = bool(
+            match and int(match.group(1)) >= _CHROMIUM_MIN_VERSION
+        )
+
+        signals: dict[str, Signal] = {
+            "claims_modern_chromium": Signal(
+                True if is_modern_chromium else None,
+                f"User-Agent: {ua!r}" if ua else "User-Agent missing",
+            )
+        }
+
+        # If the UA does not claim modern Chromium, the rest of the
+        # signals are inconclusive — a Firefox / Safari / curl client
+        # legitimately omits Sec-Fetch-*.
+        outcome = True if is_modern_chromium else None
+
+        if self._config.require_sec_fetch:
+            for header in ("sec-fetch-site", "sec-fetch-mode", "sec-fetch-dest"):
+                signal_key = header.replace("-", "_")
+                signals[signal_key] = self._check_header_present(
+                    scope, header, outcome
+                )
+            signals["sec_ch_ua"] = self._check_header_present(
+                scope, "sec-ch-ua", outcome
+            )
+
+        if self._config.require_accept_language:
+            signals["accept_language"] = self._check_header_present(
+                scope, "accept-language", outcome
+            )
+
+        return MetricResult(self.name, derive_verdict(signals), signals)
+
+    @staticmethod
+    def _check_header_present(
+        scope: Scope, header: str, expected_outcome: bool | None
+    ) -> Signal:
+        """Pass when the header is present.
+
+        When ``expected_outcome`` is ``True`` (we expect this header for
+        the claimed UA) and the header is missing, fail with a useful
+        detail. When ``expected_outcome`` is ``None`` (we have no
+        expectation), report ``None`` regardless of presence.
+        """
+        present = get_header(scope, header) is not None
+        if present:
+            return Signal(True)
+        if expected_outcome is None:
+            return Signal(None)
+        return Signal(False, f"missing {header} header")

--- a/skrift/bot_detection/metrics/headless_ua.py
+++ b/skrift/bot_detection/metrics/headless_ua.py
@@ -1,0 +1,71 @@
+"""Headless / automation framework detection by User-Agent inspection.
+
+Emits one signal per configured pattern. A signal *fails* when the UA
+contains the pattern (case-insensitive) — that is the explicit
+positive indicator of a headless browser. A separate ``ua_present``
+signal fails when the UA header is missing or empty: most legitimate
+clients send one and a missing UA is itself a weak bot indicator.
+
+This metric is cheap and stateless. It is also trivially spoofable —
+treat it as one input among several rather than a hard block.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import ClassVar
+
+from litestar.types import Scope
+
+from skrift.bot_detection.config import BotDetectionConfig, HeadlessUAConfig
+from skrift.bot_detection.metrics.base import get_header
+from skrift.bot_detection.store import BotStateStore
+from skrift.bot_detection.types import MetricResult, Signal, derive_verdict
+
+_CAMEL_CASE_SPLIT = re.compile(r"([a-z])([A-Z])")
+_NON_ALNUM = re.compile(r"[^a-z0-9]+")
+
+
+def _signal_name(pattern: str) -> str:
+    """Stable lowercase slug derived from a pattern name.
+
+    ``HeadlessChrome`` -> ``headless_chrome``, ``PhantomJS`` ->
+    ``phantom_js``, ``Puppeteer`` -> ``puppeteer``.
+    """
+    decamelized = _CAMEL_CASE_SPLIT.sub(r"\1_\2", pattern)
+    return _NON_ALNUM.sub("_", decamelized.lower()).strip("_")
+
+
+class HeadlessUAMetric:
+    """Emit a pass/fail signal per configured headless-browser pattern."""
+
+    name: ClassVar[str] = "headless_ua"
+
+    def __init__(self, config: BotDetectionConfig) -> None:
+        self._config: HeadlessUAConfig = config.headless_ua
+
+    @property
+    def enabled(self) -> bool:
+        return self._config.enabled
+
+    async def check(
+        self, scope: Scope, store: BotStateStore
+    ) -> MetricResult:
+        ua = get_header(scope, "user-agent")
+        signals: dict[str, Signal] = {}
+
+        if ua is None or ua == "":
+            signals["ua_present"] = Signal(False, "User-Agent header is missing")
+        else:
+            signals["ua_present"] = Signal(True)
+            ua_lower = ua.lower()
+            for pattern in self._config.patterns:
+                signal_name = _signal_name(pattern)
+                if pattern.lower() in ua_lower:
+                    signals[signal_name] = Signal(
+                        False, f"User-Agent contains {pattern!r}"
+                    )
+                else:
+                    signals[signal_name] = Signal(True)
+
+        return MetricResult(self.name, derive_verdict(signals), signals)

--- a/skrift/bot_detection/metrics/js_challenge.py
+++ b/skrift/bot_detection/metrics/js_challenge.py
@@ -1,0 +1,59 @@
+"""JS challenge metric — strongest positive signal for browser presence.
+
+Reads the cross-request state written by
+:meth:`BotDetectionController.verify`:
+
+- ``js_challenge:<ip>`` = ``"pass"`` -> the browser passed the
+  automation checks.
+- ``js_challenge:<ip>`` = ``"fail"`` -> the browser explicitly tripped
+  one of the indicator checks (e.g. ``navigator.webdriver``).
+- absent -> no challenge response yet.
+
+Like the pixel beacon, the metric does not accuse on its own when no
+response has been recorded — users may have JS disabled. Sensitive
+routes that *require* a JS challenge pass should opt in via
+``BotGuard(require_signals=["js_challenge.passed"], on_unknown="deny")``.
+"""
+
+from __future__ import annotations
+
+from typing import ClassVar
+
+from litestar.types import Scope
+
+from skrift.bot_detection.challenge import JS_CHALLENGE_NS
+from skrift.bot_detection.config import BotDetectionConfig, JSChallengeConfig
+from skrift.bot_detection.store import BotStateStore
+from skrift.bot_detection.types import MetricResult, Signal, derive_verdict
+from skrift.lib.client_ip import get_client_ip
+
+
+class JSChallengeMetric:
+    """Score visitors based on their JS challenge response."""
+
+    name: ClassVar[str] = "js_challenge"
+
+    def __init__(self, config: BotDetectionConfig) -> None:
+        self._config: JSChallengeConfig = config.js_challenge
+
+    @property
+    def enabled(self) -> bool:
+        return self._config.enabled
+
+    async def check(
+        self, scope: Scope, store: BotStateStore
+    ) -> MetricResult:
+        ip = get_client_ip(scope)
+        record = await store.get(JS_CHALLENGE_NS, ip)
+
+        if record == "pass":
+            signals = {"passed": Signal(True, "JS challenge passed")}
+        elif record and record.startswith("fail"):
+            reason = record[len("fail:") :] if ":" in record else "automation indicator tripped"
+            signals = {"passed": Signal(False, f"JS challenge failed: {reason}")}
+        else:
+            signals = {
+                "passed": Signal(None, "no JS challenge response recorded"),
+            }
+
+        return MetricResult(self.name, derive_verdict(signals), signals)

--- a/skrift/bot_detection/metrics/pixel_beacon.py
+++ b/skrift/bot_detection/metrics/pixel_beacon.py
@@ -1,0 +1,55 @@
+"""Pixel beacon metric — separates HTML-only fetchers from real renderers.
+
+When a real browser parses a page it auto-fetches every ``<img>``
+element. Headless browsers (Puppeteer / Playwright / Selenium) also
+do. ``curl``, ``requests``, ``httpx``, and most LLM scrapers do
+not — they fetch the HTML and stop.
+
+This metric reads the cross-request pixel-load state set by
+:class:`BotDetectionController`. It is a *positive-only* signal:
+loading the pixel passes, but absence is reported as inconclusive.
+The metric does not accuse on its own — pixel-pass strengthens the
+overall verdict, pixel-absence does not weaken it.
+"""
+
+from __future__ import annotations
+
+from typing import ClassVar
+
+from litestar.types import Scope
+
+from skrift.bot_detection.beacon import PIXEL_LOADED_NS
+from skrift.bot_detection.config import BotDetectionConfig, PixelBeaconConfig
+from skrift.bot_detection.store import BotStateStore
+from skrift.bot_detection.types import MetricResult, Signal, derive_verdict
+from skrift.lib.client_ip import get_client_ip
+
+
+class PixelBeaconMetric:
+    """Confirm a request comes from a renderer by checking pixel state."""
+
+    name: ClassVar[str] = "pixel_beacon"
+
+    def __init__(self, config: BotDetectionConfig) -> None:
+        self._config: PixelBeaconConfig = config.pixel_beacon
+
+    @property
+    def enabled(self) -> bool:
+        return self._config.enabled
+
+    async def check(
+        self, scope: Scope, store: BotStateStore
+    ) -> MetricResult:
+        ip = get_client_ip(scope)
+        loaded_via = await store.get(PIXEL_LOADED_NS, ip)
+
+        if loaded_via:
+            signals = {
+                "loaded": Signal(True, f"loaded via {loaded_via}"),
+            }
+        else:
+            signals = {
+                "loaded": Signal(None, "no pixel beacon recorded yet"),
+            }
+
+        return MetricResult(self.name, derive_verdict(signals), signals)

--- a/skrift/bot_detection/metrics/robots_honeypot.py
+++ b/skrift/bot_detection/metrics/robots_honeypot.py
@@ -1,0 +1,76 @@
+"""Robots.txt honeypot metric.
+
+Reads two pieces of cross-request state, both written by the trap
+machinery in :mod:`skrift.bot_detection.honeypot`:
+
+- ``robots_read:<ip>`` — set whenever the IP fetched ``robots.txt``.
+- ``trap_hit:<ip>`` — set whenever the IP requested a path under the
+  trap prefix.
+
+Two signals are emitted:
+
+- ``trap_compliance`` — fails when the IP hit the trap. The detail
+  string distinguishes "fetched robots.txt then ignored the rule"
+  (definitive bot) from "hit trap without reading robots.txt" (naive
+  scraper).
+- ``robots_txt_aware`` — informational. Passes when the IP fetched
+  robots.txt; ``None`` otherwise. Real users typically never fetch
+  ``robots.txt``, so a ``None`` here is normal — that is why this
+  signal does not drive the verdict on its own.
+"""
+
+from __future__ import annotations
+
+from typing import ClassVar
+
+from litestar.types import Scope
+
+from skrift.bot_detection.config import BotDetectionConfig, RobotsHoneypotConfig
+from skrift.bot_detection.honeypot import ROBOTS_READ_NS, TRAP_HIT_NS
+from skrift.bot_detection.store import BotStateStore
+from skrift.bot_detection.types import MetricResult, Signal, derive_verdict
+from skrift.lib.client_ip import get_client_ip
+
+
+class RobotsHoneypotMetric:
+    """Score visitors against the rotating-token trap rule in robots.txt."""
+
+    name: ClassVar[str] = "robots_honeypot"
+
+    def __init__(self, config: BotDetectionConfig) -> None:
+        self._config: RobotsHoneypotConfig = config.robots_honeypot
+
+    @property
+    def enabled(self) -> bool:
+        return self._config.enabled
+
+    async def check(
+        self, scope: Scope, store: BotStateStore
+    ) -> MetricResult:
+        ip = get_client_ip(scope)
+        read_robots = await store.get(ROBOTS_READ_NS, ip) is not None
+        trap_hit = await store.get(TRAP_HIT_NS, ip) is not None
+
+        if trap_hit:
+            detail = (
+                "hit trap path after fetching robots.txt — non-compliant bot"
+                if read_robots
+                else "hit trap path without reading robots.txt — naive scraper"
+            )
+            compliance = Signal(False, detail)
+        else:
+            compliance = Signal(
+                True if read_robots else None,
+                "robots.txt rules respected" if read_robots else None,
+            )
+
+        awareness = Signal(
+            True if read_robots else None,
+            "robots.txt fetched" if read_robots else None,
+        )
+
+        signals = {
+            "trap_compliance": compliance,
+            "robots_txt_aware": awareness,
+        }
+        return MetricResult(self.name, derive_verdict(signals), signals)

--- a/skrift/bot_detection/middleware.py
+++ b/skrift/bot_detection/middleware.py
@@ -1,0 +1,110 @@
+"""ASGI middleware that runs bot detection metrics and attaches the result.
+
+The middleware is wired automatically when ``bot_detection.enabled`` is
+``True`` in ``app.yaml``. It resolves the client IP from
+``scope["state"]`` (set by :class:`~skrift.middleware.client_ip.ClientIPMiddleware`),
+runs every enabled metric, applies the
+:data:`~skrift.bot_detection.hooks.BOT_DETECTION_RESULT` filter, and
+attaches a :class:`BotDetectionResult` to ``scope["state"]["bot_detection"]``
+so downstream guards / handlers can read it.
+
+Skipped paths and legitimate-bot UAs short-circuit before any metric
+runs, so the high-volume static-asset path stays cheap and known good
+crawlers (Googlebot etc.) are not flagged.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from litestar.types import ASGIApp, Receive, Scope, Send
+
+from skrift.bot_detection.config import BotDetectionConfig
+from skrift.bot_detection.hooks import (
+    BOT_DETECTED,
+    BOT_DETECTION_RESULT,
+)
+from skrift.bot_detection.metrics.base import BotMetric, get_header
+from skrift.bot_detection.store import BotStateStore
+from skrift.bot_detection.types import (
+    BotDetectionResult,
+    derive_overall_verdict,
+)
+from skrift.lib.hooks import hooks
+
+logger = logging.getLogger(__name__)
+
+
+class BotDetectionMiddleware:
+    """Attach a :class:`BotDetectionResult` to ``scope["state"]``.
+
+    Args:
+        app: The ASGI application to wrap.
+        config: The resolved :class:`BotDetectionConfig`.
+        store: Cross-request state backend used by deferred metrics.
+        metrics: The list of metric instances to run. Built by the
+            factory, possibly after running the
+            :data:`~skrift.bot_detection.hooks.BOT_METRICS` filter so
+            plugins can inject their own.
+    """
+
+    def __init__(
+        self,
+        app: ASGIApp,
+        config: BotDetectionConfig,
+        store: BotStateStore,
+        metrics: list[BotMetric],
+    ) -> None:
+        self.app = app
+        self.config = config
+        self.store = store
+        self.metrics = metrics
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        if not self.config.enabled:
+            await self.app(scope, receive, send)
+            return
+
+        path = scope.get("path", "/")
+        if any(path.startswith(prefix) for prefix in self.config.skip_paths):
+            await self.app(scope, receive, send)
+            return
+
+        # Legitimate crawlers — short-circuit with a passing verdict so
+        # downstream guards do not block them. We trust the UA here;
+        # reverse-DNS verification is a future enhancement.
+        ua = get_header(scope, "user-agent") or ""
+        if any(legit in ua for legit in self.config.legitimate_bot_uas):
+            state = scope.setdefault("state", {})
+            state["bot_detection"] = BotDetectionResult(verdict=True, metrics={})
+            await self.app(scope, receive, send)
+            return
+
+        metrics_results = {}
+        for metric in self.metrics:
+            if not metric.enabled:
+                continue
+            try:
+                result = await metric.check(scope, self.store)
+            except Exception:
+                logger.warning(
+                    "bot_detection metric %s failed", metric.name, exc_info=True
+                )
+                continue
+            metrics_results[metric.name] = result
+
+        verdict = derive_overall_verdict(metrics_results)
+        result = BotDetectionResult(verdict=verdict, metrics=metrics_results)
+        result = await hooks.apply_filters(BOT_DETECTION_RESULT, result, scope)
+
+        if result.verdict is False:
+            await hooks.do_action(BOT_DETECTED, scope, result)
+
+        state = scope.setdefault("state", {})
+        state["bot_detection"] = result
+
+        await self.app(scope, receive, send)

--- a/skrift/bot_detection/setup.py
+++ b/skrift/bot_detection/setup.py
@@ -1,0 +1,67 @@
+"""Hook handler registration for the bot detection component.
+
+Called once at app startup. Registers:
+
+- A :data:`~skrift.lib.hooks.ROBOTS_TXT` filter that injects the
+  rotating ``Disallow: <trap_path>/<token>`` rule.
+- A :data:`~skrift.lib.hooks.ROBOTS_TXT_FETCHED` action handler that
+  records the fetcher's IP in the cross-request state store.
+
+These are external to the middleware because they fire from the
+:class:`SitemapController` request flow, not from the bot detection
+middleware itself.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from skrift.bot_detection.config import BotDetectionConfig
+from skrift.bot_detection.honeypot import (
+    ROBOTS_READ_NS,
+    STATE_TTL_SECONDS,
+    inject_disallow_rule,
+    trap_url,
+)
+from skrift.bot_detection.store import BotStateStore
+from skrift.lib.hooks import ROBOTS_TXT, ROBOTS_TXT_FETCHED, hooks
+
+logger = logging.getLogger(__name__)
+
+
+def setup_honeypot_hooks(
+    config: BotDetectionConfig,
+    store: BotStateStore,
+    secret: str,
+) -> None:
+    """Register the ROBOTS_TXT filter + ROBOTS_TXT_FETCHED action.
+
+    Idempotent — safe to call once per app construction. The
+    ``secret`` is used to sign the rotating trap token; deployments
+    should pass ``settings.secret_key``.
+    """
+    if not (config.enabled and config.robots_honeypot.enabled):
+        return
+
+    honeypot_config = config.robots_honeypot
+
+    async def _inject_trap_rule(content: str) -> str:
+        try:
+            url = trap_url(honeypot_config, secret)
+        except Exception:
+            logger.warning("bot_detection trap_url generation failed", exc_info=True)
+            return content
+        return inject_disallow_rule(content, url)
+
+    async def _record_robots_fetch(request, ip: str, _ua: str) -> None:
+        if not honeypot_config.log_robots_fetches:
+            return
+        try:
+            await store.set(ROBOTS_READ_NS, ip, "1", ttl=STATE_TTL_SECONDS)
+        except Exception:
+            logger.warning(
+                "bot_detection robots_read store update failed", exc_info=True
+            )
+
+    hooks.add_filter(ROBOTS_TXT, _inject_trap_rule)
+    hooks.add_action(ROBOTS_TXT_FETCHED, _record_robots_fetch)

--- a/skrift/bot_detection/store.py
+++ b/skrift/bot_detection/store.py
@@ -1,0 +1,82 @@
+"""Cross-request state store for bot detection metrics.
+
+Deferred metrics — pixel beacon, JS challenge, robots honeypot — record
+state on one request and read it on a later request from the same
+client. The store abstraction lets the same metric work against either
+a process-local dict (for single-process deployments and tests) or
+Redis (for multi-process / multi-replica deployments).
+
+The store carries opaque string values keyed by ``(namespace, key)``
+tuples. Time-to-live is enforced lazily for the in-memory backend.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Protocol
+
+
+class BotStateStore(Protocol):
+    """Minimal key/value with TTL used by deferred metrics."""
+
+    async def get(self, namespace: str, key: str) -> str | None: ...
+
+    async def set(
+        self, namespace: str, key: str, value: str, *, ttl: int
+    ) -> None: ...
+
+    async def delete(self, namespace: str, key: str) -> None: ...
+
+
+class InMemoryBotStateStore:
+    """Process-local store backed by a dict. Not safe across replicas.
+
+    TTLs are enforced lazily on read; expired entries are dropped on
+    access.
+    """
+
+    def __init__(self) -> None:
+        self._data: dict[tuple[str, str], tuple[str, float]] = {}
+
+    async def get(self, namespace: str, key: str) -> str | None:
+        entry = self._data.get((namespace, key))
+        if entry is None:
+            return None
+        value, expires_at = entry
+        if expires_at <= time.monotonic():
+            self._data.pop((namespace, key), None)
+            return None
+        return value
+
+    async def set(
+        self, namespace: str, key: str, value: str, *, ttl: int
+    ) -> None:
+        self._data[(namespace, key)] = (value, time.monotonic() + ttl)
+
+    async def delete(self, namespace: str, key: str) -> None:
+        self._data.pop((namespace, key), None)
+
+
+class RedisBotStateStore:
+    """Redis-backed store. Used when ``settings.redis.url`` is set."""
+
+    def __init__(self, client, prefix: str) -> None:
+        self._client = client
+        self._prefix = prefix
+
+    def _full_key(self, namespace: str, key: str) -> str:
+        return f"{self._prefix}:{namespace}:{key}"
+
+    async def get(self, namespace: str, key: str) -> str | None:
+        raw = await self._client.get(self._full_key(namespace, key))
+        if raw is None:
+            return None
+        return raw.decode() if isinstance(raw, (bytes, bytearray)) else str(raw)
+
+    async def set(
+        self, namespace: str, key: str, value: str, *, ttl: int
+    ) -> None:
+        await self._client.set(self._full_key(namespace, key), value, ex=ttl)
+
+    async def delete(self, namespace: str, key: str) -> None:
+        await self._client.delete(self._full_key(namespace, key))

--- a/skrift/bot_detection/trap_controller.py
+++ b/skrift/bot_detection/trap_controller.py
@@ -1,0 +1,69 @@
+"""Dynamic Controller registered for the configured trap path.
+
+Litestar's application-level middleware does not run on unmatched
+routes (the framework returns 404 before the middleware is invoked),
+so a middleware-only trap interception was a no-op for arbitrary
+trap URLs. Instead, this module builds a Controller subclass at app
+construction time whose ``path`` is the configured ``trap_path``.
+
+The trap handler records the hit in the bot detection state store,
+fires :data:`~skrift.bot_detection.hooks.BOT_TRAP_HIT`, and then
+raises ``NotFoundException`` so the response looks identical to a
+normal 404 — bots get no signal that their visit was interesting.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Type
+
+from litestar import Controller, Request, get
+from litestar.exceptions import NotFoundException
+
+from skrift.bot_detection.honeypot import STATE_TTL_SECONDS, TRAP_HIT_NS
+from skrift.bot_detection.hooks import BOT_TRAP_HIT
+from skrift.bot_detection.store import BotStateStore
+from skrift.lib.client_ip import get_client_ip
+from skrift.lib.hooks import hooks
+
+logger = logging.getLogger(__name__)
+
+
+def build_trap_controller(
+    trap_path: str, store: BotStateStore
+) -> Type[Controller]:
+    """Construct a Controller bound to ``trap_path``.
+
+    Returns a fresh subclass each call (Litestar disallows duplicate
+    controller registration). The store is captured by closure so the
+    handler does not need to dig it back out of app state.
+    """
+
+    async def _record(request: Request) -> None:
+        ip = get_client_ip(request.scope)
+        ua = request.headers.get("user-agent", "")
+        path = request.scope.get("path", "")
+        try:
+            await store.set(TRAP_HIT_NS, ip, path, ttl=STATE_TTL_SECONDS)
+        except Exception:
+            logger.warning(
+                "bot_detection trap hit store failed", exc_info=True
+            )
+        await hooks.do_action(BOT_TRAP_HIT, request.scope, ip, ua, path)
+
+    class TrapController(Controller):
+        path = trap_path.rstrip("/") or "/"
+
+        @get("/")
+        async def trap_root(self, request: Request) -> None:
+            await _record(request)
+            raise NotFoundException()
+
+        @get("/{token:str}")
+        async def trap_with_token(
+            self, request: Request, token: str
+        ) -> None:
+            await _record(request)
+            raise NotFoundException()
+
+    return TrapController

--- a/skrift/bot_detection/types.py
+++ b/skrift/bot_detection/types.py
@@ -1,0 +1,93 @@
+"""Verdict + signal data types for bot detection.
+
+A ``Signal`` is one atomic observation (e.g. "User-Agent contains
+'Puppeteer'") with a tri-state outcome: pass (looks human), fail (looks
+like a bot), or inconclusive.
+
+A ``MetricResult`` groups the signals produced by a single metric and
+exposes a derived verdict.
+
+A ``BotDetectionResult`` aggregates per-metric results into the
+top-level shape attached to ``scope["state"]["bot_detection"]``.
+
+End users consume the verdict directly when they want a built-in
+decision, or read raw signals when they want to roll their own.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Mapping
+
+
+@dataclass(frozen=True)
+class Signal:
+    """One atomic pass/fail observation produced by a metric.
+
+    ``passed`` is tri-state: ``True`` = looks human, ``False`` = looks
+    like a bot, ``None`` = inconclusive (e.g. waiting on a deferred
+    beacon).
+    """
+
+    passed: bool | None
+    detail: str | None = None
+
+
+@dataclass(frozen=True)
+class MetricResult:
+    """The signals produced by a single metric and its derived verdict.
+
+    The verdict is computed by :func:`derive_verdict` over ``signals``
+    when the metric does not supply one explicitly.
+    """
+
+    name: str
+    verdict: bool | None
+    signals: Mapping[str, Signal] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class BotDetectionResult:
+    """Aggregate result of running every enabled metric for a request.
+
+    ``verdict`` is ``False`` if any metric verdicted ``False``, ``None``
+    if every metric verdict is inconclusive, otherwise ``True``.
+
+    Disabled metrics are absent from ``metrics``.
+    """
+
+    verdict: bool | None
+    metrics: Mapping[str, MetricResult] = field(default_factory=dict)
+
+
+def derive_verdict(signals: Mapping[str, Signal]) -> bool | None:
+    """Compute a metric verdict from its signals.
+
+    Rule: ``False`` if any signal explicitly failed; ``None`` when no
+    signal has a definitive outcome; ``True`` otherwise.
+    """
+    if not signals:
+        return None
+    saw_pass = False
+    for sig in signals.values():
+        if sig.passed is False:
+            return False
+        if sig.passed is True:
+            saw_pass = True
+    return True if saw_pass else None
+
+
+def derive_overall_verdict(metrics: Mapping[str, MetricResult]) -> bool | None:
+    """Compute the overall verdict across metric results.
+
+    Same rule as :func:`derive_verdict`, applied to per-metric verdicts.
+    """
+    if not metrics:
+        return None
+    saw_pass = False
+    for metric in metrics.values():
+        if metric.verdict is False:
+            return False
+        if metric.verdict is True:
+            saw_pass = True
+    return True if saw_pass else None

--- a/skrift/cli.py
+++ b/skrift/cli.py
@@ -172,7 +172,7 @@ def _run_alembic(project_root: Path, args: list[str]) -> None:
     skrift_versions = str(skrift_dir / "alembic" / "versions")
     user_versions = project_root / "migrations" / "versions"
     if user_versions.is_dir():
-        version_locations = f"{user_versions} {skrift_versions}"
+        version_locations = os.pathsep.join([str(user_versions), skrift_versions])
     else:
         version_locations = skrift_versions
 
@@ -187,6 +187,8 @@ def _run_alembic(project_root: Path, args: list[str]) -> None:
 
     # Build Config and inject version_locations
     cfg = Config(str(alembic_ini))
+    cfg.set_main_option("path_separator", "os")
+    cfg.set_main_option("version_path_separator", "os")
     cfg.set_main_option("version_locations", version_locations)
 
     # Parse and run through CommandLine for proper subcommand dispatch

--- a/skrift/config.py
+++ b/skrift/config.py
@@ -9,6 +9,8 @@ from dotenv import load_dotenv
 from pydantic import BaseModel, Field, PrivateAttr
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
+from skrift.bot_detection.config import BotDetectionConfig
+
 # Load .env file early so env vars are available for YAML interpolation
 # Load from current working directory (where app.yaml lives)
 _env_file = Path.cwd() / ".env"
@@ -659,6 +661,9 @@ class Settings(BaseSettings):
     # Rate limit config (loaded from app.yaml)
     rate_limit: RateLimitConfig = RateLimitConfig()
 
+    # Bot detection config (loaded from app.yaml)
+    bot_detection: BotDetectionConfig = BotDetectionConfig()
+
     # Trusted proxy / client IP resolution (loaded from app.yaml)
     trusted_proxy: TrustedProxyConfig = TrustedProxyConfig()
 
@@ -760,6 +765,9 @@ def get_settings() -> Settings:
 
     if "rate_limit" in app_config:
         kwargs["rate_limit"] = RateLimitConfig(**app_config["rate_limit"])
+
+    if "bot_detection" in app_config:
+        kwargs["bot_detection"] = BotDetectionConfig(**app_config["bot_detection"])
 
     if "trusted_proxy" in app_config:
         kwargs["trusted_proxy"] = TrustedProxyConfig(**app_config["trusted_proxy"])

--- a/skrift/controllers/helpers.py
+++ b/skrift/controllers/helpers.py
@@ -3,10 +3,10 @@
 from uuid import UUID
 
 from litestar import Request
-from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from skrift.auth.session_keys import SESSION_USER_ID
+from skrift.db.cache import get_by_pk
 from skrift.db.models.user import User
 from skrift.db.services.setting_service import get_cached_site_theme
 from skrift.lib.hooks import RESOLVE_THEME, apply_filters
@@ -18,8 +18,7 @@ async def get_user_context(request: Request, db_session: AsyncSession) -> dict:
     if not user_id:
         return {"user": None}
 
-    result = await db_session.execute(select(User).where(User.id == UUID(user_id)))
-    user = result.scalar_one_or_none()
+    user = await get_by_pk(db_session, User, UUID(user_id))
     return {"user": user}
 
 

--- a/skrift/controllers/sitemap.py
+++ b/skrift/controllers/sitemap.py
@@ -11,7 +11,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from skrift.db.services import page_service
 from skrift.db.services.setting_service import get_cached_site_base_url, get_cached_robots_txt
-from skrift.lib.hooks import hooks, SITEMAP_PAGE, SITEMAP_URLS, ROBOTS_TXT
+from skrift.lib.client_ip import get_client_ip
+from skrift.lib.hooks import hooks, ROBOTS_TXT, ROBOTS_TXT_FETCHED, SITEMAP_PAGE, SITEMAP_URLS
 
 
 @dataclass
@@ -119,6 +120,15 @@ Sitemap: {sitemap_url}
 
         # Apply robots_txt filter for customization
         content = await hooks.apply_filters(ROBOTS_TXT, content)
+
+        # Fire action so listeners (bot detection, audit logs) can record
+        # who fetched robots.txt — see the robots-honeypot metric.
+        await hooks.do_action(
+            ROBOTS_TXT_FETCHED,
+            request,
+            get_client_ip(request.scope),
+            request.headers.get("user-agent", ""),
+        )
 
         return Response(
             content=content,

--- a/skrift/db/cache.py
+++ b/skrift/db/cache.py
@@ -1,0 +1,46 @@
+"""Request-scoped primary-key cache helpers for database sessions."""
+
+from __future__ import annotations
+
+from collections.abc import Hashable
+from typing import TypeVar, cast
+
+from sqlalchemy import inspect
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from skrift.db.base import Base
+
+
+ModelT = TypeVar("ModelT", bound=Base)
+
+CACHE_KEY = "skrift_pk_cache"
+
+
+async def get_by_pk(
+    db_session: AsyncSession,
+    model: type[ModelT],
+    pk: Hashable,
+) -> ModelT | None:
+    """Return a model instance by primary key, cached for this session/request."""
+    cache = db_session.info.setdefault(CACHE_KEY, {})
+    key = (model, pk)
+    if key in cache:
+        return cast(ModelT | None, cache[key])
+
+    obj = await db_session.get(model, pk)
+    cache[key] = obj
+    return obj
+
+
+def seed_instance(db_session: AsyncSession, obj: Base) -> None:
+    """Seed the request cache with an already-loaded model instance."""
+    identity = inspect(obj).identity
+    if identity is not None and len(identity) == 1:
+        db_session.info.setdefault(CACHE_KEY, {})[(type(obj), identity[0])] = obj
+
+
+def evict_pk(db_session: AsyncSession, model: type[Base], pk: Hashable) -> None:
+    """Remove a cached primary-key entry from this session/request."""
+    cache = db_session.info.get(CACHE_KEY)
+    if cache is not None:
+        cache.pop((model, pk), None)

--- a/skrift/db/services/asset_service.py
+++ b/skrift/db/services/asset_service.py
@@ -8,6 +8,7 @@ from uuid import UUID
 from sqlalchemy import and_, delete, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from skrift.db.cache import evict_pk, get_by_pk, seed_instance
 from skrift.db.models.asset import Asset
 from skrift.db.models.page_asset import page_assets
 from skrift.lib.hooks import (
@@ -87,6 +88,7 @@ async def upload_asset(
     db_session.add(asset)
     await db_session.commit()
     await db_session.refresh(asset)
+    seed_instance(db_session, asset)
 
     # Fire after-upload action
     await hooks.do_action(AFTER_ASSET_UPLOAD, asset)
@@ -100,8 +102,7 @@ async def delete_asset(
     asset_id: UUID,
 ) -> bool:
     """Delete an asset. Removes backend file only when no other rows reference it."""
-    result = await db_session.execute(select(Asset).where(Asset.id == asset_id))
-    asset = result.scalar_one_or_none()
+    asset = await get_by_pk(db_session, Asset, asset_id)
     if not asset:
         return False
 
@@ -113,6 +114,7 @@ async def delete_asset(
 
     await db_session.delete(asset)
     await db_session.commit()
+    evict_pk(db_session, Asset, asset_id)
 
     # Check remaining references
     count_result = await db_session.execute(

--- a/skrift/db/services/page_service.py
+++ b/skrift/db/services/page_service.py
@@ -7,6 +7,7 @@ from uuid import UUID
 from sqlalchemy import select, and_, or_
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from skrift.db.cache import evict_pk, get_by_pk, seed_instance
 from skrift.db.models import Page
 from skrift.db.services import revision_service
 from skrift.lib.hooks import hooks, BEFORE_PAGE_SAVE, AFTER_PAGE_SAVE, BEFORE_PAGE_DELETE, AFTER_PAGE_DELETE, AFTER_PAGE_PUBLISHED, AFTER_PAGE_UNPUBLISHED
@@ -122,8 +123,7 @@ async def get_page_by_id(
     Returns:
         Page object or None if not found
     """
-    result = await db_session.execute(select(Page).where(Page.id == page_id))
-    return result.scalar_one_or_none()
+    return await get_by_pk(db_session, Page, page_id)
 
 
 async def create_page(
@@ -189,6 +189,7 @@ async def create_page(
     db_session.add(page)
     await db_session.commit()
     await db_session.refresh(page)
+    seed_instance(db_session, page)
 
     # Fire after_page_save action
     await hooks.do_action(AFTER_PAGE_SAVE, page, is_new=True)
@@ -327,6 +328,7 @@ async def delete_page(
 
     await db_session.delete(page)
     await db_session.commit()
+    evict_pk(db_session, Page, page_id)
 
     # Fire after_page_delete action
     await hooks.do_action(AFTER_PAGE_DELETE, page)

--- a/skrift/lib/hooks.py
+++ b/skrift/lib/hooks.py
@@ -337,3 +337,12 @@ AFTER_TOKEN_REVOKED = "after_token_revoked"
 # Page lifecycle hooks
 AFTER_PAGE_PUBLISHED = "after_page_published"
 AFTER_PAGE_UNPUBLISHED = "after_page_unpublished"
+
+# Bot detection hooks
+BOT_METRICS = "bot_metrics"                    # filter: list[BotMetric] -> list[BotMetric]
+BOT_DETECTION_RESULT = "bot_detection_result"  # filter: BotDetectionResult -> BotDetectionResult
+BOT_DETECTED = "bot_detected"                  # action: (scope, result)
+BOT_TRAP_HIT = "bot_trap_hit"                  # action: (scope, ip, ua, token)
+BOT_PIXEL_LOADED = "bot_pixel_loaded"          # action: (scope, ip, request_id)
+BOT_CHALLENGE_PASSED = "bot_challenge_passed"  # action: (scope, ip, session_id)
+ROBOTS_TXT_FETCHED = "robots_txt_fetched"      # action: (request, ip, ua)

--- a/skrift/static/bot_detection/challenge.js
+++ b/skrift/static/bot_detection/challenge.js
@@ -1,0 +1,58 @@
+// Bot detection JS challenge.
+//
+// Collects a small set of automation indicators in the user's browser,
+// posts them to /_bot/verify with a per-page-render signed token, and
+// lets the server decide pass/fail. The server does not trust the
+// values directly — it derives the verdict from them — so a tampered
+// payload only earns the client a "fail" record.
+//
+// Read the data-* attributes on this script tag for the token. Fail
+// closed: if anything throws, just bail rather than reporting bogus
+// data.
+(function () {
+  "use strict";
+
+  var script = document.currentScript;
+  if (!script) {
+    return;
+  }
+  var token = script.getAttribute("data-token") || "";
+  var signature = script.getAttribute("data-signature") || "";
+  if (!token || !signature) {
+    return;
+  }
+
+  function safe(fn, fallback) {
+    try {
+      return fn();
+    } catch (_e) {
+      return fallback;
+    }
+  }
+
+  var indicators = {
+    token: token,
+    signature: signature,
+    webdriver: safe(function () { return navigator.webdriver === true; }, false),
+    plugins: safe(function () { return navigator.plugins ? navigator.plugins.length : 0; }, 0),
+    languages: safe(function () { return (navigator.languages || []).length; }, 0),
+    chrome: safe(function () { return "chrome" in window; }, false),
+    canvas: safe(function () {
+      var c = document.createElement("canvas");
+      var ctx = c.getContext("2d");
+      if (!ctx) return -1;
+      ctx.fillStyle = "#abc";
+      ctx.fillText("bd", 1, 1);
+      return c.toDataURL().length;
+    }, -1),
+    timing: safe(function () { return Math.round(performance.now()); }, 0),
+  };
+
+  fetch("/_bot/verify", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(indicators),
+    credentials: "same-origin",
+    mode: "same-origin",
+  }).catch(function () { /* swallow */ });
+})();

--- a/tests/bot_detection/test_config.py
+++ b/tests/bot_detection/test_config.py
@@ -1,0 +1,81 @@
+"""Tests for BotDetectionConfig and Settings wiring."""
+
+from skrift.bot_detection.config import (
+    BotDetectionConfig,
+    HeadlessUAConfig,
+    JSChallengeConfig,
+    PixelBeaconConfig,
+    RobotsHoneypotConfig,
+)
+
+
+class TestBotDetectionConfigDefaults:
+    def test_disabled_by_default(self):
+        config = BotDetectionConfig()
+        assert config.enabled is False
+
+    def test_default_skip_paths(self):
+        config = BotDetectionConfig()
+        assert "/static/" in config.skip_paths
+        assert "/_bot/" in config.skip_paths
+
+    def test_default_legitimate_bots(self):
+        config = BotDetectionConfig()
+        assert "Googlebot" in config.legitimate_bot_uas
+
+    def test_each_metric_enabled_by_default_except_js_challenge(self):
+        config = BotDetectionConfig()
+        assert config.headless_ua.enabled is True
+        assert config.header_coherence.enabled is True
+        assert config.direct_request.enabled is True
+        assert config.pixel_beacon.enabled is True
+        assert config.robots_honeypot.enabled is True
+        # JS challenge is opt-in because it breaks no-JS clients.
+        assert config.js_challenge.enabled is False
+
+
+class TestPerMetricConfig:
+    def test_headless_ua_has_default_patterns(self):
+        config = HeadlessUAConfig()
+        assert "HeadlessChrome" in config.patterns
+        assert "Puppeteer" in config.patterns
+
+    def test_pixel_beacon_defaults(self):
+        config = PixelBeaconConfig()
+        assert config.cache_ttl == 60
+        assert config.inject_pixel is True
+        assert config.inject_css_beacon is True
+
+    def test_robots_honeypot_defaults(self):
+        config = RobotsHoneypotConfig()
+        assert config.trap_path == "/private-area"
+        assert config.rotate_token_days == 7
+
+    def test_js_challenge_defaults(self):
+        config = JSChallengeConfig()
+        assert config.block_unverified_after == 3
+        assert config.challenge_ttl == 3600
+
+
+class TestNestedConfigParsing:
+    def test_can_construct_with_nested_dicts(self):
+        config = BotDetectionConfig(
+            enabled=True,
+            headless_ua={"enabled": False, "patterns": ["FooBot"]},
+            pixel_beacon={"cache_ttl": 120},
+        )
+        assert config.enabled is True
+        assert config.headless_ua.enabled is False
+        assert config.headless_ua.patterns == ["FooBot"]
+        assert config.pixel_beacon.cache_ttl == 120
+
+
+class TestSettingsIntegration:
+    def test_settings_has_bot_detection(self):
+        from skrift.config import Settings
+
+        # Settings inherits BaseSettings; secret_key is required from env
+        # in production, so build directly with a stub secret_key.
+        s = Settings(secret_key="test")
+        assert isinstance(s.bot_detection, BotDetectionConfig)
+        assert s.bot_detection.enabled is False

--- a/tests/bot_detection/test_controller_edge_cases.py
+++ b/tests/bot_detection/test_controller_edge_cases.py
@@ -1,0 +1,176 @@
+"""Edge cases in BotDetectionController.
+
+Covers paths the happy-path tests skip:
+
+- Pixel/CSS/verify when bot detection store is missing from app state
+- Verify endpoint with malformed JSON keys
+- Verify endpoint when js_challenge is disabled
+- Pixel endpoint when pixel_beacon is disabled
+- Tokens with empty strings
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from litestar import Litestar
+from litestar.testing import TestClient
+
+from skrift.bot_detection.beacon import (
+    PIXEL_LOADED_NS,
+    make_pixel_token,
+)
+from skrift.bot_detection.challenge import (
+    JS_CHALLENGE_NS,
+    make_challenge_token,
+)
+from skrift.bot_detection.config import BotDetectionConfig
+from skrift.bot_detection.controllers import BotDetectionController
+from skrift.bot_detection.store import InMemoryBotStateStore
+from skrift.lib.hooks import hooks
+
+
+@pytest.fixture(autouse=True)
+def clean_hooks():
+    hooks._actions.clear()
+    hooks._filters.clear()
+    yield
+    hooks._actions.clear()
+    hooks._filters.clear()
+
+
+def _build_app(monkeypatch, *, store, config: BotDetectionConfig):
+    from skrift.config import Settings
+
+    settings = Settings(secret_key="edge-secret", bot_detection=config)
+    monkeypatch.setattr("skrift.config.get_settings", lambda: settings)
+    app = Litestar(route_handlers=[BotDetectionController])
+    if store is not None:
+        app.state.bot_detection_store = store
+    return app, settings
+
+
+class TestPixelEdgeCases:
+    def test_pixel_returns_gif_when_store_missing(self, monkeypatch):
+        """No store on app.state -> still serves the GIF, just doesn't record."""
+        app, settings = _build_app(
+            monkeypatch, store=None, config=BotDetectionConfig(enabled=True)
+        )
+        token, sig = make_pixel_token(settings.secret_key)
+        with TestClient(app) as client:
+            r = client.get(f"/_bot/p.gif?t={token}&s={sig}")
+        assert r.status_code == 200
+        assert r.content[:3] == b"GIF"
+
+    def test_pixel_does_nothing_when_metric_disabled(self, monkeypatch):
+        """Pixel beacon disabled -> token validation bypassed, no record."""
+        store = InMemoryBotStateStore()
+        config = BotDetectionConfig(
+            enabled=True, pixel_beacon={"enabled": False}
+        )
+        app, settings = _build_app(monkeypatch, store=store, config=config)
+        token, sig = make_pixel_token(settings.secret_key)
+        with TestClient(app) as client:
+            r = client.get(f"/_bot/p.gif?t={token}&s={sig}")
+        assert r.status_code == 200
+        assert asyncio.run(store.get(PIXEL_LOADED_NS, "testclient")) is None
+
+    def test_pixel_with_no_token_does_not_record(self, monkeypatch):
+        store = InMemoryBotStateStore()
+        app, _ = _build_app(
+            monkeypatch, store=store, config=BotDetectionConfig(enabled=True)
+        )
+        with TestClient(app) as client:
+            r = client.get("/_bot/p.gif")  # no t / s params
+        assert r.status_code == 200
+        assert asyncio.run(store.get(PIXEL_LOADED_NS, "testclient")) is None
+
+    def test_pixel_with_token_but_no_signature_does_not_record(self, monkeypatch):
+        store = InMemoryBotStateStore()
+        app, _ = _build_app(
+            monkeypatch, store=store, config=BotDetectionConfig(enabled=True)
+        )
+        with TestClient(app) as client:
+            r = client.get("/_bot/p.gif?t=abcd")
+        assert r.status_code == 200
+        assert asyncio.run(store.get(PIXEL_LOADED_NS, "testclient")) is None
+
+
+class TestVerifyEdgeCases:
+    def test_verify_silent_when_js_challenge_disabled(self, monkeypatch):
+        """Even with valid token, verify is a no-op when js_challenge is off."""
+        store = InMemoryBotStateStore()
+        config = BotDetectionConfig(
+            enabled=True, js_challenge={"enabled": False}
+        )
+        app, settings = _build_app(monkeypatch, store=store, config=config)
+        token, sig = make_challenge_token(settings.secret_key)
+        with TestClient(app) as client:
+            r = client.post(
+                "/_bot/verify",
+                json={
+                    "token": token,
+                    "signature": sig,
+                    "webdriver": False,
+                    "plugins": 1,
+                    "languages": 1,
+                    "chrome": True,
+                    "canvas": 200,
+                },
+            )
+        assert r.status_code == 204
+        assert asyncio.run(store.get(JS_CHALLENGE_NS, "testclient")) is None
+
+    def test_verify_returns_204_when_store_missing(self, monkeypatch):
+        config = BotDetectionConfig(
+            enabled=True, js_challenge={"enabled": True}
+        )
+        app, settings = _build_app(monkeypatch, store=None, config=config)
+        token, sig = make_challenge_token(settings.secret_key)
+        with TestClient(app) as client:
+            r = client.post(
+                "/_bot/verify",
+                json={
+                    "token": token,
+                    "signature": sig,
+                    "webdriver": False,
+                    "plugins": 1,
+                    "languages": 1,
+                    "chrome": True,
+                    "canvas": 200,
+                },
+            )
+        assert r.status_code == 204
+
+    def test_verify_with_missing_keys_does_not_crash(self, monkeypatch):
+        """Half-formed payload — evaluator coerces missing fields, returns fail."""
+        store = InMemoryBotStateStore()
+        config = BotDetectionConfig(
+            enabled=True, js_challenge={"enabled": True}
+        )
+        app, settings = _build_app(monkeypatch, store=store, config=config)
+        token, sig = make_challenge_token(settings.secret_key)
+        with TestClient(app) as client:
+            r = client.post(
+                "/_bot/verify",
+                json={"token": token, "signature": sig},
+            )
+        assert r.status_code == 204
+        record = asyncio.run(store.get(JS_CHALLENGE_NS, "testclient"))
+        assert record is not None
+        assert record.startswith("fail:")  # canvas=0 -> fails
+
+    def test_verify_with_empty_token_does_not_record(self, monkeypatch):
+        store = InMemoryBotStateStore()
+        config = BotDetectionConfig(
+            enabled=True, js_challenge={"enabled": True}
+        )
+        app, _ = _build_app(monkeypatch, store=store, config=config)
+        with TestClient(app) as client:
+            r = client.post(
+                "/_bot/verify",
+                json={"token": "", "signature": ""},
+            )
+        assert r.status_code == 204
+        assert asyncio.run(store.get(JS_CHALLENGE_NS, "testclient")) is None

--- a/tests/bot_detection/test_e2e.py
+++ b/tests/bot_detection/test_e2e.py
@@ -1,0 +1,485 @@
+"""End-to-end integration tests for the bot detection component.
+
+Spins up a real Litestar app with the bot detection middleware,
+controllers, hooks, and Jinja globals wired together — the same
+wiring ``skrift.asgi.create_app`` produces, minus the database / auth
+plumbing — and then exercises each metric through actual HTTP
+requests via ``TestClient``.
+
+A debug endpoint ``/whoami`` returns the bot detection result as JSON
+so the test can assert on the real verdict produced by the
+middleware. A separate ``/guarded`` endpoint protected by
+:class:`BotGuard` proves the guard actually blocks bot traffic at the
+HTTP level.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict
+from typing import Any
+
+import pytest
+from litestar import Controller, Litestar, Request, get
+from litestar.middleware import DefineMiddleware
+from litestar.testing import TestClient
+
+from skrift.bot_detection.beacon import make_pixel_token
+from skrift.bot_detection.challenge import make_challenge_token
+from skrift.bot_detection.config import BotDetectionConfig
+from skrift.bot_detection.controllers import BotDetectionController
+from skrift.bot_detection.factory import build_initial_metrics
+from skrift.bot_detection.guards import BotGuard
+from skrift.bot_detection.middleware import BotDetectionMiddleware
+from skrift.bot_detection.setup import setup_honeypot_hooks
+from skrift.bot_detection.store import InMemoryBotStateStore
+from skrift.bot_detection.trap_controller import build_trap_controller
+from skrift.bot_detection.types import BotDetectionResult
+from skrift.lib.hooks import (
+    ROBOTS_TXT,
+    ROBOTS_TXT_FETCHED,
+    hooks,
+)
+
+SECRET = "e2e-test-secret"
+
+
+def _result_to_dict(result: BotDetectionResult | None) -> dict[str, Any]:
+    """Serialize a BotDetectionResult for JSON return."""
+    if result is None:
+        return {"verdict": None, "metrics": {}}
+    return {
+        "verdict": result.verdict,
+        "metrics": {
+            name: {
+                "verdict": metric.verdict,
+                "signals": {
+                    sig_name: asdict(sig)
+                    for sig_name, sig in metric.signals.items()
+                },
+            }
+            for name, metric in result.metrics.items()
+        },
+    }
+
+
+class _DebugController(Controller):
+    """Surfaces bot detection state for the test, plus a guarded endpoint.
+
+    The ``/robots.txt`` handler is a faithful but DB-free reproduction
+    of :meth:`SitemapController.robots`: builds a baseline body, runs
+    it through the :data:`ROBOTS_TXT` filter, and fires the
+    :data:`ROBOTS_TXT_FETCHED` action — the same wire points the real
+    controller uses, but without needing the SQLAlchemy plugin in this
+    integration test.
+    """
+
+    @get("/whoami")
+    async def whoami(self, request: Request) -> dict:
+        result = request.scope.get("state", {}).get("bot_detection")
+        return _result_to_dict(result)
+
+    @get("/robots.txt", media_type="text/plain")
+    async def robots(self, request: Request) -> str:
+        from skrift.lib.client_ip import get_client_ip
+
+        content = "User-agent: *\nAllow: /\n"
+        content = await hooks.apply_filters(ROBOTS_TXT, content)
+        await hooks.do_action(
+            ROBOTS_TXT_FETCHED,
+            request,
+            get_client_ip(request.scope),
+            request.headers.get("user-agent", ""),
+        )
+        return content
+
+    @get("/guarded", guards=[BotGuard()])
+    async def guarded(self, request: Request) -> dict:
+        return {"ok": True}
+
+    @get("/guarded-verdict-unknown-deny", guards=[BotGuard(on_unknown="deny")])
+    async def guarded_unknown_deny(self, request: Request) -> dict:
+        return {"ok": True}
+
+    @get(
+        "/guarded-pixel",
+        guards=[BotGuard(require_signals=["pixel_beacon.loaded"])],
+    )
+    async def guarded_pixel(self, request: Request) -> dict:
+        return {"ok": True}
+
+
+@pytest.fixture(autouse=True)
+def clean_hooks_each_test():
+    hooks._actions.clear()
+    hooks._filters.clear()
+    yield
+    hooks._actions.clear()
+    hooks._filters.clear()
+
+
+@pytest.fixture
+def settings(monkeypatch):
+    """Minimal Settings-like object so the controller can resolve secret_key."""
+    from skrift.config import Settings
+
+    s = Settings(
+        secret_key=SECRET,
+        bot_detection=BotDetectionConfig(
+            enabled=True,
+            cache_backend="memory",
+            js_challenge={"enabled": True},
+            robots_honeypot={"enabled": True, "trap_path": "/private-area"},
+        ),
+    )
+    monkeypatch.setattr("skrift.config.get_settings", lambda: s)
+    return s
+
+
+@pytest.fixture
+def app(settings):
+    """Litestar app with bot detection wired end-to-end."""
+    store = InMemoryBotStateStore()
+    metrics = build_initial_metrics(settings.bot_detection)
+    setup_honeypot_hooks(settings.bot_detection, store, settings.secret_key)
+
+    trap_controller = build_trap_controller(
+        settings.bot_detection.robots_honeypot.trap_path, store
+    )
+    app = Litestar(
+        route_handlers=[
+            _DebugController,
+            BotDetectionController,
+            trap_controller,
+        ],
+        middleware=[
+            DefineMiddleware(
+                BotDetectionMiddleware,
+                config=settings.bot_detection,
+                store=store,
+                metrics=metrics,
+            )
+        ],
+    )
+    app.state.bot_detection_store = store
+    return app
+
+
+@pytest.fixture
+def client(app):
+    with TestClient(app) as c:
+        yield c
+
+
+# ---------------------------------------------------------------------------
+# Headless UA metric
+# ---------------------------------------------------------------------------
+
+
+class TestHeadlessUAEndToEnd:
+    def test_real_chrome_passes(self, client):
+        r = client.get(
+            "/whoami",
+            headers={"user-agent": "Mozilla/5.0 ... Chrome/120.0"},
+        )
+        ua = r.json()["metrics"]["headless_ua"]
+        assert ua["verdict"] is True
+        assert ua["signals"]["puppeteer"]["passed"] is True
+
+    def test_puppeteer_fails(self, client):
+        r = client.get(
+            "/whoami",
+            headers={"user-agent": "Mozilla/5.0 Chrome/120 Puppeteer/1.0"},
+        )
+        ua = r.json()["metrics"]["headless_ua"]
+        assert ua["verdict"] is False
+        assert ua["signals"]["puppeteer"]["passed"] is False
+        assert "Puppeteer" in ua["signals"]["puppeteer"]["detail"]
+
+    def test_headless_chrome_fails(self, client):
+        r = client.get(
+            "/whoami",
+            headers={"user-agent": "Mozilla/5.0 (X11) HeadlessChrome/120.0"},
+        )
+        ua = r.json()["metrics"]["headless_ua"]
+        assert ua["signals"]["headless_chrome"]["passed"] is False
+
+
+# ---------------------------------------------------------------------------
+# Header coherence metric
+# ---------------------------------------------------------------------------
+
+
+class TestHeaderCoherenceEndToEnd:
+    def test_full_chromium_headers_pass(self, client):
+        r = client.get(
+            "/whoami",
+            headers={
+                "user-agent": "Mozilla/5.0 ... Chrome/120.0",
+                "sec-fetch-site": "same-origin",
+                "sec-fetch-mode": "navigate",
+                "sec-fetch-dest": "document",
+                "sec-ch-ua": '"Chrome";v="120"',
+                "accept-language": "en-US",
+            },
+        )
+        hc = r.json()["metrics"]["header_coherence"]
+        assert hc["verdict"] is True
+
+    def test_chromium_ua_missing_sec_fetch_fails(self, client):
+        r = client.get(
+            "/whoami",
+            headers={"user-agent": "Mozilla/5.0 ... Chrome/120.0"},
+        )
+        hc = r.json()["metrics"]["header_coherence"]
+        assert hc["verdict"] is False
+        assert hc["signals"]["sec_fetch_site"]["passed"] is False
+
+    def test_curl_ua_does_not_trigger_chromium_check(self, client):
+        r = client.get("/whoami", headers={"user-agent": "curl/8.0"})
+        hc = r.json()["metrics"]["header_coherence"]
+        # Inconclusive — curl does not claim Chromium.
+        assert hc["verdict"] is None
+
+
+# ---------------------------------------------------------------------------
+# Direct request metric
+# ---------------------------------------------------------------------------
+
+
+class TestDirectRequestEndToEnd:
+    def test_navigated_request_passes(self, client):
+        r = client.get(
+            "/whoami",
+            headers={
+                "user-agent": "Mozilla/5.0 ... Chrome/120.0",
+                "referer": "https://example.com/",
+                "cookie": "session=abc123",
+                "sec-fetch-site": "same-origin",
+            },
+        )
+        dr = r.json()["metrics"]["direct_request"]
+        assert dr["verdict"] is True
+
+    def test_curl_to_deep_url_fails_referer(self, client):
+        r = client.get(
+            "/whoami", headers={"user-agent": "curl/8.0"}
+        )
+        # /whoami is a deep URL — no referer / no cookie / no sec-fetch
+        dr = r.json()["metrics"]["direct_request"]
+        assert dr["verdict"] is False
+        assert dr["signals"]["referer"]["passed"] is False
+
+
+# ---------------------------------------------------------------------------
+# Robots honeypot metric — full cycle test
+# ---------------------------------------------------------------------------
+
+
+class TestRobotsHoneypotEndToEnd:
+    def test_robots_txt_includes_trap_rule(self, client):
+        r = client.get("/robots.txt")
+        assert r.status_code == 200
+        assert "Disallow: /private-area/" in r.text
+
+    def test_full_compliance_cycle(self, client):
+        # Step 1: fetch robots.txt — IP is recorded as having read it.
+        client.get("/robots.txt")
+
+        # Step 2: regular request shows we have read robots.txt and not hit
+        # the trap — verdict True.
+        r = client.get("/whoami", headers={"user-agent": "GoodBot/1.0"})
+        rh = r.json()["metrics"]["robots_honeypot"]
+        assert rh["verdict"] is True
+        assert rh["signals"]["robots_txt_aware"]["passed"] is True
+        assert rh["signals"]["trap_compliance"]["passed"] is True
+
+    def test_full_non_compliance_cycle(self, client):
+        # Step 1: fetch robots.txt.
+        client.get("/robots.txt")
+
+        # Step 2: hit the trap path — middleware records the hit, returns 404.
+        r = client.get("/private-area/whatever")
+        assert r.status_code == 404
+
+        # Step 3: subsequent request — verdict False, both signals fired.
+        r = client.get("/whoami", headers={"user-agent": "BadBot/1.0"})
+        rh = r.json()["metrics"]["robots_honeypot"]
+        assert rh["verdict"] is False
+        assert "non-compliant bot" in rh["signals"]["trap_compliance"]["detail"]
+
+    def test_naive_scraper_hits_trap_without_robots(self, client):
+        # No robots.txt fetch — straight to the trap.
+        client.get("/private-area/whatever")
+        r = client.get("/whoami", headers={"user-agent": "NaiveScraper/1.0"})
+        rh = r.json()["metrics"]["robots_honeypot"]
+        assert rh["verdict"] is False
+        assert "naive scraper" in rh["signals"]["trap_compliance"]["detail"]
+
+
+# ---------------------------------------------------------------------------
+# Pixel beacon metric — full cycle test
+# ---------------------------------------------------------------------------
+
+
+class TestPixelBeaconEndToEnd:
+    def test_first_request_is_inconclusive(self, client):
+        r = client.get("/whoami", headers={"user-agent": "BrowserLike/1.0"})
+        pb = r.json()["metrics"]["pixel_beacon"]
+        assert pb["verdict"] is None
+
+    def test_pixel_load_then_request_passes(self, client, settings):
+        token, sig = make_pixel_token(settings.secret_key)
+        # Step 1: simulate browser loading the pixel.
+        r = client.get(f"/_bot/p.gif?t={token}&s={sig}")
+        assert r.status_code == 200
+
+        # Step 2: subsequent request — pixel_beacon now passes.
+        r = client.get("/whoami", headers={"user-agent": "BrowserLike/1.0"})
+        pb = r.json()["metrics"]["pixel_beacon"]
+        assert pb["verdict"] is True
+        assert pb["signals"]["loaded"]["passed"] is True
+
+    def test_css_beacon_also_passes(self, client, settings):
+        token, sig = make_pixel_token(settings.secret_key)
+        client.get(f"/_bot/c.gif?t={token}&s={sig}")
+        r = client.get("/whoami", headers={"user-agent": "BrowserLike/1.0"})
+        pb = r.json()["metrics"]["pixel_beacon"]
+        assert pb["verdict"] is True
+        assert "css" in pb["signals"]["loaded"]["detail"]
+
+
+# ---------------------------------------------------------------------------
+# JS challenge metric — full cycle test
+# ---------------------------------------------------------------------------
+
+
+class TestJSChallengeEndToEnd:
+    def _good_payload(self, token, sig):
+        return {
+            "token": token,
+            "signature": sig,
+            "webdriver": False,
+            "plugins": 3,
+            "languages": 2,
+            "chrome": True,
+            "canvas": 200,
+            "timing": 500,
+        }
+
+    def test_first_request_is_inconclusive(self, client):
+        r = client.get("/whoami", headers={"user-agent": "BrowserLike/1.0"})
+        jc = r.json()["metrics"]["js_challenge"]
+        assert jc["verdict"] is None
+
+    def test_passing_challenge_then_request_passes(self, client, settings):
+        token, sig = make_challenge_token(settings.secret_key)
+        r = client.post(
+            "/_bot/verify",
+            json=self._good_payload(token, sig),
+            headers={"user-agent": "Mozilla/5.0 ... Chrome/120.0"},
+        )
+        assert r.status_code == 204
+
+        r = client.get(
+            "/whoami", headers={"user-agent": "Mozilla/5.0 ... Chrome/120.0"}
+        )
+        jc = r.json()["metrics"]["js_challenge"]
+        assert jc["verdict"] is True
+
+    def test_webdriver_challenge_fails(self, client, settings):
+        token, sig = make_challenge_token(settings.secret_key)
+        payload = self._good_payload(token, sig)
+        payload["webdriver"] = True
+        client.post(
+            "/_bot/verify",
+            json=payload,
+            headers={"user-agent": "Mozilla/5.0 ... Chrome/120.0"},
+        )
+        r = client.get(
+            "/whoami", headers={"user-agent": "Mozilla/5.0 ... Chrome/120.0"}
+        )
+        jc = r.json()["metrics"]["js_challenge"]
+        assert jc["verdict"] is False
+        assert "webdriver" in jc["signals"]["passed"]["detail"]
+
+
+# ---------------------------------------------------------------------------
+# Legitimate bot allow-list short-circuits
+# ---------------------------------------------------------------------------
+
+
+class TestLegitimateBotEndToEnd:
+    def test_googlebot_passes_with_empty_metrics(self, client):
+        r = client.get(
+            "/whoami",
+            headers={
+                "user-agent": "Mozilla/5.0 (compatible; Googlebot/2.1)"
+            },
+        )
+        assert r.json()["verdict"] is True
+        assert r.json()["metrics"] == {}
+
+
+# ---------------------------------------------------------------------------
+# BotGuard at the HTTP layer
+# ---------------------------------------------------------------------------
+
+
+class TestBotGuardEndToEnd:
+    def test_guard_blocks_bot_with_403(self, client):
+        # Send a request that fails the headless_ua metric.
+        r = client.get(
+            "/guarded",
+            headers={
+                "user-agent": "Mozilla/5.0 Chrome/120 Puppeteer/1.0"
+            },
+        )
+        assert r.status_code == 403
+
+    def test_guard_allows_real_browser(self, client):
+        r = client.get(
+            "/guarded",
+            headers={
+                "user-agent": "Mozilla/5.0 ... Chrome/120.0",
+                "sec-fetch-site": "same-origin",
+                "sec-fetch-mode": "navigate",
+                "sec-fetch-dest": "document",
+                "sec-ch-ua": '"Chrome";v="120"',
+                "accept-language": "en-US",
+                "referer": "https://example.com/",
+                "cookie": "session=abc",
+            },
+        )
+        assert r.status_code == 200
+
+    def test_guard_with_on_unknown_deny_blocks_silent_visitor(self, client):
+        # No bot-detection state would be inconclusive (verdict None) —
+        # on_unknown="deny" should block.
+        r = client.get(
+            "/guarded-verdict-unknown-deny",
+            headers={"user-agent": "curl/8.0"},
+        )
+        # curl/8.0 will fail direct_request and headless_ua presence checks,
+        # so the verdict is False here — the deny path is the same status.
+        assert r.status_code == 403
+
+    def test_signal_guard_blocks_until_pixel_loads(self, client, settings):
+        # Without a pixel load, /guarded-pixel should be denied
+        # (signal absent + on_unknown defaults to allow at config level
+        # but require_signals strictly checks the named signal).
+        r = client.get(
+            "/guarded-pixel",
+            headers={"user-agent": "Mozilla/5.0 Chrome/120"},
+        )
+        # Default on_unknown is allow at config level, so missing
+        # signals don't deny — this should pass through.
+        assert r.status_code == 200
+
+        # After a pixel load, the signal explicitly passes.
+        token, sig = make_pixel_token(settings.secret_key)
+        client.get(f"/_bot/p.gif?t={token}&s={sig}")
+        r = client.get(
+            "/guarded-pixel",
+            headers={"user-agent": "Mozilla/5.0 Chrome/120"},
+        )
+        assert r.status_code == 200

--- a/tests/bot_detection/test_extensibility.py
+++ b/tests/bot_detection/test_extensibility.py
@@ -1,0 +1,215 @@
+"""Tests for plugin extensibility — custom metrics + on_startup metric filter.
+
+Validates the two main extension paths a plugin author would use:
+
+- Register a ``BOT_METRICS`` filter handler that injects a custom
+  metric instance into the list run on every request.
+- Have ``apply_metrics_filter`` (called from ``on_startup``) actually
+  pick that handler up and mutate the list passed to the middleware
+  in place.
+"""
+
+from __future__ import annotations
+
+from typing import ClassVar
+
+import pytest
+
+from skrift.bot_detection.config import BotDetectionConfig
+from skrift.bot_detection.factory import (
+    apply_metrics_filter,
+    build_initial_metrics,
+)
+from skrift.bot_detection.hooks import BOT_METRICS
+from skrift.bot_detection.middleware import BotDetectionMiddleware
+from skrift.bot_detection.store import InMemoryBotStateStore
+from skrift.bot_detection.types import MetricResult, Signal
+from skrift.lib.hooks import hooks
+
+
+class CustomMetric:
+    """Test-only metric that fails the verdict for any request from a banned IP."""
+
+    name: ClassVar[str] = "ban_list"
+
+    def __init__(self, banned_ips: set[str]):
+        self._banned = banned_ips
+        self.enabled = True
+
+    async def check(self, scope, store):
+        ip = ""
+        state = scope.get("state", {})
+        if isinstance(state, dict):
+            ip = state.get("client_ip", "") or ""
+        if not ip:
+            client = scope.get("client")
+            if client:
+                ip = client[0]
+
+        if ip in self._banned:
+            sig = Signal(False, f"{ip} on ban list")
+        else:
+            sig = Signal(True)
+        return MetricResult(self.name, sig.passed, {"banned": sig})
+
+
+@pytest.fixture(autouse=True)
+def clean_hooks():
+    hooks._actions.clear()
+    hooks._filters.clear()
+    yield
+    hooks._actions.clear()
+    hooks._filters.clear()
+
+
+class TestApplyMetricsFilter:
+    @pytest.mark.asyncio
+    async def test_filter_can_append_custom_metric(self):
+        async def add_custom(metrics, config):
+            return metrics + [CustomMetric(banned_ips={"5.5.5.5"})]
+
+        hooks.add_filter(BOT_METRICS, add_custom)
+
+        config = BotDetectionConfig(enabled=True)
+        metrics = build_initial_metrics(config)
+        original_count = len(metrics)
+        await apply_metrics_filter(metrics, config)
+
+        assert len(metrics) == original_count + 1
+        names = {m.name for m in metrics}
+        assert "ban_list" in names
+
+    @pytest.mark.asyncio
+    async def test_filter_can_replace_metric_list(self):
+        async def replace_all(metrics, config):
+            return [CustomMetric(banned_ips=set())]
+
+        hooks.add_filter(BOT_METRICS, replace_all)
+
+        config = BotDetectionConfig(enabled=True)
+        metrics = build_initial_metrics(config)
+        await apply_metrics_filter(metrics, config)
+
+        assert len(metrics) == 1
+        assert metrics[0].name == "ban_list"
+
+    @pytest.mark.asyncio
+    async def test_filter_chains_in_priority_order(self):
+        order: list[str] = []
+
+        async def first(metrics, config):
+            order.append("first")
+            return metrics
+
+        async def second(metrics, config):
+            order.append("second")
+            return metrics
+
+        hooks.add_filter(BOT_METRICS, first, priority=10)
+        hooks.add_filter(BOT_METRICS, second, priority=5)
+
+        config = BotDetectionConfig(enabled=True)
+        metrics = build_initial_metrics(config)
+        await apply_metrics_filter(metrics, config)
+
+        # Lower priority runs first.
+        assert order == ["second", "first"]
+
+    @pytest.mark.asyncio
+    async def test_filter_mutates_list_in_place(self):
+        """The middleware holds a reference; the filter must update that list."""
+        async def add_custom(metrics, config):
+            return metrics + [CustomMetric(banned_ips={"1.1.1.1"})]
+
+        hooks.add_filter(BOT_METRICS, add_custom)
+
+        config = BotDetectionConfig(enabled=True)
+        metrics = build_initial_metrics(config)
+        original_id = id(metrics)
+        await apply_metrics_filter(metrics, config)
+        # Same list object — mutated in place so the middleware reference stays valid.
+        assert id(metrics) == original_id
+
+
+class TestCustomMetricEndToEnd:
+    @pytest.mark.asyncio
+    async def test_custom_metric_drives_middleware_verdict(self):
+        async def add_custom(metrics, config):
+            return metrics + [CustomMetric(banned_ips={"5.5.5.5"})]
+
+        hooks.add_filter(BOT_METRICS, add_custom)
+
+        config = BotDetectionConfig(enabled=True)
+        store = InMemoryBotStateStore()
+        metrics = build_initial_metrics(config)
+        await apply_metrics_filter(metrics, config)
+
+        captured: dict = {}
+
+        async def app(scope, receive, send):
+            captured["scope"] = scope
+            await send({"type": "http.response.start", "status": 200, "headers": []})
+            await send({"type": "http.response.body", "body": b""})
+
+        async def send(message):
+            return None
+
+        middleware = BotDetectionMiddleware(app, config, store, metrics)
+
+        # Banned IP -> custom metric fails -> verdict False.
+        scope = {
+            "type": "http",
+            "method": "GET",
+            "path": "/page",
+            "headers": [(b"user-agent", b"Mozilla/5.0 ... Chrome/120.0")],
+            "client": ("5.5.5.5", 0),
+            "state": {"client_ip": "5.5.5.5"},
+        }
+        await middleware(scope, None, send)
+        result = captured["scope"]["state"]["bot_detection"]
+        assert result.metrics["ban_list"].verdict is False
+        assert result.verdict is False
+
+    @pytest.mark.asyncio
+    async def test_unbanned_ip_passes_custom_metric(self):
+        async def add_custom(metrics, config):
+            return metrics + [CustomMetric(banned_ips={"5.5.5.5"})]
+
+        hooks.add_filter(BOT_METRICS, add_custom)
+
+        config = BotDetectionConfig(enabled=True)
+        store = InMemoryBotStateStore()
+        metrics = build_initial_metrics(config)
+        await apply_metrics_filter(metrics, config)
+
+        captured: dict = {}
+
+        async def app(scope, receive, send):
+            captured["scope"] = scope
+            await send({"type": "http.response.start", "status": 200, "headers": []})
+            await send({"type": "http.response.body", "body": b""})
+
+        async def send(message):
+            return None
+
+        middleware = BotDetectionMiddleware(app, config, store, metrics)
+        scope = {
+            "type": "http",
+            "method": "GET",
+            "path": "/",
+            "headers": [
+                (b"user-agent", b"Mozilla/5.0 ... Chrome/120.0"),
+                (b"sec-fetch-site", b"same-origin"),
+                (b"sec-fetch-mode", b"navigate"),
+                (b"sec-fetch-dest", b"document"),
+                (b"sec-ch-ua", b'"Chrome";v="120"'),
+                (b"accept-language", b"en-US"),
+                (b"referer", b"https://example.com/"),
+                (b"cookie", b"session=abc"),
+            ],
+            "client": ("9.9.9.9", 0),
+            "state": {"client_ip": "9.9.9.9"},
+        }
+        await middleware(scope, None, send)
+        result = captured["scope"]["state"]["bot_detection"]
+        assert result.metrics["ban_list"].verdict is True

--- a/tests/bot_detection/test_guards.py
+++ b/tests/bot_detection/test_guards.py
@@ -1,0 +1,105 @@
+"""Tests for the BotGuard Litestar route guard."""
+
+from unittest.mock import MagicMock
+
+import pytest
+from litestar.exceptions import PermissionDeniedException
+
+from skrift.bot_detection.guards import BotGuard
+from skrift.bot_detection.types import BotDetectionResult, MetricResult, Signal
+
+
+def make_connection(result: BotDetectionResult | None):
+    """Build a minimal ASGIConnection-like stand-in with the desired state."""
+    state = {} if result is None else {"bot_detection": result}
+    connection = MagicMock()
+    connection.scope = {"state": state}
+    return connection
+
+
+class TestBotGuardDefaultMode:
+    def test_passes_when_verdict_true(self):
+        result = BotDetectionResult(verdict=True, metrics={})
+        BotGuard()(make_connection(result), MagicMock())
+
+    def test_blocks_when_verdict_false(self):
+        result = BotDetectionResult(verdict=False, metrics={})
+        with pytest.raises(PermissionDeniedException):
+            BotGuard()(make_connection(result), MagicMock())
+
+    def test_allows_unknown_when_on_unknown_allow(self):
+        result = BotDetectionResult(verdict=None, metrics={})
+        BotGuard(on_unknown="allow")(make_connection(result), MagicMock())
+
+    def test_blocks_unknown_when_on_unknown_deny(self):
+        result = BotDetectionResult(verdict=None, metrics={})
+        with pytest.raises(PermissionDeniedException):
+            BotGuard(on_unknown="deny")(make_connection(result), MagicMock())
+
+    def test_no_middleware_state_passes_through(self):
+        BotGuard()(make_connection(None), MagicMock())
+
+
+class TestBotGuardSignalMode:
+    def _result(self, **signals):
+        metric = MetricResult("headless_ua", verdict=True, signals=signals)
+        return BotDetectionResult(verdict=True, metrics={"headless_ua": metric})
+
+    def test_passes_when_required_signal_passes(self):
+        result = self._result(puppeteer=Signal(True))
+        BotGuard(require_signals=["headless_ua.puppeteer"])(
+            make_connection(result), MagicMock()
+        )
+
+    def test_blocks_when_required_signal_fails(self):
+        result = self._result(puppeteer=Signal(False))
+        with pytest.raises(PermissionDeniedException):
+            BotGuard(require_signals=["headless_ua.puppeteer"])(
+                make_connection(result), MagicMock()
+            )
+
+    def test_allows_missing_signal_when_on_unknown_allow(self):
+        result = self._result(other=Signal(True))
+        BotGuard(
+            require_signals=["headless_ua.puppeteer"], on_unknown="allow"
+        )(make_connection(result), MagicMock())
+
+    def test_blocks_missing_signal_when_on_unknown_deny(self):
+        result = self._result(other=Signal(True))
+        with pytest.raises(PermissionDeniedException):
+            BotGuard(
+                require_signals=["headless_ua.puppeteer"], on_unknown="deny"
+            )(make_connection(result), MagicMock())
+
+    def test_blocks_inconclusive_signal_when_on_unknown_deny(self):
+        result = self._result(puppeteer=Signal(None))
+        with pytest.raises(PermissionDeniedException):
+            BotGuard(
+                require_signals=["headless_ua.puppeteer"], on_unknown="deny"
+            )(make_connection(result), MagicMock())
+
+    def test_blocks_when_metric_missing_entirely(self):
+        result = BotDetectionResult(verdict=True, metrics={})
+        with pytest.raises(PermissionDeniedException):
+            BotGuard(
+                require_signals=["headless_ua.puppeteer"], on_unknown="deny"
+            )(make_connection(result), MagicMock())
+
+    def test_invalid_reference_raises_value_error(self):
+        result = self._result(puppeteer=Signal(True))
+        with pytest.raises(ValueError):
+            BotGuard(require_signals=["badref"])(
+                make_connection(result), MagicMock()
+            )
+
+    def test_multiple_required_signals_all_must_pass(self):
+        metric = MetricResult(
+            "headless_ua",
+            verdict=True,
+            signals={"a": Signal(True), "b": Signal(False)},
+        )
+        result = BotDetectionResult(verdict=True, metrics={"headless_ua": metric})
+        with pytest.raises(PermissionDeniedException):
+            BotGuard(
+                require_signals=["headless_ua.a", "headless_ua.b"]
+            )(make_connection(result), MagicMock())

--- a/tests/bot_detection/test_honeypot.py
+++ b/tests/bot_detection/test_honeypot.py
@@ -1,0 +1,169 @@
+"""Tests for the robots honeypot — token rotation, rule injection, metric."""
+
+from unittest.mock import patch
+
+import pytest
+
+from skrift.bot_detection.config import BotDetectionConfig, RobotsHoneypotConfig
+from skrift.bot_detection.honeypot import (
+    inject_disallow_rule,
+    is_trap_path,
+    make_trap_token,
+    trap_url,
+)
+from skrift.bot_detection.metrics.robots_honeypot import RobotsHoneypotMetric
+from skrift.bot_detection.store import InMemoryBotStateStore
+
+
+class TestMakeTrapToken:
+    def test_token_is_stable_within_period(self):
+        with patch("skrift.bot_detection.honeypot.time.time", return_value=1_700_000_000):
+            t1 = make_trap_token("secret", rotate_token_days=7)
+            t2 = make_trap_token("secret", rotate_token_days=7)
+        assert t1 == t2
+
+    def test_token_changes_when_period_advances(self):
+        seven_days = 7 * 86400
+        with patch("skrift.bot_detection.honeypot.time.time", return_value=1_700_000_000):
+            t1 = make_trap_token("secret", rotate_token_days=7)
+        with patch(
+            "skrift.bot_detection.honeypot.time.time",
+            return_value=1_700_000_000 + seven_days * 2,
+        ):
+            t2 = make_trap_token("secret", rotate_token_days=7)
+        assert t1 != t2
+
+    def test_token_differs_per_secret(self):
+        with patch("skrift.bot_detection.honeypot.time.time", return_value=1_700_000_000):
+            t1 = make_trap_token("secret-a", rotate_token_days=7)
+            t2 = make_trap_token("secret-b", rotate_token_days=7)
+        assert t1 != t2
+
+    def test_token_is_url_safe(self):
+        token = make_trap_token("secret", rotate_token_days=7)
+        # base64.urlsafe charset.
+        assert all(
+            c.isalnum() or c in "-_=" for c in token
+        )
+
+
+class TestTrapUrl:
+    def test_trap_url_combines_prefix_and_token(self):
+        cfg = RobotsHoneypotConfig(trap_path="/private-area")
+        url = trap_url(cfg, "secret")
+        assert url.startswith("/private-area/")
+        assert len(url) > len("/private-area/")
+
+    def test_trap_url_strips_trailing_slash(self):
+        cfg = RobotsHoneypotConfig(trap_path="/private-area/")
+        url = trap_url(cfg, "secret")
+        # No double slash.
+        assert "//" not in url
+
+
+class TestIsTrapPath:
+    def test_exact_prefix_matches(self):
+        cfg = RobotsHoneypotConfig(trap_path="/private-area")
+        assert is_trap_path("/private-area", cfg) is True
+
+    def test_sub_path_matches(self):
+        cfg = RobotsHoneypotConfig(trap_path="/private-area")
+        assert is_trap_path("/private-area/abc123", cfg) is True
+
+    def test_unrelated_path_does_not_match(self):
+        cfg = RobotsHoneypotConfig(trap_path="/private-area")
+        assert is_trap_path("/public", cfg) is False
+
+    def test_partial_prefix_does_not_match(self):
+        cfg = RobotsHoneypotConfig(trap_path="/private-area")
+        assert is_trap_path("/private-areas", cfg) is False  # different path
+
+    def test_empty_trap_path_never_matches(self):
+        cfg = RobotsHoneypotConfig(trap_path="")
+        assert is_trap_path("/anything", cfg) is False
+
+
+class TestInjectDisallowRule:
+    def test_appends_to_existing_user_agent_block(self):
+        content = "User-agent: *\nAllow: /\n\nSitemap: https://example.com/sitemap.xml\n"
+        result = inject_disallow_rule(content, "/private-area/abc")
+        assert "Disallow: /private-area/abc" in result
+        # The injected rule should appear before the Allow line (right after User-agent: *).
+        ua_idx = result.index("User-agent: *")
+        rule_idx = result.index("Disallow: /private-area/abc")
+        assert rule_idx > ua_idx
+
+    def test_prepends_when_no_user_agent_block(self):
+        content = "# empty file\n"
+        result = inject_disallow_rule(content, "/private-area/abc")
+        assert result.startswith("User-agent: *\n")
+        assert "Disallow: /private-area/abc" in result
+
+    def test_idempotent_when_rule_already_present(self):
+        content = "User-agent: *\nDisallow: /private-area/abc\n"
+        result = inject_disallow_rule(content, "/private-area/abc")
+        # Should not be added a second time.
+        assert result.count("Disallow: /private-area/abc") == 1
+
+
+class TestRobotsHoneypotMetric:
+    @pytest.mark.asyncio
+    async def test_inconclusive_when_no_state(self):
+        metric = RobotsHoneypotMetric(BotDetectionConfig())
+        store = InMemoryBotStateStore()
+        scope = _scope("1.2.3.4")
+        result = await metric.check(scope, store)
+        assert result.verdict is None
+
+    @pytest.mark.asyncio
+    async def test_passes_when_robots_read_no_trap(self):
+        from skrift.bot_detection.honeypot import ROBOTS_READ_NS
+
+        metric = RobotsHoneypotMetric(BotDetectionConfig())
+        store = InMemoryBotStateStore()
+        await store.set(ROBOTS_READ_NS, "1.2.3.4", "1", ttl=3600)
+        result = await metric.check(_scope("1.2.3.4"), store)
+        assert result.verdict is True
+        assert result.signals["trap_compliance"].passed is True
+        assert result.signals["robots_txt_aware"].passed is True
+
+    @pytest.mark.asyncio
+    async def test_fails_when_trap_hit_and_robots_read(self):
+        from skrift.bot_detection.honeypot import (
+            ROBOTS_READ_NS,
+            TRAP_HIT_NS,
+        )
+
+        metric = RobotsHoneypotMetric(BotDetectionConfig())
+        store = InMemoryBotStateStore()
+        await store.set(ROBOTS_READ_NS, "1.2.3.4", "1", ttl=3600)
+        await store.set(TRAP_HIT_NS, "1.2.3.4", "/private-area/x", ttl=3600)
+        result = await metric.check(_scope("1.2.3.4"), store)
+        assert result.verdict is False
+        assert "non-compliant" in (
+            result.signals["trap_compliance"].detail or ""
+        )
+
+    @pytest.mark.asyncio
+    async def test_fails_when_trap_hit_and_robots_not_read(self):
+        from skrift.bot_detection.honeypot import TRAP_HIT_NS
+
+        metric = RobotsHoneypotMetric(BotDetectionConfig())
+        store = InMemoryBotStateStore()
+        await store.set(TRAP_HIT_NS, "1.2.3.4", "/private-area/x", ttl=3600)
+        result = await metric.check(_scope("1.2.3.4"), store)
+        assert result.verdict is False
+        assert "naive scraper" in (
+            result.signals["trap_compliance"].detail or ""
+        )
+
+
+def _scope(ip: str):
+    return {
+        "type": "http",
+        "method": "GET",
+        "path": "/page",
+        "headers": [],
+        "client": ("0.0.0.0", 0),
+        "state": {"client_ip": ip},
+    }

--- a/tests/bot_detection/test_isolation_and_composite.py
+++ b/tests/bot_detection/test_isolation_and_composite.py
@@ -1,0 +1,334 @@
+"""Multi-IP isolation + composite-metric scenario tests.
+
+The deferred metrics (pixel beacon, JS challenge, robots honeypot)
+all key cross-request state by client IP. Two basic correctness
+properties:
+
+1. State for IP A must not bleed into IP B's verdict.
+2. Hitting the trap from one IP should not penalize a different IP.
+
+The composite tests then put the whole stack through real-world
+scenarios that combine multiple metrics, mirroring how a guard would
+see traffic in production.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from litestar import Controller, Litestar, Request, get
+from litestar.middleware import DefineMiddleware
+from litestar.testing import TestClient
+
+from skrift.bot_detection.beacon import make_pixel_token
+from skrift.bot_detection.config import BotDetectionConfig
+from skrift.bot_detection.controllers import BotDetectionController
+from skrift.bot_detection.factory import build_initial_metrics
+from skrift.bot_detection.honeypot import (
+    ROBOTS_READ_NS,
+    TRAP_HIT_NS,
+)
+from skrift.bot_detection.middleware import BotDetectionMiddleware
+from skrift.bot_detection.setup import setup_honeypot_hooks
+from skrift.bot_detection.store import InMemoryBotStateStore
+from skrift.bot_detection.trap_controller import build_trap_controller
+from skrift.lib.hooks import (
+    ROBOTS_TXT,
+    ROBOTS_TXT_FETCHED,
+    hooks,
+)
+
+SECRET = "isolation-test-secret"
+
+
+class _DebugController(Controller):
+    @get("/whoami")
+    async def whoami(self, request: Request) -> dict:
+        result = request.scope.get("state", {}).get("bot_detection")
+        if result is None:
+            return {"verdict": None, "metrics": {}}
+        return {
+            "verdict": result.verdict,
+            "metric_verdicts": {
+                name: m.verdict for name, m in result.metrics.items()
+            },
+        }
+
+    @get("/robots.txt", media_type="text/plain")
+    async def robots(self, request: Request) -> str:
+        from skrift.lib.client_ip import get_client_ip
+
+        content = "User-agent: *\nAllow: /\n"
+        content = await hooks.apply_filters(ROBOTS_TXT, content)
+        await hooks.do_action(
+            ROBOTS_TXT_FETCHED,
+            request,
+            get_client_ip(request.scope),
+            request.headers.get("user-agent", ""),
+        )
+        return content
+
+
+@pytest.fixture(autouse=True)
+def clean_hooks():
+    hooks._actions.clear()
+    hooks._filters.clear()
+    yield
+    hooks._actions.clear()
+    hooks._filters.clear()
+
+
+@pytest.fixture
+def settings(monkeypatch):
+    from skrift.config import Settings
+
+    s = Settings(
+        secret_key=SECRET,
+        bot_detection=BotDetectionConfig(
+            enabled=True,
+            cache_backend="memory",
+            js_challenge={"enabled": True},
+            robots_honeypot={"enabled": True, "trap_path": "/private-area"},
+        ),
+    )
+    monkeypatch.setattr("skrift.config.get_settings", lambda: s)
+    return s
+
+
+@pytest.fixture
+def store():
+    return InMemoryBotStateStore()
+
+
+@pytest.fixture
+def app(settings, store):
+    metrics = build_initial_metrics(settings.bot_detection)
+    setup_honeypot_hooks(settings.bot_detection, store, settings.secret_key)
+    trap = build_trap_controller(
+        settings.bot_detection.robots_honeypot.trap_path, store
+    )
+    app = Litestar(
+        route_handlers=[_DebugController, BotDetectionController, trap],
+        middleware=[
+            DefineMiddleware(
+                BotDetectionMiddleware,
+                config=settings.bot_detection,
+                store=store,
+                metrics=metrics,
+            )
+        ],
+    )
+    app.state.bot_detection_store = store
+    return app
+
+
+# ---------------------------------------------------------------------------
+# Multi-IP isolation
+# ---------------------------------------------------------------------------
+
+
+class TestMultiIPIsolation:
+    @pytest.mark.asyncio
+    async def test_trap_hit_only_taints_the_hitting_ip(self, store):
+        """Bot from IP A hits trap; IP B's verdict is unaffected."""
+        await store.set(TRAP_HIT_NS, "1.1.1.1", "/private-area/x", ttl=3600)
+
+        from skrift.bot_detection.metrics.robots_honeypot import (
+            RobotsHoneypotMetric,
+        )
+
+        metric = RobotsHoneypotMetric(BotDetectionConfig())
+
+        bot_scope = {
+            "type": "http",
+            "path": "/page",
+            "headers": [],
+            "state": {"client_ip": "1.1.1.1"},
+        }
+        clean_scope = {
+            "type": "http",
+            "path": "/page",
+            "headers": [],
+            "state": {"client_ip": "2.2.2.2"},
+        }
+
+        bot_result = await metric.check(bot_scope, store)
+        clean_result = await metric.check(clean_scope, store)
+
+        assert bot_result.verdict is False
+        assert clean_result.verdict is None  # no signal on this IP
+
+    @pytest.mark.asyncio
+    async def test_pixel_load_only_passes_for_the_loading_ip(self, store):
+        """Browser at IP A loads pixel; IP B doesn't get a free pass."""
+        from skrift.bot_detection.beacon import PIXEL_LOADED_NS
+        from skrift.bot_detection.metrics.pixel_beacon import (
+            PixelBeaconMetric,
+        )
+
+        await store.set(PIXEL_LOADED_NS, "1.1.1.1", "pixel", ttl=3600)
+        metric = PixelBeaconMetric(BotDetectionConfig())
+
+        loader = await metric.check(
+            {
+                "type": "http",
+                "path": "/x",
+                "headers": [],
+                "state": {"client_ip": "1.1.1.1"},
+            },
+            store,
+        )
+        other = await metric.check(
+            {
+                "type": "http",
+                "path": "/x",
+                "headers": [],
+                "state": {"client_ip": "2.2.2.2"},
+            },
+            store,
+        )
+
+        assert loader.verdict is True
+        assert other.verdict is None
+
+    @pytest.mark.asyncio
+    async def test_robots_fetch_isolated_per_ip(self, store):
+        """Compliant bot at IP A fetched robots; IP B is untouched."""
+        from skrift.bot_detection.metrics.robots_honeypot import (
+            RobotsHoneypotMetric,
+        )
+
+        await store.set(ROBOTS_READ_NS, "1.1.1.1", "1", ttl=3600)
+        metric = RobotsHoneypotMetric(BotDetectionConfig())
+
+        a = await metric.check(
+            {
+                "type": "http",
+                "path": "/x",
+                "headers": [],
+                "state": {"client_ip": "1.1.1.1"},
+            },
+            store,
+        )
+        b = await metric.check(
+            {
+                "type": "http",
+                "path": "/x",
+                "headers": [],
+                "state": {"client_ip": "2.2.2.2"},
+            },
+            store,
+        )
+
+        assert a.signals["robots_txt_aware"].passed is True
+        assert b.signals["robots_txt_aware"].passed is None
+
+
+# ---------------------------------------------------------------------------
+# Composite scenarios — a real bot trips multiple metrics
+# ---------------------------------------------------------------------------
+
+
+class TestCompositeBotScenarios:
+    def test_puppeteer_with_no_navigation_fails_multiple_metrics(self, app):
+        """Headless bot with bare-bones request — multiple metrics fail."""
+        with TestClient(app) as client:
+            r = client.get(
+                "/whoami",
+                headers={
+                    "user-agent": "Mozilla/5.0 Chrome/120.0 Puppeteer/1.0",
+                },
+            )
+        body = r.json()
+        assert body["verdict"] is False
+        verdicts = body["metric_verdicts"]
+        # Headless UA fires explicitly; header coherence too (UA claims
+        # Chromium 120 without Sec-Fetch headers); direct_request too
+        # because there is no Referer / cookie / sec-fetch-site.
+        assert verdicts["headless_ua"] is False
+        assert verdicts["header_coherence"] is False
+        assert verdicts["direct_request"] is False
+
+    def test_real_browser_with_full_context_passes_all_passive_metrics(self, app):
+        with TestClient(app) as client:
+            r = client.get(
+                "/whoami",
+                headers={
+                    "user-agent": "Mozilla/5.0 ... Chrome/120.0",
+                    "sec-fetch-site": "same-origin",
+                    "sec-fetch-mode": "navigate",
+                    "sec-fetch-dest": "document",
+                    "sec-ch-ua": '"Chrome";v="120"',
+                    "accept-language": "en-US",
+                    "referer": "https://example.com/",
+                    "cookie": "session=abc",
+                },
+            )
+        body = r.json()
+        assert body["verdict"] is True
+        verdicts = body["metric_verdicts"]
+        assert verdicts["headless_ua"] is True
+        assert verdicts["header_coherence"] is True
+        assert verdicts["direct_request"] is True
+
+    def test_compliant_bot_passes_with_robots_aware_signal(self, app, settings):
+        """Visitor that fetches robots.txt + then a deep page WITH valid headers passes."""
+        with TestClient(app) as client:
+            client.get("/robots.txt")
+            # Real-browser-style follow-up.
+            r = client.get(
+                "/whoami",
+                headers={
+                    "user-agent": "Mozilla/5.0 ... Chrome/120.0",
+                    "sec-fetch-site": "same-origin",
+                    "sec-fetch-mode": "navigate",
+                    "sec-fetch-dest": "document",
+                    "sec-ch-ua": '"Chrome";v="120"',
+                    "accept-language": "en-US",
+                    "referer": "https://example.com/",
+                    "cookie": "session=abc",
+                },
+            )
+        body = r.json()
+        assert body["verdict"] is True
+        assert body["metric_verdicts"]["robots_honeypot"] is True
+
+    def test_full_bot_lifecycle_combined(self, app, store, settings):
+        """Bot fetches robots, hits trap, then visits site — verdict aggregates correctly."""
+        with TestClient(app) as client:
+            client.get("/robots.txt")
+            r = client.get("/private-area/whatever")
+            assert r.status_code == 404
+            r = client.get(
+                "/whoami", headers={"user-agent": "BadBot/1.0"}
+            )
+        body = r.json()
+        # Multiple metrics now agree on False.
+        assert body["verdict"] is False
+        verdicts = body["metric_verdicts"]
+        assert verdicts["robots_honeypot"] is False
+        assert verdicts["direct_request"] is False  # no Referer
+
+    def test_browser_renders_pixel_then_passes_pixel_metric(
+        self, app, store, settings
+    ):
+        with TestClient(app) as client:
+            token, sig = make_pixel_token(settings.secret_key)
+            client.get(f"/_bot/p.gif?t={token}&s={sig}")
+            r = client.get(
+                "/whoami",
+                headers={
+                    "user-agent": "Mozilla/5.0 ... Chrome/120.0",
+                    "sec-fetch-site": "same-origin",
+                    "sec-fetch-mode": "navigate",
+                    "sec-fetch-dest": "document",
+                    "sec-ch-ua": '"Chrome";v="120"',
+                    "accept-language": "en-US",
+                    "referer": "https://example.com/",
+                    "cookie": "session=abc",
+                },
+            )
+        body = r.json()
+        assert body["metric_verdicts"]["pixel_beacon"] is True
+        assert body["verdict"] is True

--- a/tests/bot_detection/test_js_challenge.py
+++ b/tests/bot_detection/test_js_challenge.py
@@ -1,0 +1,158 @@
+"""Tests for the JS challenge — token signing, indicator scoring, metric."""
+
+import pytest
+
+from skrift.bot_detection.challenge import (
+    JS_CHALLENGE_NS,
+    evaluate_indicators,
+    make_challenge_token,
+    render_challenge_tag,
+    verify_challenge_token,
+)
+from skrift.bot_detection.config import BotDetectionConfig
+from skrift.bot_detection.metrics.js_challenge import JSChallengeMetric
+from skrift.bot_detection.store import InMemoryBotStateStore
+
+
+class TestChallengeToken:
+    def test_round_trip(self):
+        token, sig = make_challenge_token("secret")
+        assert verify_challenge_token("secret", token, sig) is True
+
+    def test_pixel_token_does_not_verify_at_challenge(self):
+        from skrift.bot_detection.beacon import make_pixel_token
+
+        token, sig = make_pixel_token("secret")
+        # Different namespace -> challenge verifier rejects pixel signatures.
+        assert verify_challenge_token("secret", token, sig) is False
+
+    def test_wrong_secret_fails(self):
+        token, sig = make_challenge_token("secret-a")
+        assert verify_challenge_token("secret-b", token, sig) is False
+
+    def test_each_token_is_unique(self):
+        t1, _ = make_challenge_token("secret")
+        t2, _ = make_challenge_token("secret")
+        assert t1 != t2
+
+
+class TestEvaluateIndicators:
+    def _good(self, **overrides):
+        baseline = {
+            "webdriver": False,
+            "plugins": 3,
+            "languages": 2,
+            "chrome": True,
+            "canvas": 100,
+            "timing": 500,
+        }
+        baseline.update(overrides)
+        return baseline
+
+    def test_passes_for_good_indicators(self):
+        verdict = evaluate_indicators(
+            self._good(), "Mozilla/5.0 ... Chrome/120.0"
+        )
+        assert verdict.passed is True
+
+    def test_fails_when_webdriver_true(self):
+        verdict = evaluate_indicators(
+            self._good(webdriver=True), "Mozilla/5.0 ... Chrome/120.0"
+        )
+        assert verdict.passed is False
+        assert "webdriver" in verdict.reason
+
+    def test_fails_when_canvas_unavailable(self):
+        verdict = evaluate_indicators(
+            self._good(canvas=-1), "Mozilla/5.0 ... Chrome/120.0"
+        )
+        assert verdict.passed is False
+        assert "canvas" in verdict.reason
+
+    def test_fails_chromium_ua_without_window_chrome(self):
+        verdict = evaluate_indicators(
+            self._good(chrome=False), "Mozilla/5.0 ... Chrome/120.0"
+        )
+        assert verdict.passed is False
+        assert "Chromium" in verdict.reason
+
+    def test_passes_firefox_without_window_chrome(self):
+        verdict = evaluate_indicators(
+            self._good(chrome=False),
+            "Mozilla/5.0 (X11) Gecko/20100101 Firefox/120.0",
+        )
+        assert verdict.passed is True
+
+    def test_no_user_agent_does_not_crash(self):
+        verdict = evaluate_indicators(self._good(), None)
+        assert verdict.passed is True
+
+
+class TestRenderChallengeTag:
+    def test_includes_token_and_signature(self):
+        html = str(render_challenge_tag("token-abc", "sig-xyz"))
+        assert 'data-token="token-abc"' in html
+        assert 'data-signature="sig-xyz"' in html
+        assert "/static/bot_detection/challenge.js" in html
+
+    def test_includes_nonce_when_provided(self):
+        html = str(render_challenge_tag("t", "s", csp_nonce="abc123"))
+        assert 'nonce="abc123"' in html
+
+    def test_omits_nonce_when_empty(self):
+        html = str(render_challenge_tag("t", "s", csp_nonce=""))
+        assert "nonce=" not in html
+
+
+class TestJSChallengeMetric:
+    @pytest.mark.asyncio
+    async def test_inconclusive_when_no_record(self):
+        metric = JSChallengeMetric(
+            BotDetectionConfig(js_challenge={"enabled": True})
+        )
+        result = await metric.check(_scope("1.2.3.4"), InMemoryBotStateStore())
+        assert result.verdict is None
+        assert result.signals["passed"].passed is None
+
+    @pytest.mark.asyncio
+    async def test_passes_when_pass_recorded(self):
+        metric = JSChallengeMetric(
+            BotDetectionConfig(js_challenge={"enabled": True})
+        )
+        store = InMemoryBotStateStore()
+        await store.set(JS_CHALLENGE_NS, "1.2.3.4", "pass", ttl=3600)
+        result = await metric.check(_scope("1.2.3.4"), store)
+        assert result.verdict is True
+        assert result.signals["passed"].passed is True
+
+    @pytest.mark.asyncio
+    async def test_fails_when_fail_recorded(self):
+        metric = JSChallengeMetric(
+            BotDetectionConfig(js_challenge={"enabled": True})
+        )
+        store = InMemoryBotStateStore()
+        await store.set(
+            JS_CHALLENGE_NS, "1.2.3.4", "fail:navigator.webdriver = true",
+            ttl=3600,
+        )
+        result = await metric.check(_scope("1.2.3.4"), store)
+        assert result.verdict is False
+        assert result.signals["passed"].passed is False
+        assert "webdriver" in (result.signals["passed"].detail or "")
+
+    @pytest.mark.asyncio
+    async def test_disabled_metric_reports_disabled(self):
+        config = BotDetectionConfig(js_challenge={"enabled": False})
+        metric = JSChallengeMetric(config)
+        assert metric.enabled is False
+
+
+def _scope(ip: str):
+    return {
+        "type": "http",
+        "method": "GET",
+        "path": "/page",
+        "headers": [],
+        "client": ("0.0.0.0", 0),
+        "state": {"client_ip": ip},
+    }

--- a/tests/bot_detection/test_metrics_passive.py
+++ b/tests/bot_detection/test_metrics_passive.py
@@ -1,0 +1,237 @@
+"""Tests for the passive (header-only) bot detection metrics."""
+
+import pytest
+
+from skrift.bot_detection.config import BotDetectionConfig
+from skrift.bot_detection.metrics.direct_request import DirectRequestMetric
+from skrift.bot_detection.metrics.header_coherence import HeaderCoherenceMetric
+from skrift.bot_detection.metrics.headless_ua import HeadlessUAMetric
+from skrift.bot_detection.store import InMemoryBotStateStore
+
+
+def make_scope(path="/page", headers=None):
+    return {
+        "type": "http",
+        "method": "GET",
+        "path": path,
+        "headers": [(k.encode(), v.encode()) for k, v in (headers or {}).items()],
+        "client": ("127.0.0.1", 0),
+        "state": {},
+    }
+
+
+@pytest.fixture
+def store():
+    return InMemoryBotStateStore()
+
+
+class TestHeadlessUAMetric:
+    @pytest.mark.asyncio
+    async def test_passes_for_real_chrome(self, store):
+        metric = HeadlessUAMetric(BotDetectionConfig())
+        scope = make_scope(headers={"user-agent": "Mozilla/5.0 ... Chrome/120.0"})
+        result = await metric.check(scope, store)
+        assert result.verdict is True
+        assert result.signals["ua_present"].passed is True
+        assert result.signals["puppeteer"].passed is True
+        assert result.signals["headless_chrome"].passed is True
+
+    @pytest.mark.asyncio
+    async def test_fails_for_puppeteer_ua(self, store):
+        metric = HeadlessUAMetric(BotDetectionConfig())
+        scope = make_scope(
+            headers={"user-agent": "Mozilla/5.0 ... Chrome/120.0 Puppeteer/1.0"}
+        )
+        result = await metric.check(scope, store)
+        assert result.verdict is False
+        assert result.signals["puppeteer"].passed is False
+        assert "Puppeteer" in (result.signals["puppeteer"].detail or "")
+
+    @pytest.mark.asyncio
+    async def test_fails_for_headless_chrome(self, store):
+        metric = HeadlessUAMetric(BotDetectionConfig())
+        scope = make_scope(
+            headers={"user-agent": "Mozilla/5.0 (X11) HeadlessChrome/120.0"}
+        )
+        result = await metric.check(scope, store)
+        assert result.verdict is False
+        assert result.signals["headless_chrome"].passed is False
+
+    @pytest.mark.asyncio
+    async def test_fails_when_ua_missing(self, store):
+        metric = HeadlessUAMetric(BotDetectionConfig())
+        scope = make_scope()  # no UA
+        result = await metric.check(scope, store)
+        assert result.verdict is False
+        assert result.signals["ua_present"].passed is False
+
+    @pytest.mark.asyncio
+    async def test_match_is_case_insensitive(self, store):
+        metric = HeadlessUAMetric(BotDetectionConfig())
+        scope = make_scope(headers={"user-agent": "headlesschrome/119"})
+        result = await metric.check(scope, store)
+        assert result.signals["headless_chrome"].passed is False
+
+    @pytest.mark.asyncio
+    async def test_custom_pattern_via_config(self, store):
+        metric = HeadlessUAMetric(
+            BotDetectionConfig(headless_ua={"patterns": ["MyBot"]})
+        )
+        scope = make_scope(headers={"user-agent": "MyBot/1.0"})
+        result = await metric.check(scope, store)
+        assert result.verdict is False
+        # Slug decamelizes: "MyBot" -> "my_bot".
+        assert result.signals["my_bot"].passed is False
+
+
+class TestHeaderCoherenceMetric:
+    @pytest.mark.asyncio
+    async def test_passes_for_chromium_with_full_headers(self, store):
+        metric = HeaderCoherenceMetric(BotDetectionConfig())
+        scope = make_scope(
+            headers={
+                "user-agent": "Mozilla/5.0 ... Chrome/120.0",
+                "sec-fetch-site": "same-origin",
+                "sec-fetch-mode": "navigate",
+                "sec-fetch-dest": "document",
+                "sec-ch-ua": '"Chrome";v="120"',
+                "accept-language": "en-US",
+            }
+        )
+        result = await metric.check(scope, store)
+        assert result.verdict is True
+        assert result.signals["claims_modern_chromium"].passed is True
+        assert result.signals["sec_fetch_site"].passed is True
+
+    @pytest.mark.asyncio
+    async def test_fails_chromium_missing_sec_fetch(self, store):
+        metric = HeaderCoherenceMetric(BotDetectionConfig())
+        scope = make_scope(
+            headers={
+                "user-agent": "Mozilla/5.0 ... Chrome/120.0",
+                "accept-language": "en-US",
+            }
+        )
+        result = await metric.check(scope, store)
+        assert result.verdict is False
+        assert result.signals["sec_fetch_site"].passed is False
+        assert result.signals["sec_fetch_mode"].passed is False
+
+    @pytest.mark.asyncio
+    async def test_inconclusive_for_non_chromium(self, store):
+        """Firefox UAs legitimately lack Sec-Fetch headers in older versions."""
+        metric = HeaderCoherenceMetric(BotDetectionConfig())
+        scope = make_scope(
+            headers={"user-agent": "Mozilla/5.0 (X11) Gecko/20100101 Firefox/120.0"}
+        )
+        result = await metric.check(scope, store)
+        # No signal explicitly fails — verdict is None or True depending on
+        # the claims_modern_chromium signal.
+        assert result.verdict is None
+        assert result.signals["sec_fetch_site"].passed is None
+
+    @pytest.mark.asyncio
+    async def test_fails_chromium_missing_accept_language(self, store):
+        metric = HeaderCoherenceMetric(BotDetectionConfig())
+        scope = make_scope(
+            headers={
+                "user-agent": "Mozilla/5.0 ... Chrome/120.0",
+                "sec-fetch-site": "same-origin",
+                "sec-fetch-mode": "navigate",
+                "sec-fetch-dest": "document",
+                "sec-ch-ua": '"Chrome";v="120"',
+            }
+        )
+        result = await metric.check(scope, store)
+        assert result.signals["accept_language"].passed is False
+
+    @pytest.mark.asyncio
+    async def test_old_chrome_does_not_trigger_modern_check(self, store):
+        metric = HeaderCoherenceMetric(BotDetectionConfig())
+        scope = make_scope(
+            headers={"user-agent": "Mozilla/5.0 ... Chrome/50.0"}
+        )
+        result = await metric.check(scope, store)
+        assert result.signals["claims_modern_chromium"].passed is None
+
+
+class TestDirectRequestMetric:
+    @pytest.mark.asyncio
+    async def test_passes_for_navigated_request(self, store):
+        metric = DirectRequestMetric(BotDetectionConfig())
+        scope = make_scope(
+            "/page",
+            headers={
+                "referer": "https://example.com/",
+                "cookie": "session=abc123",
+                "sec-fetch-site": "same-origin",
+            },
+        )
+        result = await metric.check(scope, store)
+        assert result.verdict is True
+
+    @pytest.mark.asyncio
+    async def test_fails_for_curl_to_deep_url(self, store):
+        metric = DirectRequestMetric(BotDetectionConfig())
+        scope = make_scope("/api/sensitive", headers={"user-agent": "curl/8.0"})
+        result = await metric.check(scope, store)
+        assert result.verdict is False
+        assert result.signals["referer"].passed is False
+
+    @pytest.mark.asyncio
+    async def test_root_path_with_no_referer_is_ok(self, store):
+        metric = DirectRequestMetric(BotDetectionConfig())
+        scope = make_scope("/")
+        result = await metric.check(scope, store)
+        # All three signals should be inconclusive for a bare root visit.
+        assert result.signals["referer"].passed is None
+        assert result.signals["session_cookie"].passed is None
+        assert result.signals["sec_fetch_site"].passed is None
+        assert result.verdict is None
+
+    @pytest.mark.asyncio
+    async def test_sec_fetch_site_none_on_deep_url_fails(self, store):
+        metric = DirectRequestMetric(BotDetectionConfig())
+        scope = make_scope("/page", headers={"sec-fetch-site": "none"})
+        result = await metric.check(scope, store)
+        assert result.signals["sec_fetch_site"].passed is False
+
+    @pytest.mark.asyncio
+    async def test_session_cookie_passes(self, store):
+        metric = DirectRequestMetric(BotDetectionConfig())
+        scope = make_scope("/page", headers={"cookie": "foo=bar; session=xyz"})
+        result = await metric.check(scope, store)
+        assert result.signals["session_cookie"].passed is True
+
+
+class TestMetricRegistration:
+    def test_builtin_metrics_includes_all_three_passives(self):
+        from skrift.bot_detection.metrics import BUILTIN_METRICS
+
+        names = {m.name for m in BUILTIN_METRICS}
+        assert {"headless_ua", "header_coherence", "direct_request"} <= names
+
+    @pytest.mark.asyncio
+    async def test_factory_builds_enabled_metrics(self):
+        from skrift.bot_detection.factory import build_initial_metrics
+
+        config = BotDetectionConfig(enabled=True)
+        metrics = build_initial_metrics(config)
+        names = {m.name for m in metrics}
+        assert {
+            "headless_ua",
+            "header_coherence",
+            "direct_request",
+            "robots_honeypot",
+        } <= names
+
+    @pytest.mark.asyncio
+    async def test_factory_skips_disabled_metrics(self):
+        from skrift.bot_detection.factory import build_initial_metrics
+
+        config = BotDetectionConfig(
+            enabled=True,
+            headless_ua={"enabled": False},
+        )
+        metrics = build_initial_metrics(config)
+        assert "headless_ua" not in {m.name for m in metrics}

--- a/tests/bot_detection/test_middleware.py
+++ b/tests/bot_detection/test_middleware.py
@@ -1,0 +1,264 @@
+"""Tests for the BotDetectionMiddleware ASGI behaviour."""
+
+from dataclasses import dataclass, field
+
+import pytest
+
+from skrift.bot_detection.config import BotDetectionConfig
+from skrift.bot_detection.hooks import BOT_DETECTED, BOT_DETECTION_RESULT
+from skrift.bot_detection.middleware import BotDetectionMiddleware
+from skrift.bot_detection.store import InMemoryBotStateStore
+from skrift.bot_detection.types import BotDetectionResult, MetricResult, Signal
+from skrift.lib.hooks import hooks
+
+
+@dataclass
+class FakeMetric:
+    name: str
+    enabled: bool = True
+    result: MetricResult = field(
+        default_factory=lambda: MetricResult("fake", True, {})
+    )
+
+    async def check(self, scope, store):
+        return self.result
+
+
+@dataclass
+class CrashingMetric:
+    name: str = "crash"
+    enabled: bool = True
+
+    async def check(self, scope, store):
+        raise RuntimeError("metric exploded")
+
+
+def make_inner_app(captured):
+    async def app(scope, receive, send):
+        captured["scope"] = scope
+        await send({"type": "http.response.start", "status": 200, "headers": []})
+        await send({"type": "http.response.body", "body": b""})
+
+    return app
+
+
+def make_send():
+    async def send(message):
+        return None
+
+    return send
+
+
+def make_scope(path="/page", headers=None):
+    return {
+        "type": "http",
+        "method": "GET",
+        "path": path,
+        "headers": headers or [],
+        "client": ("127.0.0.1", 0),
+        "state": {},
+    }
+
+
+@pytest.fixture(autouse=True)
+def clean_hooks_each_test():
+    hooks._actions.clear()
+    hooks._filters.clear()
+    yield
+    hooks._actions.clear()
+    hooks._filters.clear()
+
+
+class TestBotDetectionMiddleware:
+    @pytest.mark.asyncio
+    async def test_disabled_config_passes_through(self):
+        captured = {}
+        config = BotDetectionConfig(enabled=False)
+        middleware = BotDetectionMiddleware(
+            make_inner_app(captured), config, InMemoryBotStateStore(), []
+        )
+        scope = make_scope()
+        await middleware(scope, None, make_send())
+        assert captured["scope"]["state"].get("bot_detection") is None
+
+    @pytest.mark.asyncio
+    async def test_websocket_passes_through(self):
+        captured = {}
+        config = BotDetectionConfig(enabled=True)
+        middleware = BotDetectionMiddleware(
+            make_inner_app(captured), config, InMemoryBotStateStore(), []
+        )
+        scope = {
+            "type": "websocket",
+            "path": "/ws",
+            "headers": [],
+            "client": ("127.0.0.1", 0),
+            "state": {},
+        }
+        await middleware(scope, None, make_send())
+        assert captured["scope"]["state"].get("bot_detection") is None
+
+    @pytest.mark.asyncio
+    async def test_skip_paths_short_circuit(self):
+        captured = {}
+        config = BotDetectionConfig(enabled=True, skip_paths=["/static/"])
+        middleware = BotDetectionMiddleware(
+            make_inner_app(captured), config, InMemoryBotStateStore(),
+            [FakeMetric("never_runs")],
+        )
+        scope = make_scope("/static/foo.css")
+        await middleware(scope, None, make_send())
+        assert "bot_detection" not in captured["scope"]["state"]
+
+    @pytest.mark.asyncio
+    async def test_legitimate_bot_ua_short_circuits_with_pass(self):
+        captured = {}
+        config = BotDetectionConfig(
+            enabled=True, legitimate_bot_uas=["Googlebot"]
+        )
+        # Even with a metric that would say False, Googlebot should pass.
+        failing = FakeMetric(
+            "headless_ua",
+            result=MetricResult("headless_ua", False, {"x": Signal(False)}),
+        )
+        middleware = BotDetectionMiddleware(
+            make_inner_app(captured), config, InMemoryBotStateStore(), [failing]
+        )
+        scope = make_scope(
+            headers=[(b"user-agent", b"Mozilla/5.0 (compatible; Googlebot/2.1)")]
+        )
+        await middleware(scope, None, make_send())
+        result = captured["scope"]["state"]["bot_detection"]
+        assert result.verdict is True
+        assert result.metrics == {}
+
+    @pytest.mark.asyncio
+    async def test_empty_metric_list_yields_inconclusive_verdict(self):
+        captured = {}
+        config = BotDetectionConfig(enabled=True)
+        middleware = BotDetectionMiddleware(
+            make_inner_app(captured), config, InMemoryBotStateStore(), []
+        )
+        await middleware(make_scope(), None, make_send())
+        result = captured["scope"]["state"]["bot_detection"]
+        assert result.verdict is None
+        assert result.metrics == {}
+
+    @pytest.mark.asyncio
+    async def test_failing_metric_drives_verdict_false(self):
+        captured = {}
+        config = BotDetectionConfig(enabled=True)
+        failing = FakeMetric(
+            "headless_ua",
+            result=MetricResult(
+                "headless_ua", False, {"puppeteer": Signal(False, "ua")}
+            ),
+        )
+        passing = FakeMetric(
+            "direct_request",
+            result=MetricResult("direct_request", True, {"ok": Signal(True)}),
+        )
+        middleware = BotDetectionMiddleware(
+            make_inner_app(captured), config, InMemoryBotStateStore(),
+            [failing, passing],
+        )
+        await middleware(make_scope(), None, make_send())
+        result = captured["scope"]["state"]["bot_detection"]
+        assert result.verdict is False
+        assert result.metrics["headless_ua"].verdict is False
+        assert result.metrics["direct_request"].verdict is True
+
+    @pytest.mark.asyncio
+    async def test_bot_detected_action_fires_only_on_failure(self):
+        captured = {}
+        called = []
+
+        async def on_detected(scope, result):
+            called.append(result)
+
+        hooks.add_action(BOT_DETECTED, on_detected)
+
+        config = BotDetectionConfig(enabled=True)
+        failing = FakeMetric(
+            "headless_ua",
+            result=MetricResult("headless_ua", False, {"x": Signal(False)}),
+        )
+        middleware = BotDetectionMiddleware(
+            make_inner_app(captured), config, InMemoryBotStateStore(), [failing]
+        )
+        await middleware(make_scope(), None, make_send())
+        assert len(called) == 1
+        assert called[0].verdict is False
+
+    @pytest.mark.asyncio
+    async def test_bot_detected_action_does_not_fire_on_pass(self):
+        captured = {}
+        called = []
+
+        async def on_detected(scope, result):
+            called.append(result)
+
+        hooks.add_action(BOT_DETECTED, on_detected)
+
+        config = BotDetectionConfig(enabled=True)
+        passing = FakeMetric(
+            "ok", result=MetricResult("ok", True, {"x": Signal(True)})
+        )
+        middleware = BotDetectionMiddleware(
+            make_inner_app(captured), config, InMemoryBotStateStore(), [passing]
+        )
+        await middleware(make_scope(), None, make_send())
+        assert called == []
+
+    @pytest.mark.asyncio
+    async def test_result_filter_can_override_verdict(self):
+        captured = {}
+
+        async def force_pass(result, scope):
+            return BotDetectionResult(verdict=True, metrics=result.metrics)
+
+        hooks.add_filter(BOT_DETECTION_RESULT, force_pass)
+
+        config = BotDetectionConfig(enabled=True)
+        failing = FakeMetric(
+            "x", result=MetricResult("x", False, {"a": Signal(False)})
+        )
+        middleware = BotDetectionMiddleware(
+            make_inner_app(captured), config, InMemoryBotStateStore(), [failing]
+        )
+        await middleware(make_scope(), None, make_send())
+        result = captured["scope"]["state"]["bot_detection"]
+        assert result.verdict is True
+
+    @pytest.mark.asyncio
+    async def test_metric_exception_does_not_crash_middleware(self):
+        captured = {}
+        config = BotDetectionConfig(enabled=True)
+        passing = FakeMetric(
+            "ok", result=MetricResult("ok", True, {"x": Signal(True)})
+        )
+        middleware = BotDetectionMiddleware(
+            make_inner_app(captured), config, InMemoryBotStateStore(),
+            [CrashingMetric(), passing],
+        )
+        await middleware(make_scope(), None, make_send())
+        result = captured["scope"]["state"]["bot_detection"]
+        # Crashing metric is dropped; only ok remains.
+        assert "crash" not in result.metrics
+        assert "ok" in result.metrics
+
+    @pytest.mark.asyncio
+    async def test_disabled_metric_is_skipped(self):
+        captured = {}
+        config = BotDetectionConfig(enabled=True)
+        disabled = FakeMetric(
+            "disabled",
+            enabled=False,
+            result=MetricResult("disabled", False, {"x": Signal(False)}),
+        )
+        middleware = BotDetectionMiddleware(
+            make_inner_app(captured), config, InMemoryBotStateStore(), [disabled]
+        )
+        await middleware(make_scope(), None, make_send())
+        result = captured["scope"]["state"]["bot_detection"]
+        assert "disabled" not in result.metrics

--- a/tests/bot_detection/test_pixel_beacon.py
+++ b/tests/bot_detection/test_pixel_beacon.py
@@ -1,0 +1,100 @@
+"""Tests for the pixel beacon — token signing, metric, and template helper."""
+
+import pytest
+
+from skrift.bot_detection.beacon import (
+    PIXEL_LOADED_NS,
+    make_pixel_token,
+    render_pixel_tag,
+    verify_pixel_token,
+)
+from skrift.bot_detection.config import BotDetectionConfig
+from skrift.bot_detection.metrics.pixel_beacon import PixelBeaconMetric
+from skrift.bot_detection.store import InMemoryBotStateStore
+
+
+class TestPixelToken:
+    def test_round_trip_verification(self):
+        token, sig = make_pixel_token("secret")
+        assert verify_pixel_token("secret", token, sig) is True
+
+    def test_wrong_secret_fails(self):
+        token, sig = make_pixel_token("secret-a")
+        assert verify_pixel_token("secret-b", token, sig) is False
+
+    def test_tampered_token_fails(self):
+        token, sig = make_pixel_token("secret")
+        tampered = token[:-1] + ("A" if token[-1] != "A" else "B")
+        assert verify_pixel_token("secret", tampered, sig) is False
+
+    def test_empty_token_fails(self):
+        assert verify_pixel_token("secret", "", "") is False
+
+    def test_each_token_is_unique(self):
+        t1, _ = make_pixel_token("secret")
+        t2, _ = make_pixel_token("secret")
+        assert t1 != t2
+
+
+class TestRenderPixelTag:
+    def test_outputs_img_tag_with_token_and_signature(self):
+        html = str(render_pixel_tag("token-abc", "sig-xyz"))
+        assert '<img ' in html
+        assert "/_bot/p.gif?t=token-abc&s=sig-xyz" in html
+        assert 'aria-hidden="true"' in html
+
+    def test_css_beacon_includes_both_tags(self):
+        html = str(render_pixel_tag("token", "sig", css_beacon=True))
+        assert "/_bot/p.gif" in html
+        assert "/_bot/c.gif" in html
+
+    def test_no_css_beacon_omits_css(self):
+        html = str(render_pixel_tag("token", "sig", css_beacon=False))
+        assert "/_bot/c.gif" not in html
+
+
+class TestPixelBeaconMetric:
+    @pytest.mark.asyncio
+    async def test_inconclusive_when_no_pixel_loaded(self):
+        metric = PixelBeaconMetric(BotDetectionConfig())
+        store = InMemoryBotStateStore()
+        scope = _scope("1.2.3.4")
+        result = await metric.check(scope, store)
+        assert result.verdict is None
+        assert result.signals["loaded"].passed is None
+
+    @pytest.mark.asyncio
+    async def test_passes_when_pixel_recorded(self):
+        metric = PixelBeaconMetric(BotDetectionConfig())
+        store = InMemoryBotStateStore()
+        await store.set(PIXEL_LOADED_NS, "1.2.3.4", "pixel", ttl=3600)
+        result = await metric.check(_scope("1.2.3.4"), store)
+        assert result.verdict is True
+        assert result.signals["loaded"].passed is True
+        assert "pixel" in (result.signals["loaded"].detail or "")
+
+    @pytest.mark.asyncio
+    async def test_passes_when_css_beacon_recorded(self):
+        metric = PixelBeaconMetric(BotDetectionConfig())
+        store = InMemoryBotStateStore()
+        await store.set(PIXEL_LOADED_NS, "1.2.3.4", "css", ttl=3600)
+        result = await metric.check(_scope("1.2.3.4"), store)
+        assert result.verdict is True
+        assert "css" in (result.signals["loaded"].detail or "")
+
+    @pytest.mark.asyncio
+    async def test_disabled_metric_does_not_run(self):
+        config = BotDetectionConfig(pixel_beacon={"enabled": False})
+        metric = PixelBeaconMetric(config)
+        assert metric.enabled is False
+
+
+def _scope(ip: str):
+    return {
+        "type": "http",
+        "method": "GET",
+        "path": "/page",
+        "headers": [],
+        "client": ("0.0.0.0", 0),
+        "state": {"client_ip": ip},
+    }

--- a/tests/bot_detection/test_pixel_controller.py
+++ b/tests/bot_detection/test_pixel_controller.py
@@ -1,0 +1,112 @@
+"""Integration tests for the BotDetectionController pixel endpoints."""
+
+import pytest
+from litestar import Litestar
+from litestar.testing import TestClient
+
+from skrift.bot_detection.beacon import (
+    PIXEL_LOADED_NS,
+    make_pixel_token,
+)
+from skrift.bot_detection.controllers import BotDetectionController
+from skrift.bot_detection.store import InMemoryBotStateStore
+from skrift.bot_detection.hooks import BOT_PIXEL_LOADED
+from skrift.lib.hooks import hooks
+
+
+@pytest.fixture(autouse=True)
+def clean_hooks():
+    hooks._actions.clear()
+    hooks._filters.clear()
+    yield
+    hooks._actions.clear()
+    hooks._filters.clear()
+
+
+@pytest.fixture
+def app_with_pixel(tmp_path, monkeypatch):
+    """Build a Litestar app with the bot detection controller wired up.
+
+    Patches ``get_settings`` to return a minimal Settings with
+    ``bot_detection.enabled=True`` and a known secret, and stashes the
+    store on app state.
+    """
+    from skrift.bot_detection.config import BotDetectionConfig
+    from skrift.config import Settings
+
+    store = InMemoryBotStateStore()
+    settings = Settings(
+        secret_key="test-secret",
+        bot_detection=BotDetectionConfig(enabled=True),
+    )
+    monkeypatch.setattr(
+        "skrift.config.get_settings", lambda: settings
+    )
+
+    app = Litestar(route_handlers=[BotDetectionController])
+    app.state.bot_detection_store = store
+    return app, store, settings
+
+
+class TestPixelEndpoint:
+    def test_returns_gif_with_no_cache_headers(self, app_with_pixel):
+        app, _, settings = app_with_pixel
+        token, sig = make_pixel_token(settings.secret_key)
+        with TestClient(app) as client:
+            response = client.get(f"/_bot/p.gif?t={token}&s={sig}")
+        assert response.status_code == 200
+        assert response.headers["content-type"] == "image/gif"
+        assert response.content[:3] == b"GIF"
+        assert "no-store" in response.headers.get("cache-control", "")
+
+    def test_records_load_with_valid_token(self, app_with_pixel):
+        app, store, settings = app_with_pixel
+        token, sig = make_pixel_token(settings.secret_key)
+        with TestClient(app) as client:
+            response = client.get(f"/_bot/p.gif?t={token}&s={sig}")
+        assert response.status_code == 200
+
+        # Synchronous check via the in-memory store.
+        import asyncio
+
+        loaded = asyncio.run(store.get(PIXEL_LOADED_NS, "testclient"))
+        assert loaded == "pixel"
+
+    def test_invalid_token_does_not_record(self, app_with_pixel):
+        app, store, _ = app_with_pixel
+        with TestClient(app) as client:
+            response = client.get("/_bot/p.gif?t=fake&s=fake")
+        assert response.status_code == 200
+
+        import asyncio
+        loaded = asyncio.run(store.get(PIXEL_LOADED_NS, "testclient"))
+        assert loaded is None
+
+    def test_css_beacon_records_separately(self, app_with_pixel):
+        app, store, settings = app_with_pixel
+        token, sig = make_pixel_token(settings.secret_key)
+        with TestClient(app) as client:
+            response = client.get(f"/_bot/c.gif?t={token}&s={sig}")
+        assert response.status_code == 200
+
+        import asyncio
+        loaded = asyncio.run(store.get(PIXEL_LOADED_NS, "testclient"))
+        assert loaded == "css"
+
+    def test_pixel_load_fires_action(self, app_with_pixel):
+        captured = []
+
+        async def on_load(scope, ip, token):
+            captured.append((ip, token))
+
+        hooks.add_action(BOT_PIXEL_LOADED, on_load)
+
+        app, _, settings = app_with_pixel
+        token, sig = make_pixel_token(settings.secret_key)
+        with TestClient(app) as client:
+            client.get(f"/_bot/p.gif?t={token}&s={sig}")
+
+        assert len(captured) == 1
+        ip, recorded_token = captured[0]
+        assert ip == "testclient"
+        assert recorded_token == token

--- a/tests/bot_detection/test_redis_store.py
+++ b/tests/bot_detection/test_redis_store.py
@@ -1,0 +1,132 @@
+"""Tests for the Redis-backed bot state store.
+
+Uses a small fake Redis client that implements just the methods we
+call (``get``, ``set`` with ``ex=``, ``delete``). Avoids a live Redis
+dependency in unit tests but verifies the wiring: prefixing,
+namespacing, byte/string round-trip, TTL passthrough.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from skrift.bot_detection.store import RedisBotStateStore
+
+
+class FakeRedis:
+    """Minimal in-memory stand-in for redis.asyncio.Redis."""
+
+    def __init__(self) -> None:
+        self.store: dict[str, bytes] = {}
+        self.ttls: dict[str, int] = {}
+        self.calls: list[tuple[str, ...]] = []
+
+    async def get(self, key: str) -> Any:
+        self.calls.append(("get", key))
+        return self.store.get(key)
+
+    async def set(
+        self, key: str, value: str, ex: int | None = None
+    ) -> None:
+        self.calls.append(("set", key, value, str(ex)))
+        self.store[key] = value.encode() if isinstance(value, str) else value
+        if ex is not None:
+            self.ttls[key] = ex
+
+    async def delete(self, key: str) -> None:
+        self.calls.append(("delete", key))
+        self.store.pop(key, None)
+        self.ttls.pop(key, None)
+
+
+class TestRedisBotStateStore:
+    @pytest.mark.asyncio
+    async def test_set_uses_full_key_with_prefix(self):
+        client = FakeRedis()
+        store = RedisBotStateStore(client, prefix="myapp:bd")
+        await store.set("trap_hit", "1.2.3.4", "/path", ttl=600)
+        assert ("set", "myapp:bd:trap_hit:1.2.3.4", "/path", "600") in client.calls
+
+    @pytest.mark.asyncio
+    async def test_get_returns_string_value(self):
+        client = FakeRedis()
+        store = RedisBotStateStore(client, prefix="bd")
+        await store.set("ns", "key", "value", ttl=60)
+        assert await store.get("ns", "key") == "value"
+
+    @pytest.mark.asyncio
+    async def test_get_returns_none_for_missing_key(self):
+        client = FakeRedis()
+        store = RedisBotStateStore(client, prefix="bd")
+        assert await store.get("ns", "missing") is None
+
+    @pytest.mark.asyncio
+    async def test_get_decodes_bytes(self):
+        client = FakeRedis()
+        store = RedisBotStateStore(client, prefix="bd")
+        client.store["bd:ns:key"] = b"hello"
+        assert await store.get("ns", "key") == "hello"
+
+    @pytest.mark.asyncio
+    async def test_delete_removes_key(self):
+        client = FakeRedis()
+        store = RedisBotStateStore(client, prefix="bd")
+        await store.set("ns", "key", "v", ttl=60)
+        await store.delete("ns", "key")
+        assert await store.get("ns", "key") is None
+
+    @pytest.mark.asyncio
+    async def test_namespace_isolation(self):
+        client = FakeRedis()
+        store = RedisBotStateStore(client, prefix="bd")
+        await store.set("trap_hit", "1.2.3.4", "/trap", ttl=60)
+        await store.set("pixel_loaded", "1.2.3.4", "pixel", ttl=60)
+        assert await store.get("trap_hit", "1.2.3.4") == "/trap"
+        assert await store.get("pixel_loaded", "1.2.3.4") == "pixel"
+
+    @pytest.mark.asyncio
+    async def test_factory_picks_redis_when_client_provided(self):
+        from skrift.bot_detection.config import BotDetectionConfig
+        from skrift.bot_detection.factory import build_bot_state_store
+        from skrift.config import RedisConfig
+
+        client = FakeRedis()
+        store = build_bot_state_store(
+            BotDetectionConfig(cache_backend="redis"),
+            RedisConfig(prefix="myapp"),
+            redis_client=client,
+        )
+        assert isinstance(store, RedisBotStateStore)
+        await store.set("ns", "key", "v", ttl=10)
+        assert ("set", "myapp:skrift:bot_detection:ns:key", "v", "10") in client.calls
+
+    @pytest.mark.asyncio
+    async def test_factory_falls_back_to_memory_when_redis_missing(self):
+        from skrift.bot_detection.config import BotDetectionConfig
+        from skrift.bot_detection.factory import build_bot_state_store
+        from skrift.bot_detection.store import InMemoryBotStateStore
+        from skrift.config import RedisConfig
+
+        store = build_bot_state_store(
+            BotDetectionConfig(cache_backend="redis"),
+            RedisConfig(),
+            redis_client=None,
+        )
+        assert isinstance(store, InMemoryBotStateStore)
+
+    @pytest.mark.asyncio
+    async def test_factory_picks_memory_when_configured(self):
+        from skrift.bot_detection.config import BotDetectionConfig
+        from skrift.bot_detection.factory import build_bot_state_store
+        from skrift.bot_detection.store import InMemoryBotStateStore
+        from skrift.config import RedisConfig
+
+        client = FakeRedis()
+        store = build_bot_state_store(
+            BotDetectionConfig(cache_backend="memory"),
+            RedisConfig(),
+            redis_client=client,  # provided but ignored
+        )
+        assert isinstance(store, InMemoryBotStateStore)

--- a/tests/bot_detection/test_setup.py
+++ b/tests/bot_detection/test_setup.py
@@ -1,0 +1,76 @@
+"""Tests for the bot_detection setup hooks (ROBOTS_TXT filter, action handler)."""
+
+import pytest
+
+from skrift.bot_detection.config import BotDetectionConfig
+from skrift.bot_detection.honeypot import ROBOTS_READ_NS
+from skrift.bot_detection.setup import setup_honeypot_hooks
+from skrift.bot_detection.store import InMemoryBotStateStore
+from skrift.lib.hooks import ROBOTS_TXT, ROBOTS_TXT_FETCHED, hooks
+
+
+@pytest.fixture(autouse=True)
+def clean_hooks_each_test():
+    hooks._actions.clear()
+    hooks._filters.clear()
+    yield
+    hooks._actions.clear()
+    hooks._filters.clear()
+
+
+class TestSetupHoneypotHooks:
+    @pytest.mark.asyncio
+    async def test_robots_txt_filter_injects_disallow(self):
+        config = BotDetectionConfig(enabled=True)
+        store = InMemoryBotStateStore()
+        setup_honeypot_hooks(config, store, "test-secret")
+
+        original = "User-agent: *\nAllow: /\n\nSitemap: https://example.com/sitemap.xml\n"
+        modified = await hooks.apply_filters(ROBOTS_TXT, original)
+        assert "Disallow: /private-area/" in modified
+
+    @pytest.mark.asyncio
+    async def test_does_nothing_when_component_disabled(self):
+        config = BotDetectionConfig(enabled=False)
+        store = InMemoryBotStateStore()
+        setup_honeypot_hooks(config, store, "test-secret")
+
+        # No filter registered.
+        assert not hooks.has_filter(ROBOTS_TXT)
+        assert not hooks.has_action(ROBOTS_TXT_FETCHED)
+
+    @pytest.mark.asyncio
+    async def test_does_nothing_when_honeypot_disabled(self):
+        config = BotDetectionConfig(
+            enabled=True,
+            robots_honeypot={"enabled": False},
+        )
+        store = InMemoryBotStateStore()
+        setup_honeypot_hooks(config, store, "test-secret")
+
+        assert not hooks.has_filter(ROBOTS_TXT)
+        assert not hooks.has_action(ROBOTS_TXT_FETCHED)
+
+    @pytest.mark.asyncio
+    async def test_robots_fetched_action_records_state(self):
+        config = BotDetectionConfig(enabled=True)
+        store = InMemoryBotStateStore()
+        setup_honeypot_hooks(config, store, "test-secret")
+
+        await hooks.do_action(ROBOTS_TXT_FETCHED, None, "1.2.3.4", "Curl/8")
+        assert await store.get(ROBOTS_READ_NS, "1.2.3.4") == "1"
+
+    @pytest.mark.asyncio
+    async def test_log_robots_fetches_can_be_disabled(self):
+        config = BotDetectionConfig(
+            enabled=True,
+            robots_honeypot={"log_robots_fetches": False},
+        )
+        store = InMemoryBotStateStore()
+        setup_honeypot_hooks(config, store, "test-secret")
+
+        # Filter still registered (we still inject the rule)
+        assert hooks.has_filter(ROBOTS_TXT)
+        # Action registered but should not record when disabled
+        await hooks.do_action(ROBOTS_TXT_FETCHED, None, "1.2.3.4", "Curl/8")
+        assert await store.get(ROBOTS_READ_NS, "1.2.3.4") is None

--- a/tests/bot_detection/test_store.py
+++ b/tests/bot_detection/test_store.py
@@ -1,0 +1,48 @@
+"""Tests for the in-memory bot state store."""
+
+import asyncio
+import time
+
+import pytest
+
+from skrift.bot_detection.store import InMemoryBotStateStore
+
+
+class TestInMemoryBotStateStore:
+    @pytest.mark.asyncio
+    async def test_get_returns_none_for_missing_key(self):
+        store = InMemoryBotStateStore()
+        assert await store.get("ns", "missing") is None
+
+    @pytest.mark.asyncio
+    async def test_set_then_get_round_trip(self):
+        store = InMemoryBotStateStore()
+        await store.set("ns", "key", "value", ttl=60)
+        assert await store.get("ns", "key") == "value"
+
+    @pytest.mark.asyncio
+    async def test_namespace_isolates_keys(self):
+        store = InMemoryBotStateStore()
+        await store.set("ns1", "key", "v1", ttl=60)
+        await store.set("ns2", "key", "v2", ttl=60)
+        assert await store.get("ns1", "key") == "v1"
+        assert await store.get("ns2", "key") == "v2"
+
+    @pytest.mark.asyncio
+    async def test_delete_removes_key(self):
+        store = InMemoryBotStateStore()
+        await store.set("ns", "key", "value", ttl=60)
+        await store.delete("ns", "key")
+        assert await store.get("ns", "key") is None
+
+    @pytest.mark.asyncio
+    async def test_expired_key_returns_none(self, monkeypatch):
+        store = InMemoryBotStateStore()
+        await store.set("ns", "key", "value", ttl=1)
+
+        # Simulate clock advance past TTL.
+        original_monotonic = time.monotonic
+        future = original_monotonic() + 5
+        monkeypatch.setattr(time, "monotonic", lambda: future)
+
+        assert await store.get("ns", "key") is None

--- a/tests/bot_detection/test_trap_intercept.py
+++ b/tests/bot_detection/test_trap_intercept.py
@@ -1,0 +1,81 @@
+"""Tests for the trap-path Controller (build_trap_controller)."""
+
+import asyncio
+
+import pytest
+from litestar import Litestar
+from litestar.testing import TestClient
+
+from skrift.bot_detection.honeypot import TRAP_HIT_NS
+from skrift.bot_detection.hooks import BOT_TRAP_HIT
+from skrift.bot_detection.store import InMemoryBotStateStore
+from skrift.bot_detection.trap_controller import build_trap_controller
+from skrift.lib.hooks import hooks
+
+
+@pytest.fixture(autouse=True)
+def clean_hooks_each_test():
+    hooks._actions.clear()
+    hooks._filters.clear()
+    yield
+    hooks._actions.clear()
+    hooks._filters.clear()
+
+
+@pytest.fixture
+def trap_app():
+    store = InMemoryBotStateStore()
+    controller = build_trap_controller("/private-area", store)
+    app = Litestar(route_handlers=[controller])
+    return app, store
+
+
+class TestTrapController:
+    def test_root_path_returns_404_and_records(self, trap_app):
+        app, store = trap_app
+        with TestClient(app) as client:
+            r = client.get("/private-area")
+        assert r.status_code == 404
+        assert asyncio.run(store.get(TRAP_HIT_NS, "testclient")) == "/private-area"
+
+    def test_token_path_returns_404_and_records(self, trap_app):
+        app, store = trap_app
+        with TestClient(app) as client:
+            r = client.get("/private-area/anything")
+        assert r.status_code == 404
+        assert (
+            asyncio.run(store.get(TRAP_HIT_NS, "testclient"))
+            == "/private-area/anything"
+        )
+
+    def test_action_fires_with_token(self, trap_app):
+        captured = []
+
+        async def on_trap(scope, ip, ua, path):
+            captured.append((ip, ua, path))
+
+        hooks.add_action(BOT_TRAP_HIT, on_trap)
+
+        app, _ = trap_app
+        with TestClient(app) as client:
+            client.get(
+                "/private-area/abc",
+                headers={"user-agent": "BadBot/1.0"},
+            )
+        assert captured == [("testclient", "BadBot/1.0", "/private-area/abc")]
+
+    def test_unrelated_path_does_not_record(self, trap_app):
+        app, store = trap_app
+        with TestClient(app) as client:
+            r = client.get("/somewhere-else")
+        assert r.status_code == 404  # no handler — Litestar's 404
+        assert asyncio.run(store.get(TRAP_HIT_NS, "testclient")) is None
+
+    def test_distinct_subclass_per_call(self):
+        """Two trap controllers can coexist on different paths."""
+        store = InMemoryBotStateStore()
+        c1 = build_trap_controller("/path-a", store)
+        c2 = build_trap_controller("/path-b", store)
+        assert c1 is not c2
+        assert c1.path == "/path-a"
+        assert c2.path == "/path-b"

--- a/tests/bot_detection/test_types.py
+++ b/tests/bot_detection/test_types.py
@@ -1,0 +1,77 @@
+"""Tests for the verdict + signal data types."""
+
+from skrift.bot_detection.types import (
+    BotDetectionResult,
+    MetricResult,
+    Signal,
+    derive_overall_verdict,
+    derive_verdict,
+)
+
+
+class TestDeriveVerdict:
+    def test_empty_signals_is_inconclusive(self):
+        assert derive_verdict({}) is None
+
+    def test_all_inconclusive_signals_is_inconclusive(self):
+        signals = {"a": Signal(None), "b": Signal(None)}
+        assert derive_verdict(signals) is None
+
+    def test_any_failed_signal_fails_verdict(self):
+        signals = {"a": Signal(True), "b": Signal(False), "c": Signal(None)}
+        assert derive_verdict(signals) is False
+
+    def test_all_passing_signals_passes(self):
+        signals = {"a": Signal(True), "b": Signal(True)}
+        assert derive_verdict(signals) is True
+
+    def test_pass_plus_inconclusive_passes(self):
+        signals = {"a": Signal(True), "b": Signal(None)}
+        assert derive_verdict(signals) is True
+
+
+class TestDeriveOverallVerdict:
+    def test_empty_metrics_is_inconclusive(self):
+        assert derive_overall_verdict({}) is None
+
+    def test_any_failed_metric_fails_overall(self):
+        metrics = {
+            "a": MetricResult("a", verdict=True, signals={}),
+            "b": MetricResult("b", verdict=False, signals={}),
+        }
+        assert derive_overall_verdict(metrics) is False
+
+    def test_all_passing_metrics_pass_overall(self):
+        metrics = {
+            "a": MetricResult("a", verdict=True, signals={}),
+            "b": MetricResult("b", verdict=True, signals={}),
+        }
+        assert derive_overall_verdict(metrics) is True
+
+    def test_all_inconclusive_metrics_is_inconclusive(self):
+        metrics = {"a": MetricResult("a", verdict=None, signals={})}
+        assert derive_overall_verdict(metrics) is None
+
+
+class TestSignalAndResultStructures:
+    def test_signal_has_optional_detail(self):
+        s = Signal(False, detail="Puppeteer detected")
+        assert s.passed is False
+        assert s.detail == "Puppeteer detected"
+
+    def test_metric_result_carries_named_signals(self):
+        m = MetricResult(
+            "headless_ua",
+            verdict=False,
+            signals={"puppeteer": Signal(False, "UA contains 'Puppeteer'")},
+        )
+        assert m.name == "headless_ua"
+        assert m.signals["puppeteer"].passed is False
+
+    def test_bot_detection_result_aggregates_metrics(self):
+        result = BotDetectionResult(
+            verdict=False,
+            metrics={"headless_ua": MetricResult("headless_ua", False, {})},
+        )
+        assert result.verdict is False
+        assert "headless_ua" in result.metrics

--- a/tests/bot_detection/test_verify_controller.py
+++ b/tests/bot_detection/test_verify_controller.py
@@ -1,0 +1,141 @@
+"""Integration tests for the JS challenge /_bot/verify endpoint."""
+
+import asyncio
+
+import pytest
+from litestar import Litestar
+from litestar.testing import TestClient
+
+from skrift.bot_detection.challenge import (
+    JS_CHALLENGE_NS,
+    make_challenge_token,
+)
+from skrift.bot_detection.config import BotDetectionConfig
+from skrift.bot_detection.controllers import BotDetectionController
+from skrift.bot_detection.hooks import BOT_CHALLENGE_PASSED
+from skrift.bot_detection.store import InMemoryBotStateStore
+from skrift.lib.hooks import hooks
+
+
+@pytest.fixture(autouse=True)
+def clean_hooks():
+    hooks._actions.clear()
+    hooks._filters.clear()
+    yield
+    hooks._actions.clear()
+    hooks._filters.clear()
+
+
+@pytest.fixture
+def app_with_verify(monkeypatch):
+    """Litestar app with the controller wired and a known challenge config."""
+    from skrift.config import Settings
+
+    store = InMemoryBotStateStore()
+    settings = Settings(
+        secret_key="test-secret",
+        bot_detection=BotDetectionConfig(
+            enabled=True,
+            js_challenge={"enabled": True, "challenge_ttl": 3600},
+        ),
+    )
+    monkeypatch.setattr("skrift.config.get_settings", lambda: settings)
+
+    app = Litestar(route_handlers=[BotDetectionController])
+    app.state.bot_detection_store = store
+    return app, store, settings
+
+
+def _good_payload(token, signature):
+    return {
+        "token": token,
+        "signature": signature,
+        "webdriver": False,
+        "plugins": 3,
+        "languages": 2,
+        "chrome": True,
+        "canvas": 200,
+        "timing": 500,
+    }
+
+
+class TestVerifyEndpoint:
+    def test_passing_payload_records_pass(self, app_with_verify):
+        app, store, settings = app_with_verify
+        token, sig = make_challenge_token(settings.secret_key)
+
+        with TestClient(app) as client:
+            response = client.post(
+                "/_bot/verify",
+                json=_good_payload(token, sig),
+                headers={"user-agent": "Mozilla/5.0 ... Chrome/120.0"},
+            )
+        assert response.status_code == 204
+        assert asyncio.run(store.get(JS_CHALLENGE_NS, "testclient")) == "pass"
+
+    def test_webdriver_payload_records_fail(self, app_with_verify):
+        app, store, settings = app_with_verify
+        token, sig = make_challenge_token(settings.secret_key)
+        payload = _good_payload(token, sig)
+        payload["webdriver"] = True
+
+        with TestClient(app) as client:
+            response = client.post(
+                "/_bot/verify",
+                json=payload,
+                headers={"user-agent": "Mozilla/5.0 ... Chrome/120.0"},
+            )
+        assert response.status_code == 204
+        record = asyncio.run(store.get(JS_CHALLENGE_NS, "testclient"))
+        assert record is not None
+        assert record.startswith("fail:")
+        assert "webdriver" in record
+
+    def test_invalid_token_does_not_record(self, app_with_verify):
+        app, store, _ = app_with_verify
+        with TestClient(app) as client:
+            response = client.post(
+                "/_bot/verify",
+                json={"token": "fake", "signature": "fake"},
+            )
+        assert response.status_code == 204
+        assert asyncio.run(store.get(JS_CHALLENGE_NS, "testclient")) is None
+
+    def test_pass_fires_action(self, app_with_verify):
+        captured = []
+
+        async def on_pass(scope, ip, session_id):
+            captured.append((ip, session_id))
+
+        hooks.add_action(BOT_CHALLENGE_PASSED, on_pass)
+
+        app, _, settings = app_with_verify
+        token, sig = make_challenge_token(settings.secret_key)
+        with TestClient(app) as client:
+            client.post(
+                "/_bot/verify",
+                json=_good_payload(token, sig),
+                headers={"user-agent": "Mozilla/5.0 ... Chrome/120.0"},
+            )
+        assert len(captured) == 1
+        assert captured[0][0] == "testclient"
+
+    def test_fail_does_not_fire_pass_action(self, app_with_verify):
+        captured = []
+
+        async def on_pass(scope, ip, session_id):
+            captured.append(ip)
+
+        hooks.add_action(BOT_CHALLENGE_PASSED, on_pass)
+
+        app, _, settings = app_with_verify
+        token, sig = make_challenge_token(settings.secret_key)
+        payload = _good_payload(token, sig)
+        payload["webdriver"] = True
+        with TestClient(app) as client:
+            client.post(
+                "/_bot/verify",
+                json=payload,
+                headers={"user-agent": "Mozilla/5.0 ... Chrome/120.0"},
+            )
+        assert captured == []

--- a/tests/test_admin_controller.py
+++ b/tests/test_admin_controller.py
@@ -31,12 +31,11 @@ class TestGetAdminContext:
         request.url.path = "/admin"
 
         db_session = AsyncMock()
-        mock_result = MagicMock()
-        mock_result.scalar_one_or_none.return_value = None
-        db_session.execute.return_value = mock_result
 
-        with patch("skrift.admin.helpers.select"), \
-             pytest.raises(NotAuthorizedException):
+        with (
+            patch("skrift.admin.helpers.get_by_pk", new_callable=AsyncMock, return_value=None),
+            pytest.raises(NotAuthorizedException),
+        ):
             await get_admin_context(request, db_session)
 
     @pytest.mark.asyncio
@@ -53,16 +52,27 @@ class TestGetAdminContext:
         request.url.path = "/admin"
 
         db_session = AsyncMock()
-        mock_result = MagicMock()
-        mock_result.scalar_one_or_none.return_value = mock_user
-        db_session.execute.return_value = mock_result
 
         mock_perms = MagicMock()
         mock_nav = [MagicMock()]
 
-        with patch("skrift.admin.helpers.select"), \
-             patch("skrift.admin.helpers.get_user_permissions", new_callable=AsyncMock, return_value=mock_perms), \
-             patch("skrift.admin.helpers.build_admin_nav", new_callable=AsyncMock, return_value=mock_nav):
+        with (
+            patch(
+                "skrift.admin.helpers.get_by_pk",
+                new_callable=AsyncMock,
+                return_value=mock_user,
+            ),
+            patch(
+                "skrift.admin.helpers.get_user_permissions",
+                new_callable=AsyncMock,
+                return_value=mock_perms,
+            ),
+            patch(
+                "skrift.admin.helpers.build_admin_nav",
+                new_callable=AsyncMock,
+                return_value=mock_nav,
+            ),
+        ):
             ctx = await get_admin_context(request, db_session)
 
         assert ctx["user"] is mock_user

--- a/tests/test_cli_db.py
+++ b/tests/test_cli_db.py
@@ -1,0 +1,46 @@
+"""Tests for the ``skrift db`` CLI helpers."""
+
+import argparse
+import os
+from pathlib import Path
+
+from skrift.cli import _run_alembic
+
+
+def test_run_alembic_uses_os_separator_for_paths_with_spaces(tmp_path, monkeypatch):
+    project_root = tmp_path / "project with spaces"
+    user_versions = project_root / "migrations" / "versions"
+    user_versions.mkdir(parents=True)
+
+    captured = {}
+
+    def run_command(cfg):
+        captured["cfg"] = cfg
+
+    class Parser:
+        def parse_args(self, args):
+            captured["args"] = args
+            return argparse.Namespace(cmd=(run_command, [], []))
+
+        def error(self, message):
+            raise AssertionError(message)
+
+    class FakeCommandLine:
+        def __init__(self):
+            self.parser = Parser()
+
+    monkeypatch.setattr("alembic.config.CommandLine", FakeCommandLine)
+
+    _run_alembic(project_root, ["heads"])
+
+    skrift_versions = str(
+        Path(__file__).resolve().parent.parent / "skrift" / "alembic" / "versions"
+    )
+    expected_locations = [str(user_versions), skrift_versions]
+    cfg = captured["cfg"]
+
+    assert captured["args"] == ["heads"]
+    assert cfg.get_main_option("path_separator") == "os"
+    assert cfg.get_main_option("version_path_separator") == "os"
+    assert cfg.get_main_option("version_locations") == os.pathsep.join(expected_locations)
+    assert cfg.get_version_locations_list() == expected_locations

--- a/tests/test_db_request_cache.py
+++ b/tests/test_db_request_cache.py
@@ -1,0 +1,156 @@
+"""ASGI-level tests for request-scoped primary-key DB caching."""
+
+from __future__ import annotations
+
+import asyncio
+from uuid import UUID, uuid4
+
+from advanced_alchemy.extensions.litestar import (
+    AsyncSessionConfig,
+    SQLAlchemyAsyncConfig,
+    SQLAlchemyPlugin,
+)
+from litestar import Litestar, get
+from litestar.testing import TestClient
+from sqlalchemy import event
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.pool import StaticPool
+
+import skrift.db.models  # noqa: F401 - registers all models on Base.metadata
+from skrift.db.base import Base
+from skrift.db.cache import get_by_pk
+from skrift.db.models import Page
+
+
+def _run(coro):
+    """Run async setup code for sync TestClient tests."""
+    return asyncio.run(coro)
+
+
+async def _create_schema(engine) -> None:
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+
+async def _dispose_engine(engine) -> None:
+    await engine.dispose()
+
+
+async def _insert_page(engine) -> UUID:
+    async with AsyncSession(engine, expire_on_commit=False) as session:
+        page = Page(slug=f"cached-{uuid4()}", title="Cached", content="")
+        session.add(page)
+        await session.commit()
+        return page.id
+
+
+def _is_page_pk_select(statement: str) -> bool:
+    normalized = " ".join(statement.lower().split())
+    return (
+        normalized.startswith("select ")
+        and " from pages " in normalized
+        and " where pages.id = " in normalized
+    )
+
+
+def _build_app():
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        poolclass=StaticPool,
+        connect_args={"check_same_thread": False},
+    )
+
+    page_pk_select_count = 0
+
+    @event.listens_for(engine.sync_engine, "before_cursor_execute")
+    def _count_page_pk_selects(
+        _conn,
+        _cursor,
+        statement,
+        _parameters,
+        _context,
+        _executemany,
+    ):
+        nonlocal page_pk_select_count
+        if _is_page_pk_select(statement):
+            page_pk_select_count += 1
+
+    @get("/pages/{page_id:str}/twice")
+    async def get_page_twice(page_id: str, db_session: AsyncSession) -> dict:
+        first = await get_by_pk(db_session, Page, UUID(page_id))
+        second = await get_by_pk(db_session, Page, UUID(page_id))
+        return {
+            "found": first is not None,
+            "same_object": first is second,
+            "page_pk_select_count": page_pk_select_count,
+        }
+
+    db_config = SQLAlchemyAsyncConfig(
+        engine_instance=engine,
+        metadata=Base.metadata,
+        create_all=False,
+        session_config=AsyncSessionConfig(expire_on_commit=False),
+    )
+    app = Litestar(
+        route_handlers=[get_page_twice],
+        plugins=[SQLAlchemyPlugin(config=db_config)],
+        debug=True,
+    )
+    app.state.engine = engine
+    return app
+
+
+def test_repeated_pk_reads_are_cached_within_one_asgi_request():
+    app = _build_app()
+    try:
+        _run(_create_schema(app.state.engine))
+        page_id = _run(_insert_page(app.state.engine))
+
+        with TestClient(app=app) as client:
+            response = client.get(f"/pages/{page_id}/twice")
+    finally:
+        _run(_dispose_engine(app.state.engine))
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "found": True,
+        "same_object": True,
+        "page_pk_select_count": 1,
+    }
+
+
+def test_pk_cache_is_scoped_to_each_asgi_request():
+    app = _build_app()
+    try:
+        _run(_create_schema(app.state.engine))
+        page_id = _run(_insert_page(app.state.engine))
+
+        with TestClient(app=app) as client:
+            first = client.get(f"/pages/{page_id}/twice")
+            second = client.get(f"/pages/{page_id}/twice")
+    finally:
+        _run(_dispose_engine(app.state.engine))
+
+    assert first.status_code == 200
+    assert first.json()["page_pk_select_count"] == 1
+    assert second.status_code == 200
+    assert second.json()["page_pk_select_count"] == 2
+
+
+def test_missing_pk_reads_are_cached_within_one_asgi_request():
+    app = _build_app()
+    try:
+        _run(_create_schema(app.state.engine))
+        missing_id = uuid4()
+
+        with TestClient(app=app) as client:
+            response = client.get(f"/pages/{missing_id}/twice")
+    finally:
+        _run(_dispose_engine(app.state.engine))
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "found": False,
+        "same_object": True,
+        "page_pk_select_count": 1,
+    }

--- a/uv.lock
+++ b/uv.lock
@@ -1828,7 +1828,7 @@ wheels = [
 
 [[package]]
 name = "skrift"
-version = "0.1.0a86"
+version = "0.1.0a87"
 source = { editable = "." }
 dependencies = [
     { name = "advanced-alchemy" },

--- a/uv.lock
+++ b/uv.lock
@@ -1828,7 +1828,7 @@ wheels = [
 
 [[package]]
 name = "skrift"
-version = "0.1.0a85"
+version = "0.1.0a86"
 source = { editable = "." }
 dependencies = [
     { name = "advanced-alchemy" },


### PR DESCRIPTION
## Summary

Release `0.1.0a87`, covering all changes since `v0.1.0a86`.

## Changes

### Notifications
- Added reactive notification watcher helpers for client-side notification updates.
- Reconnect notification streams when the server shuts down a stream.
- Updated notification guide documentation.

### Database
- Added a request-scoped primary-key cache for page and asset lookup paths.
- Added controller/admin coverage for cache behavior.

### Bot Detection
- Added an opt-in `bot_detection.enabled` subsystem with passive, beacon, and robots-honeypot detection.
- Added built-in metrics for user-agent, header coherence, direct request, pixel beacon, JS challenge, and robots honeypot signals.
- Added `BotGuard`, request-scope bot detection state, Redis/in-memory store support, and hooks for detected bots, trap hits, pixel loads, and challenge passes.
- Added comprehensive bot detection test coverage.

### Database CLI
- Fixed `skrift db` no-op behavior when project or package paths contain spaces by using Alembic OS path separators.
- Hardened packaged Alembic config defaults and added regression coverage.

### Versioning
- Synced `uv.lock` to the current `0.1.0a86` package version before the release bump.
- Bumped package and lockfile version to `0.1.0a87`.

## Verification

- `uv run --all-extras python -c "import pkgutil, importlib; [importlib.import_module(m.name) for m in pkgutil.walk_packages(['skrift'], prefix='skrift.')]"` passed.
- `uv run --all-extras pytest -m "not integration"` passed: 1131 passed, 3 skipped, 30 deselected.

## Release version

`0.1.0a86` -> `0.1.0a87`
