### PR TITLE
Add structured approval rejection and dynamic approval gates

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "skrift"
-version = "0.1.0a88"
+version = "0.1.0a89"
 description = "A lightweight async Python CMS for crafting modern websites"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/skrift/__init__.py
+++ b/skrift/__init__.py
@@ -2,6 +2,7 @@
 
 from skrift.agents import (
     Agent,
+    ApprovalRejection,
     BlobRef,
     Chat,
     ReasoningLevel,
@@ -32,6 +33,7 @@ from skrift.workers import (
 
 __all__ = [
     "Agent",
+    "ApprovalRejection",
     "BlobRef",
     "Chat",
     "Job",

--- a/skrift/agents/__init__.py
+++ b/skrift/agents/__init__.py
@@ -10,7 +10,7 @@ from skrift.agents.blob import (
 )
 from skrift.agents.chat import Chat
 from skrift.agents.context import set_actor
-from skrift.agents.models import BlobRef, ResumeContext, Steer
+from skrift.agents.models import ApprovalRejection, BlobRef, ResumeContext, Steer
 from skrift.agents.registry import registry
 from skrift.agents.session import AgentSessionError, Session, session
 from skrift.agents.turns import ReasoningLevel
@@ -21,6 +21,7 @@ from skrift.agents import runtime as _runtime  # noqa: F401
 __all__ = [
     "Agent",
     "AgentSessionError",
+    "ApprovalRejection",
     "ArchiveBlobStore",
     "AuditTrail",
     "BlobIntegrityError",

--- a/skrift/agents/agent.py
+++ b/skrift/agents/agent.py
@@ -3,11 +3,12 @@
 from __future__ import annotations
 
 import functools
+import inspect
 from typing import Any, Callable
 from uuid import uuid4
 
-from pydantic_ai import Agent as PydanticAgent
-from pydantic_ai.exceptions import CallDeferred
+from pydantic_ai import Agent as PydanticAgent, RunContext
+from pydantic_ai.exceptions import ApprovalRequired, CallDeferred
 
 from skrift.agents.config import get_agents_config
 from skrift.agents.context import current_session_id, resolve_actor
@@ -49,6 +50,7 @@ class Agent(PydanticAgent):
         self.skrift_name = name
         self.deps_factory = deps_factory
         self._tool_policies: dict[str, ToolPolicy] = {}
+        self._approval_gates: dict[str, Callable[..., Any]] = {}
         self._detached_tools: dict[str, Callable[..., Any]] = {}
         registry.register(
             AgentDefinition(
@@ -79,24 +81,35 @@ class Agent(PydanticAgent):
                 "looks up resources internally, or wait for the context rehydration path."
             )
         metadata = dict(kwargs.pop("metadata", {}) or {})
-        if approval and "requires_approval" not in kwargs:
-            kwargs["requires_approval"] = True
+        policy_approval, approval_mode, approval_callable_name, approval_gate = (
+            self._configure_approval(approval, kwargs)
+        )
         metadata["skrift_policy"] = ToolPolicy(
-            approval=bool(approval),
+            approval=policy_approval,
+            approval_mode=approval_mode,
+            approval_callable_name=approval_callable_name,
             idempotent=idempotent,
             detached=detached,
             approval_on_retry=approval_on_retry,
             policy_description=policy_description,
         ).model_dump(mode="json")
         original_func = func
-        if detached and func is not None:
-            func = self._deferred_tool_wrapper(func)
+        if func is not None:
+            if approval_gate is not None:
+                func = self._approval_gate_wrapper(func, approval_gate, plain=False)
+            elif detached:
+                func = self._deferred_tool_wrapper(func)
         decorator = super().tool(func, metadata=metadata, **kwargs)
         if func is not None:
             self._record_tool_policy(
                 kwargs.get("name") or getattr(original_func, "__name__", ""),
                 metadata["skrift_policy"],
             )
+            if approval_gate is not None:
+                self._record_approval_gate(
+                    kwargs.get("name") or getattr(original_func, "__name__", ""),
+                    approval_gate,
+                )
             if detached and original_func is not None:
                 self._record_detached_tool(
                     kwargs.get("name") or getattr(original_func, "__name__", ""),
@@ -107,7 +120,9 @@ class Agent(PydanticAgent):
             decorator,
             kwargs.get("name"),
             metadata["skrift_policy"],
+            approval_gate=approval_gate,
             detached=detached,
+            plain=False,
         )
 
     def tool_plain(
@@ -123,24 +138,41 @@ class Agent(PydanticAgent):
         **kwargs: Any,
     ) -> Any:
         metadata = dict(kwargs.pop("metadata", {}) or {})
-        if approval and "requires_approval" not in kwargs:
-            kwargs["requires_approval"] = True
+        policy_approval, approval_mode, approval_callable_name, approval_gate = (
+            self._configure_approval(approval, kwargs)
+        )
         metadata["skrift_policy"] = ToolPolicy(
-            approval=bool(approval),
+            approval=policy_approval,
+            approval_mode=approval_mode,
+            approval_callable_name=approval_callable_name,
             idempotent=idempotent,
             detached=detached,
             approval_on_retry=approval_on_retry,
             policy_description=policy_description,
         ).model_dump(mode="json")
         original_func = func
-        if detached and func is not None:
-            func = self._deferred_tool_wrapper(func)
-        decorator = super().tool_plain(func, metadata=metadata, **kwargs)
+        if func is not None:
+            if approval_gate is not None:
+                func = self._approval_gate_wrapper(
+                    func,
+                    approval_gate,
+                    plain=True,
+                    detached=detached,
+                )
+            elif detached:
+                func = self._deferred_tool_wrapper(func)
+        register_tool = super().tool if approval_gate is not None else super().tool_plain
+        decorator = register_tool(func, metadata=metadata, **kwargs)
         if func is not None:
             self._record_tool_policy(
                 kwargs.get("name") or getattr(original_func, "__name__", ""),
                 metadata["skrift_policy"],
             )
+            if approval_gate is not None:
+                self._record_approval_gate(
+                    kwargs.get("name") or getattr(original_func, "__name__", ""),
+                    approval_gate,
+                )
             if detached and original_func is not None:
                 self._record_detached_tool(
                     kwargs.get("name") or getattr(original_func, "__name__", ""),
@@ -151,8 +183,23 @@ class Agent(PydanticAgent):
             decorator,
             kwargs.get("name"),
             metadata["skrift_policy"],
+            approval_gate=approval_gate,
             detached=detached,
+            plain=True,
         )
+
+    def _configure_approval(
+        self,
+        approval: bool | Callable[..., Any],
+        kwargs: dict[str, Any],
+    ) -> tuple[bool, str, str | None, Callable[..., Any] | None]:
+        if callable(approval):
+            gate = approval
+            kwargs["requires_approval"] = False
+            return False, "callable", _callable_name(gate), gate
+        if approval and "requires_approval" not in kwargs:
+            kwargs["requires_approval"] = True
+        return bool(approval), "static" if approval else "none", None, None
 
     def _wrap_tool_decorator(
         self,
@@ -160,15 +207,28 @@ class Agent(PydanticAgent):
         explicit_name: str | None,
         policy: dict[str, Any],
         *,
+        approval_gate: Callable[..., Any] | None = None,
         detached: bool = False,
+        plain: bool = False,
     ) -> Any:
         if not callable(decorator):
             return decorator
 
         def wrapped(func: Any) -> Any:
-            self._record_tool_policy(explicit_name or getattr(func, "__name__", ""), policy)
+            name = explicit_name or getattr(func, "__name__", "")
+            self._record_tool_policy(name, policy)
+            if approval_gate is not None:
+                self._record_approval_gate(name, approval_gate)
+                return decorator(
+                    self._approval_gate_wrapper(
+                        func,
+                        approval_gate,
+                        plain=plain,
+                        detached=detached,
+                    )
+                )
             if detached:
-                self._record_detached_tool(explicit_name or getattr(func, "__name__", ""), func)
+                self._record_detached_tool(name, func)
                 return decorator(self._deferred_tool_wrapper(func))
             return decorator(func)
 
@@ -181,6 +241,101 @@ class Agent(PydanticAgent):
     def _record_detached_tool(self, name: str, func: Callable[..., Any]) -> None:
         if name:
             self._detached_tools[name] = func
+
+    def _record_approval_gate(self, name: str, gate: Callable[..., Any]) -> None:
+        if name:
+            self._approval_gates[name] = gate
+
+    def _approval_gate_wrapper(
+        self,
+        func: Callable[..., Any],
+        gate: Callable[..., Any],
+        *,
+        plain: bool,
+        detached: bool = False,
+    ) -> Callable[..., Any]:
+        call_func = self._deferred_tool_wrapper(func) if detached else func
+
+        if plain:
+            signature = inspect.signature(func)
+            context_param = inspect.Parameter(
+                "ctx",
+                inspect.Parameter.POSITIONAL_OR_KEYWORD,
+                annotation=RunContext[Any],
+            )
+
+            @functools.wraps(func)
+            async def plain_wrapper(ctx: RunContext[Any], *args: Any, **kwargs: Any) -> Any:
+                await self._apply_dynamic_approval(ctx, gate, kwargs)
+                result = call_func(*args, **kwargs)
+                if inspect.isawaitable(result):
+                    return await result
+                return result
+
+            plain_wrapper.__signature__ = signature.replace(  # type: ignore[attr-defined]
+                parameters=[context_param, *signature.parameters.values()]
+            )
+            plain_wrapper.__annotations__ = {
+                **getattr(func, "__annotations__", {}),
+                "ctx": RunContext[Any],
+            }
+            return plain_wrapper
+
+        @functools.wraps(func)
+        async def context_wrapper(ctx: RunContext[Any], *args: Any, **kwargs: Any) -> Any:
+            await self._apply_dynamic_approval(ctx, gate, kwargs)
+            result = call_func(ctx, *args, **kwargs)
+            if inspect.isawaitable(result):
+                return await result
+            return result
+
+        return context_wrapper
+
+    async def _apply_dynamic_approval(
+        self,
+        ctx: RunContext[Any],
+        gate: Callable[..., Any],
+        args: dict[str, Any],
+    ) -> None:
+        if ctx.tool_call_approved:
+            return
+        gate_result = gate(**args)
+        if inspect.isawaitable(gate_result):
+            gate_result = await gate_result
+        gated = bool(gate_result)
+        decision = {
+            "gated": gated,
+            "policy": "callable",
+            "callable_name": _callable_name(gate),
+        }
+        await self._record_dynamic_approval_decision(ctx, args, decision)
+        if gated:
+            raise ApprovalRequired({"skrift_approval_decision": decision})
+
+    async def _record_dynamic_approval_decision(
+        self,
+        ctx: RunContext[Any],
+        args: dict[str, Any],
+        decision: dict[str, Any],
+    ) -> None:
+        session_id = current_session_id()
+        if not session_id:
+            return
+
+        async def mutate(state: RunState) -> RunState:
+            append_event(
+                state,
+                "ToolApprovalDecision",
+                {
+                    "tool_call_id": ctx.tool_call_id,
+                    "tool_name": ctx.tool_name,
+                    "args": args,
+                    "approval_decision": decision,
+                },
+            )
+            return state
+
+        await update_runstate(session_id, mutate)
 
     @staticmethod
     def _deferred_tool_wrapper(func: Callable[..., Any]) -> Callable[..., Any]:
@@ -316,6 +471,10 @@ def _safe_name(value: Any) -> str | None:
     if isinstance(value, type):
         return f"{value.__module__}.{value.__qualname__}"
     return repr(value)
+
+
+def _callable_name(value: Callable[..., Any]) -> str:
+    return getattr(value, "__name__", None) or repr(value)
 
 
 def _snapshot_callables(value: Any) -> list[str]:

--- a/skrift/agents/models.py
+++ b/skrift/agents/models.py
@@ -37,10 +37,18 @@ class Steer(BaseModel):
 
 class ToolPolicy(BaseModel):
     approval: bool = False
+    approval_mode: Literal["none", "static", "callable"] = "none"
+    approval_callable_name: str | None = None
     idempotent: bool = False
     detached: bool = False
     approval_on_retry: bool = False
     policy_description: str | None = None
+
+
+class ApprovalRejection(BaseModel):
+    rejected: Literal[True] = True
+    reason: str
+    payload: Any | None = None
 
 
 class ToolExecutionState(BaseModel):

--- a/skrift/agents/runtime.py
+++ b/skrift/agents/runtime.py
@@ -15,6 +15,7 @@ from skrift.agents.context import reset_current_session_id, set_current_session_
 from skrift.agents.models import (
     AgentRunJob,
     AgentToolCallJob,
+    ApprovalRejection,
     OutboxSubmit,
     ResumeContext,
     ToolExecutionState,
@@ -238,12 +239,16 @@ async def agents_run_handler(payload: AgentRunJob, context: WorkerContext) -> An
             for event_type, event_payload in _tool_events_from_messages(new_messages):
                 append_event(runstate, event_type, event_payload)
             for call in output.approvals:
+                metadata = output.metadata.get(call.tool_call_id, {})
                 approval = {
                     "tool_call_id": call.tool_call_id,
                     "tool_name": call.tool_name,
                     "args": call.args_as_dict(),
-                    "requesting_context": {},
+                    "requesting_context": metadata,
                 }
+                approval_decision = metadata.get("skrift_approval_decision")
+                if approval_decision is not None:
+                    approval["approval_decision"] = approval_decision
                 if not any(
                     existing.get("tool_call_id") == call.tool_call_id
                     for existing in runstate.pending_approvals
@@ -624,9 +629,15 @@ def _deferred_tool_results(state) -> DeferredToolResults | None:
         if decision.get("approved"):
             resolved[tool_call_id] = True
         else:
-            resolved[tool_call_id] = ToolDenied(
-                decision.get("message") or "The tool call was denied."
-            )
+            reason = decision.get("message") or "The tool call was denied."
+            if "payload" in decision:
+                denial = ApprovalRejection(
+                    reason=reason,
+                    payload=decision.get("payload"),
+                ).model_dump(mode="json")
+            else:
+                denial = reason
+            resolved[tool_call_id] = ToolDenied(denial)
     return DeferredToolResults(approvals=resolved, calls=calls)
 
 

--- a/skrift/agents/session.py
+++ b/skrift/agents/session.py
@@ -6,6 +6,8 @@ import asyncio
 from typing import Any, AsyncIterator
 from uuid import uuid4
 
+from pydantic_core import PydanticSerializationError, to_jsonable_python
+
 from skrift.agents.blob import dereference_blob_refs
 from skrift.agents.context import resolve_actor
 from skrift.agents.models import Actor, RunState, Steer
@@ -296,8 +298,21 @@ class Session:
     async def approve(self, tool_call_id: str, *, actor: Actor | dict | str | None = None, note: str | None = None) -> None:
         await self._decision(tool_call_id, approved=True, actor=actor, note=note)
 
-    async def reject(self, tool_call_id: str, *, actor: Actor | dict | str | None = None, reason: str) -> None:
-        await self._decision(tool_call_id, approved=False, actor=actor, note=reason)
+    async def reject(
+        self,
+        tool_call_id: str,
+        *,
+        actor: Actor | dict | str | None = None,
+        reason: str,
+        payload: Any | None = None,
+    ) -> None:
+        await self._decision(
+            tool_call_id,
+            approved=False,
+            actor=actor,
+            note=reason,
+            rejection_payload=_jsonable_payload(payload),
+        )
 
     async def _decision(
         self,
@@ -306,6 +321,7 @@ class Session:
         approved: bool,
         actor: Actor | dict | str | None,
         note: str | None,
+        rejection_payload: Any | None = None,
     ) -> None:
         resolved = resolve_actor(actor)
         event_type = "ToolCallApproved" if approved else "ToolCallRejected"
@@ -320,14 +336,21 @@ class Session:
                 "approved": approved,
                 "message": note,
             }
+            approval_results = state.deferred_tool_results["approvals"]
+            if not approved and rejection_payload is not None:
+                approval_results[tool_call_id]["payload"] = rejection_payload
             state.status = "queued"
-            payload = {
+            event_payload = {
                 "tool_call_id": tool_call_id,
                 "actor": actor_payload(resolved),
                 "decided_at": utcnow().isoformat(),
             }
-            payload["note" if approved else "reason"] = note
-            append_event(state, event_type, payload)
+            event_payload["note" if approved else "reason"] = note
+            if not approved:
+                stored_rejection_payload = approval_results[tool_call_id].get("payload")
+                if stored_rejection_payload is not None:
+                    event_payload["payload"] = stored_rejection_payload
+            append_event(state, event_type, event_payload)
             if state.current_run_job_id:
                 append_wake(state, state.current_run_job_id)
             return state
@@ -366,6 +389,15 @@ class Session:
             if state.status == "cancelled":
                 raise asyncio.CancelledError(f"Agent session {self.id} was cancelled")
             await asyncio.sleep(poll_interval)
+
+
+def _jsonable_payload(payload: Any | None) -> Any | None:
+    if payload is None:
+        return None
+    try:
+        return to_jsonable_python(payload)
+    except PydanticSerializationError as exc:
+        raise AgentSessionError("Rejection payload must be JSON-serializable") from exc
 
 
 async def session(session_id: str) -> Session:

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -458,8 +458,11 @@ async def test_hitl_approval_pauses_and_resumes_tool_call():
     session = await agent.run("use the tool", actor="ada")
     await runtime.start()
     try:
-        while await session.status() != "awaiting_approval":
-            await asyncio.sleep(0.01)
+        async def wait_for_approval() -> None:
+            while await session.status() != "awaiting_approval":
+                await asyncio.sleep(0.01)
+
+        await asyncio.wait_for(wait_for_approval(), timeout=1)
         state = await session.state()
         tool_call_id = state.pending_approvals[0]["tool_call_id"]
 
@@ -474,6 +477,96 @@ async def test_hitl_approval_pauses_and_resumes_tool_call():
     assert "ToolCallAwaitingApproval" in event_types
     assert "ToolCallApproved" in event_types
     assert "ToolCallCompleted" in event_types
+
+
+async def test_callable_approval_false_runs_tool_inline():
+    decisions: list[tuple[int, int]] = []
+    agent = skrift.Agent(TestModel(), name="demo")
+
+    def needs_approval(x: int, y: int) -> bool:
+        decisions.append((x, y))
+        return False
+
+    @agent.tool_plain(approval=needs_approval, policy_description="conditional approval")
+    def add(x: int, y: int) -> int:
+        return x + y
+
+    session = await agent.run("use the tool", actor="ada")
+
+    assert await session.status() == "completed"
+    assert await session.result() == '{"add":0}'
+    assert decisions == [(0, 0)]
+
+    events = await skrift.get_runtime().event_log.read(f"agents:run:{session.id}")
+    event_types = [event["type"] for _, event in events]
+    assert "ToolApprovalDecision" in event_types
+    assert "ToolCallAwaitingApproval" not in event_types
+    decision = next(event for _, event in events if event["type"] == "ToolApprovalDecision")
+    assert decision["payload"]["approval_decision"] == {
+        "gated": False,
+        "policy": "callable",
+        "callable_name": "needs_approval",
+    }
+
+
+async def test_callable_approval_true_pauses_then_resumes_tool_call_once():
+    runtime = skrift.configure_workers(mode="in_process", queues=("agents",))
+    decisions: list[tuple[int, int]] = []
+    agent = skrift.Agent(TestModel(), name="demo")
+
+    def needs_approval(x: int, y: int) -> bool:
+        decisions.append((x, y))
+        return True
+
+    @agent.tool_plain(approval=needs_approval, policy_description="conditional approval")
+    def add(x: int, y: int) -> int:
+        return x + y
+
+    session = await agent.run("use the tool", actor="ada")
+    await runtime.start()
+    try:
+        async def wait_for_approval() -> None:
+            while await session.status() != "awaiting_approval":
+                await asyncio.sleep(0.01)
+
+        await asyncio.wait_for(wait_for_approval(), timeout=1)
+        state = await session.state()
+        approval = state.pending_approvals[0]
+        assert approval["approval_decision"]["gated"] is True
+        assert decisions == [(0, 0)]
+
+        await session.approve(approval["tool_call_id"], actor="ada", note="ok")
+
+        assert await session.result() == '{"add":0}'
+        assert decisions == [(0, 0)]
+    finally:
+        await runtime.stop()
+
+    events = await skrift.get_runtime().event_log.read(f"agents:run:{session.id}")
+    event_types = [event["type"] for _, event in events]
+    assert "ToolApprovalDecision" in event_types
+    assert "ToolCallAwaitingApproval" in event_types
+    assert "ToolCallCompleted" in event_types
+
+
+async def test_callable_approval_supports_async_gate_on_context_tool():
+    decisions: list[tuple[int, int]] = []
+    agent = skrift.Agent(TestModel(), name="demo")
+
+    async def needs_approval(x: int, y: int) -> bool:
+        await asyncio.sleep(0)
+        decisions.append((x, y))
+        return False
+
+    @agent.tool(approval=needs_approval, policy_description="conditional approval")
+    def add(ctx: RunContext[None], x: int, y: int) -> int:
+        return x + y
+
+    session = await agent.run("use the tool", actor="ada")
+
+    assert await session.status() == "completed"
+    assert await session.result() == '{"add":0}'
+    assert decisions == [(0, 0)]
 
 
 async def test_hitl_rejection_returns_denial_to_model():
@@ -501,6 +594,53 @@ async def test_hitl_rejection_returns_denial_to_model():
     events = await skrift.get_runtime().event_log.read(f"agents:run:{session.id}")
     event_types = [event["type"] for _, event in events]
     assert "ToolCallRejected" in event_types
+
+
+async def test_hitl_rejection_with_payload_returns_structured_denial_to_model_and_audit():
+    runtime = skrift.configure_workers(mode="in_process", queues=("agents",))
+    agent = skrift.Agent(TestModel(), name="demo")
+
+    @agent.tool_plain(approval=True, policy_description="approval required")
+    def add(x: int, y: int) -> int:
+        return x + y
+
+    session = await agent.run("use the tool", actor="ada")
+    await runtime.start()
+    try:
+        while await session.status() != "awaiting_approval":
+            await asyncio.sleep(0.01)
+        await runtime.stop()
+
+        state = await session.state()
+        tool_call_id = state.pending_approvals[0]["tool_call_id"]
+
+        await session.reject(
+            tool_call_id,
+            actor="ada",
+            reason="user redirected to draft",
+            payload={"action": "saved_as_draft", "draft_id": "draft_123"},
+        )
+
+        state = await session.state()
+        assert state.deferred_tool_results["approvals"][tool_call_id]["payload"] == {
+            "action": "saved_as_draft",
+            "draft_id": "draft_123",
+        }
+
+        await runtime.start()
+        assert await session.result() == (
+            '{"add":{"rejected":true,"reason":"user redirected to draft",'
+            '"payload":{"action":"saved_as_draft","draft_id":"draft_123"}}}'
+        )
+    finally:
+        await runtime.stop()
+
+    audit = await skrift.audit_export(session.id)
+    rejection = next(event for event in audit.events if event["type"] == "ToolCallRejected")
+    assert rejection["payload"]["payload"] == {
+        "action": "saved_as_draft",
+        "draft_id": "draft_123",
+    }
 
 
 async def test_detached_tool_runs_in_tool_call_job_and_wakes_parent():

--- a/uv.lock
+++ b/uv.lock
@@ -1957,7 +1957,7 @@ wheels = [
 
 [[package]]
 name = "skrift"
-version = "0.1.0a88"
+version = "0.1.0a89"
 source = { editable = "." }
 dependencies = [
     { name = "advanced-alchemy" },


### PR DESCRIPTION
## Summary

- Add `Session.reject(..., payload=...)` and structured `ApprovalRejection` results for payload-bearing approval denials.
- Add callable approval policies for agent tools, including sync/async gates and resume-safe execution after approval.
- Bump alpha version to `0.1.0a89`.

## Tests

- `pytest tests/test_agents.py -q`
- `python -m compileall skrift/agents tests/test_agents.py`

Note: `ruff` and `python -m build` are not installed in this local environment.