### PR TITLE
Add approval context and runtime approval checkpoints

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "skrift"
-version = "0.1.0a89"
+version = "0.1.0a90"
 description = "A lightweight async Python CMS for crafting modern websites"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/skrift/__init__.py
+++ b/skrift/__init__.py
@@ -2,6 +2,7 @@
 
 from skrift.agents import (
     Agent,
+    ApprovalContext,
     ApprovalRejection,
     BlobRef,
     Chat,
@@ -11,6 +12,7 @@ from skrift.agents import (
     Steer,
     audit_export,
     replay,
+    require_approval,
     session,
     set_actor,
     set_blob_store,
@@ -33,6 +35,7 @@ from skrift.workers import (
 
 __all__ = [
     "Agent",
+    "ApprovalContext",
     "ApprovalRejection",
     "BlobRef",
     "Chat",
@@ -53,6 +56,7 @@ __all__ = [
     "handler",
     "local_executor",
     "replay",
+    "require_approval",
     "session",
     "set_actor",
     "set_blob_store",

--- a/skrift/agents/__init__.py
+++ b/skrift/agents/__init__.py
@@ -1,6 +1,7 @@
 """Durable agent subsystem."""
 
 from skrift.agents.agent import Agent
+from skrift.agents.approval import ApprovalContext, require_approval
 from skrift.agents.audit import AuditTrail, audit_export, replay
 from skrift.agents.blob import (
     ArchiveBlobStore,
@@ -21,6 +22,7 @@ from skrift.agents import runtime as _runtime  # noqa: F401
 __all__ = [
     "Agent",
     "AgentSessionError",
+    "ApprovalContext",
     "ApprovalRejection",
     "ArchiveBlobStore",
     "AuditTrail",
@@ -35,6 +37,7 @@ __all__ = [
     "audit_export",
     "registry",
     "replay",
+    "require_approval",
     "session",
     "set_actor",
     "set_blob_store",

--- a/skrift/agents/agent.py
+++ b/skrift/agents/agent.py
@@ -10,6 +10,7 @@ from uuid import uuid4
 from pydantic_ai import Agent as PydanticAgent, RunContext
 from pydantic_ai.exceptions import ApprovalRequired, CallDeferred
 
+from skrift.agents.approval import ApprovalContext, _record_tool_approval_decision
 from skrift.agents.config import get_agents_config
 from skrift.agents.context import current_session_id, resolve_actor
 from skrift.agents.models import ResumeContext, RunState, ToolPolicy
@@ -299,7 +300,16 @@ class Agent(PydanticAgent):
     ) -> None:
         if ctx.tool_call_approved:
             return
-        gate_result = gate(**args)
+        gate_kwargs = dict(args)
+        if _accepts_approval_context(gate):
+            gate_kwargs["ctx"] = ApprovalContext(
+                session_id=current_session_id(),
+                tool_call_id=ctx.tool_call_id,
+                tool_name=ctx.tool_name,
+                deps=ctx.deps,
+                metadata=dict(ctx.metadata or {}),
+            )
+        gate_result = gate(**gate_kwargs)
         if inspect.isawaitable(gate_result):
             gate_result = await gate_result
         gated = bool(gate_result)
@@ -308,34 +318,9 @@ class Agent(PydanticAgent):
             "policy": "callable",
             "callable_name": _callable_name(gate),
         }
-        await self._record_dynamic_approval_decision(ctx, args, decision)
+        await _record_tool_approval_decision(ctx, args, decision)
         if gated:
             raise ApprovalRequired({"skrift_approval_decision": decision})
-
-    async def _record_dynamic_approval_decision(
-        self,
-        ctx: RunContext[Any],
-        args: dict[str, Any],
-        decision: dict[str, Any],
-    ) -> None:
-        session_id = current_session_id()
-        if not session_id:
-            return
-
-        async def mutate(state: RunState) -> RunState:
-            append_event(
-                state,
-                "ToolApprovalDecision",
-                {
-                    "tool_call_id": ctx.tool_call_id,
-                    "tool_name": ctx.tool_name,
-                    "args": args,
-                    "approval_decision": decision,
-                },
-            )
-            return state
-
-        await update_runstate(session_id, mutate)
 
     @staticmethod
     def _deferred_tool_wrapper(func: Callable[..., Any]) -> Callable[..., Any]:
@@ -475,6 +460,13 @@ def _safe_name(value: Any) -> str | None:
 
 def _callable_name(value: Callable[..., Any]) -> str:
     return getattr(value, "__name__", None) or repr(value)
+
+
+def _accepts_approval_context(value: Callable[..., Any]) -> bool:
+    try:
+        return "ctx" in inspect.signature(value).parameters
+    except (TypeError, ValueError):
+        return False
 
 
 def _snapshot_callables(value: Any) -> list[str]:

--- a/skrift/agents/approval.py
+++ b/skrift/agents/approval.py
@@ -1,0 +1,85 @@
+"""Approval helpers for Skrift agents."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from pydantic_ai import RunContext
+from pydantic_ai.exceptions import ApprovalRequired
+from pydantic_core import PydanticSerializationError, to_jsonable_python
+
+from skrift.agents.context import current_session_id
+from skrift.agents.state import append_event, update_runstate
+
+
+@dataclass(frozen=True)
+class ApprovalContext:
+    """Narrow context passed to callable approval gates."""
+
+    session_id: str | None
+    tool_call_id: str | None
+    tool_name: str | None
+    deps: Any = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+async def require_approval(
+    ctx: RunContext[Any],
+    *,
+    reason: str,
+    payload: Any | None = None,
+) -> None:
+    """Pause a context tool until the current tool call is approved."""
+
+    if ctx.tool_call_approved:
+        return
+    json_payload = _jsonable_payload(payload)
+    decision = {
+        "gated": True,
+        "policy": "runtime",
+        "reason": reason,
+    }
+    metadata = {
+        "skrift_runtime_approval": {
+            "reason": reason,
+            "payload": json_payload,
+        },
+        "skrift_approval_decision": decision,
+    }
+    await _record_tool_approval_decision(ctx, {}, decision)
+    raise ApprovalRequired(metadata)
+
+
+async def _record_tool_approval_decision(
+    ctx: RunContext[Any],
+    args: dict[str, Any],
+    decision: dict[str, Any],
+) -> None:
+    session_id = current_session_id()
+    if not session_id:
+        return
+
+    async def mutate(state):
+        append_event(
+            state,
+            "ToolApprovalDecision",
+            {
+                "tool_call_id": ctx.tool_call_id,
+                "tool_name": ctx.tool_name,
+                "args": args,
+                "approval_decision": decision,
+            },
+        )
+        return state
+
+    await update_runstate(session_id, mutate)
+
+
+def _jsonable_payload(payload: Any | None) -> Any | None:
+    if payload is None:
+        return None
+    try:
+        return to_jsonable_python(payload)
+    except PydanticSerializationError as exc:
+        raise ValueError("Approval payload must be JSON-serializable") from exc

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -569,6 +569,99 @@ async def test_callable_approval_supports_async_gate_on_context_tool():
     assert decisions == [(0, 0)]
 
 
+async def test_callable_approval_can_use_context_deps_for_async_gate():
+    runtime = skrift.configure_workers(mode="in_process", queues=("agents",))
+    gate_checks: list[tuple[str | None, str | None, str]] = []
+
+    class EmailStore:
+        async def threat_level(self, record_id: str) -> str:
+            await asyncio.sleep(0)
+            return "high"
+
+    async def deps_factory(ctx):
+        return EmailStore()
+
+    agent = skrift.Agent(TestModel(), name="demo", deps_type=EmailStore, deps_factory=deps_factory)
+
+    async def needs_approval(ctx: skrift.ApprovalContext, record_id: str) -> bool:
+        threat_level = await ctx.deps.threat_level(record_id)
+        gate_checks.append((ctx.session_id, ctx.tool_name, threat_level))
+        return threat_level == "high"
+
+    @agent.tool_plain(approval=needs_approval, idempotent=True)
+    async def read_email(record_id: str) -> str:
+        return f"body:{record_id}"
+
+    session = await agent.run("read the email", actor="ada")
+    await runtime.start()
+    try:
+        async def wait_for_approval() -> None:
+            while await session.status() != "awaiting_approval":
+                await asyncio.sleep(0.01)
+
+        await asyncio.wait_for(wait_for_approval(), timeout=1)
+        state = await session.state()
+        approval = state.pending_approvals[0]
+        assert approval["tool_name"] == "read_email"
+        assert approval["approval_decision"] == {
+            "gated": True,
+            "policy": "callable",
+            "callable_name": "needs_approval",
+        }
+        assert gate_checks == [(session.id, "read_email", "high")]
+
+        await session.approve(approval["tool_call_id"], actor="ada", note="ok")
+
+        assert await session.result() == '{"read_email":"body:a"}'
+        assert gate_checks == [(session.id, "read_email", "high")]
+    finally:
+        await runtime.stop()
+
+
+async def test_require_approval_pauses_context_tool_until_approved():
+    runtime = skrift.configure_workers(mode="in_process", queues=("agents",))
+    attempts: list[str] = []
+    agent = skrift.Agent(TestModel(), name="demo")
+
+    @agent.tool(idempotent=True)
+    async def read_email(ctx: RunContext[None], record_id: str) -> str:
+        attempts.append(record_id)
+        await skrift.require_approval(
+            ctx,
+            reason="flagged_email",
+            payload={"record_id": record_id, "threat_level": "high"},
+        )
+        return f"body:{record_id}"
+
+    session = await agent.run("read the email", actor="ada")
+    await runtime.start()
+    try:
+        async def wait_for_approval() -> None:
+            while await session.status() != "awaiting_approval":
+                await asyncio.sleep(0.01)
+
+        await asyncio.wait_for(wait_for_approval(), timeout=1)
+        state = await session.state()
+        approval = state.pending_approvals[0]
+        assert approval["approval_decision"] == {
+            "gated": True,
+            "policy": "runtime",
+            "reason": "flagged_email",
+        }
+        assert approval["requesting_context"]["skrift_runtime_approval"] == {
+            "reason": "flagged_email",
+            "payload": {"record_id": "a", "threat_level": "high"},
+        }
+        assert attempts == ["a"]
+
+        await session.approve(approval["tool_call_id"], actor="ada", note="ok")
+
+        assert await session.result() == '{"read_email":"body:a"}'
+        assert attempts == ["a", "a"]
+    finally:
+        await runtime.stop()
+
+
 async def test_hitl_rejection_returns_denial_to_model():
     runtime = skrift.configure_workers(mode="in_process", queues=("agents",))
     agent = skrift.Agent(TestModel(), name="demo")

--- a/uv.lock
+++ b/uv.lock
@@ -1957,7 +1957,7 @@ wheels = [
 
 [[package]]
 name = "skrift"
-version = "0.1.0a89"
+version = "0.1.0a90"
 source = { editable = "." }
 dependencies = [
     { name = "advanced-alchemy" },


### PR DESCRIPTION
## Summary

- Add ApprovalContext for callable approval gates that need async dependency/DB checks.
- Add require_approval(ctx, reason=..., payload=...) for runtime approval checkpoints inside context tools.
- Bump alpha version to 0.1.0a90.

## Tests

- pytest tests/test_agents.py -q
- python -m compileall skrift/agents tests/test_agents.py
- git diff --check

Note: ruff is not installed in this local environment.