### PR TITLE
Release v0.2.0a2 — bounded TTL for terminal agent RunState

### DIFF
--- a/docs/reference/workers.md
+++ b/docs/reference/workers.md
@@ -35,6 +35,8 @@ workers:
     enabled: true
     prune_interval: 300.0
     terminal_job_state_ttl: 604800
+    terminal_runstate_ttl: 86400
+    active_runstate_ttl: 604800
     redis_event_ttl: 86400
     redis_event_max_entries: 100000
     dead_queue_marker_ttl: 86400
@@ -154,6 +156,8 @@ Retention pruning keeps hot-path stores and archives bounded.
 | `enabled` | `true` | Start pruning inside `skrift workers persister` |
 | `prune_interval` | `300.0` | Seconds between pruning passes |
 | `terminal_job_state_ttl` | `604800` | Age in seconds before completed, failed, cancelled, or dead-lettered Redis job state can be removed |
+| `terminal_runstate_ttl` | `86400` | TTL applied to an agent session's hot `RunState` once it reaches a terminal status (completed, failed, cancelled); the terminal state remains durable in the archive snapshot |
+| `active_runstate_ttl` | `604800` | Sliding TTL refreshed on every write to a non-terminal `RunState`, so a wedged session cannot leak indefinitely |
 | `redis_event_ttl` | `86400` | Minimum age before archived Redis stream events can be removed |
 | `redis_event_max_entries` | `100000` | Maximum Redis stream entries retained per stream after archive cursor safety checks |
 | `dead_queue_marker_ttl` | `86400` | Age before Redis dead queue markers can be removed |
@@ -169,7 +173,7 @@ skrift workers prune --json
 
 Redis lifecycle events are pruned only after the persister cursor shows they have been archived.
 
-The defaults keep Redis hot-path data long enough for fast recent `jobs inspect` and admin views while keeping longer operational history in SQLAlchemy archive and DLQ tables. Individual TTLs cannot be disabled; each TTL field must be a positive number. To disable pruning, set `workers.retention.enabled: false`.
+The defaults keep Redis hot-path data long enough for fast recent `jobs inspect` and admin views while keeping longer operational history in SQLAlchemy archive and DLQ tables. Each TTL field must be a positive number and cannot be disabled, with one exception: `active_runstate_ttl` may be set to `null` to leave non-terminal agent sessions without a sliding TTL (terminal sessions still expire via `terminal_runstate_ttl`). To disable pruning entirely, set `workers.retention.enabled: false`.
 
 ## Dead-Letter Queue
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "skrift"
-version = "0.2.0a1"
+version = "0.2.0a2"
 description = "A lightweight async Python CMS for crafting modern websites"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/skrift/agents/config.py
+++ b/skrift/agents/config.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import importlib
 from typing import Any
 
-from skrift.config import AgentsConfig
+from skrift.config import AgentsConfig, WorkerRetentionConfig
 
 
 def get_agents_config() -> AgentsConfig:
@@ -17,6 +17,17 @@ def get_agents_config() -> AgentsConfig:
         return get_settings().agents
     except Exception:
         return AgentsConfig()
+
+
+def get_worker_retention_config() -> WorkerRetentionConfig:
+    """Return worker retention settings, falling back to defaults when unavailable."""
+
+    try:
+        from skrift.config import get_settings
+
+        return get_settings().workers.retention
+    except Exception:
+        return WorkerRetentionConfig()
 
 
 def import_from_string(path: str) -> Any:

--- a/skrift/agents/state.py
+++ b/skrift/agents/state.py
@@ -9,7 +9,7 @@ from typing import Any
 from uuid import uuid4
 
 from skrift.agents.blob import offload_large_payload_fields
-from skrift.agents.config import get_agents_config
+from skrift.agents.config import get_agents_config, get_worker_retention_config
 from skrift.agents.models import (
     AGENT_EVENT_SCHEMA_VERSION,
     Actor,
@@ -36,13 +36,35 @@ def stream_name(session_id: str) -> str:
     return f"agents:run:{session_id}"
 
 
+def _runstate_ttl(state: RunState) -> float | None:
+    """TTL for a runstate write: bounded once terminal, sliding while active.
+
+    Terminal runstate is durable in the archive snapshot, so the hot copy is a
+    cache that can safely expire. Active sessions refresh a long sliding TTL on
+    every write so a wedged session can't leak indefinitely.
+    """
+
+    retention = get_worker_retention_config()
+    if state.terminal_at is not None:
+        return retention.terminal_runstate_ttl
+    return retention.active_runstate_ttl
+
+
+def _coerce_runstate(value: Any) -> RunState:
+    return value if isinstance(value, RunState) else RunState.model_validate(value)
+
+
 async def load_runstate(session_id: str) -> RunState | None:
-    value = await get_runtime().state_store.get(runstate_key(session_id))
-    if value is None:
+    runtime = get_runtime()
+    value = await runtime.state_store.get(runstate_key(session_id))
+    if value is not None:
+        return _coerce_runstate(value)
+    # Hot copy may have expired (terminal sessions get a bounded TTL); fall back
+    # to the durable archive snapshot so terminal sessions remain readable.
+    snapshot = await runtime.archive.latest_state_snapshot(runstate_key(session_id))
+    if snapshot is None:
         return None
-    if isinstance(value, RunState):
-        return value
-    return RunState.model_validate(value)
+    return _coerce_runstate(snapshot)
 
 
 async def update_runstate(session_id: str, fn: UpdateRunState) -> RunState:
@@ -63,7 +85,9 @@ async def update_runstate(session_id: str, fn: UpdateRunState) -> RunState:
             should_snapshot = True
         return next_state
 
-    updated = await get_runtime().state_store.update(runstate_key(session_id), wrapper)
+    updated = await get_runtime().state_store.update(
+        runstate_key(session_id), wrapper, ttl=_runstate_ttl
+    )
     if should_snapshot:
         await _snapshot_runstate(updated)
     return updated
@@ -81,7 +105,9 @@ async def create_or_update_runstate(state: RunState) -> RunState:
         existing = value if isinstance(value, RunState) else RunState.model_validate(value)
         return existing
 
-    updated = await get_runtime().state_store.update(runstate_key(state.session_id), wrapper)
+    updated = await get_runtime().state_store.update(
+        runstate_key(state.session_id), wrapper, ttl=_runstate_ttl
+    )
     if should_snapshot:
         await _snapshot_runstate(updated)
     return updated

--- a/skrift/config.py
+++ b/skrift/config.py
@@ -684,6 +684,8 @@ class WorkerRetentionConfig(BaseModel):
     enabled: bool = True
     prune_interval: float = Field(default=300.0, gt=0)
     terminal_job_state_ttl: float = Field(default=7 * 24 * 60 * 60, gt=0)
+    terminal_runstate_ttl: float = Field(default=24 * 60 * 60, gt=0)
+    active_runstate_ttl: float | None = Field(default=7 * 24 * 60 * 60, gt=0)
     redis_event_ttl: float = Field(default=24 * 60 * 60, gt=0)
     redis_event_max_entries: int = Field(default=100_000, ge=1)
     dead_queue_marker_ttl: float = Field(default=24 * 60 * 60, gt=0)

--- a/skrift/workers/interfaces.py
+++ b/skrift/workers/interfaces.py
@@ -15,6 +15,17 @@ class BackendCapabilities(frozenset[str]):
 
 UpdateFn = Callable[[Any], Any | Awaitable[Any]]
 
+# TTL may be a fixed value, or a callable resolved against the value being written
+# (the post-`fn` value for `update`). The callable form lets callers choose a TTL
+# based on the computed next value — e.g. a shorter TTL once a record is terminal.
+TTL = float | None | Callable[[Any], float | None]
+
+
+def resolve_ttl(ttl: TTL, value: Any) -> float | None:
+    """Resolve a TTL specification against the value being written."""
+
+    return ttl(value) if callable(ttl) else ttl
+
 
 class StateStore(Protocol):
     """Async key/value storage with atomic update semantics."""
@@ -22,9 +33,9 @@ class StateStore(Protocol):
     capabilities: BackendCapabilities
 
     async def get(self, key: str) -> Any: ...
-    async def set(self, key: str, value: Any, *, ttl: float | None = None) -> None: ...
+    async def set(self, key: str, value: Any, *, ttl: TTL = None) -> None: ...
     async def delete(self, key: str) -> None: ...
-    async def update(self, key: str, fn: UpdateFn, *, ttl: float | None = None) -> Any: ...
+    async def update(self, key: str, fn: UpdateFn, *, ttl: TTL = None) -> Any: ...
     async def keys(self, prefix: str = "") -> list[str]: ...
 
 

--- a/skrift/workers/memory.py
+++ b/skrift/workers/memory.py
@@ -11,7 +11,7 @@ from datetime import datetime, timedelta, timezone
 from typing import Any
 from uuid import uuid4
 
-from skrift.workers.interfaces import BackendCapabilities, UpdateFn
+from skrift.workers.interfaces import TTL, BackendCapabilities, UpdateFn, resolve_ttl
 from skrift.workers.models import (
     ClaimedJob,
     DeadJobEntry,
@@ -54,8 +54,9 @@ class InMemoryStateStore:
                 return None
             return stored.value
 
-    async def set(self, key: str, value: Any, *, ttl: float | None = None) -> None:
-        expires_at = _now() + timedelta(seconds=ttl) if ttl is not None else None
+    async def set(self, key: str, value: Any, *, ttl: TTL = None) -> None:
+        resolved_ttl = resolve_ttl(ttl, value)
+        expires_at = _now() + timedelta(seconds=resolved_ttl) if resolved_ttl is not None else None
         async with self._lock:
             self._values[key] = _StoredValue(value=value, expires_at=expires_at)
 
@@ -63,8 +64,7 @@ class InMemoryStateStore:
         async with self._lock:
             self._values.pop(key, None)
 
-    async def update(self, key: str, fn: UpdateFn, *, ttl: float | None = None) -> Any:
-        expires_at = _now() + timedelta(seconds=ttl) if ttl is not None else None
+    async def update(self, key: str, fn: UpdateFn, *, ttl: TTL = None) -> Any:
         async with self._lock:
             current = self._values.get(key)
             current_value = None
@@ -73,6 +73,10 @@ class InMemoryStateStore:
             next_value = fn(current_value)
             if inspect.isawaitable(next_value):
                 next_value = await next_value
+            resolved_ttl = resolve_ttl(ttl, next_value)
+            expires_at = (
+                _now() + timedelta(seconds=resolved_ttl) if resolved_ttl is not None else None
+            )
             self._values[key] = _StoredValue(value=next_value, expires_at=expires_at)
             return next_value
 

--- a/skrift/workers/redis.py
+++ b/skrift/workers/redis.py
@@ -12,7 +12,7 @@ from datetime import datetime, timedelta, timezone
 from typing import Any
 from uuid import uuid4
 
-from skrift.workers.interfaces import BackendCapabilities, UpdateFn
+from skrift.workers.interfaces import TTL, BackendCapabilities, UpdateFn, resolve_ttl
 from skrift.workers.models import (
     ClaimedJob,
     EventIdConflict,
@@ -131,13 +131,14 @@ class RedisStateStore(_RedisBackend):
     async def get(self, key: str) -> Any:
         return _value_from_json(_json_loads(await self._client.get(self._state_key(key))))
 
-    async def set(self, key: str, value: Any, *, ttl: float | None = None) -> None:
+    async def set(self, key: str, value: Any, *, ttl: TTL = None) -> None:
         redis_key = self._state_key(key)
         payload = _json_dumps(_value_to_json(value))
-        if ttl is None:
+        resolved_ttl = resolve_ttl(ttl, value)
+        if resolved_ttl is None:
             await self._client.set(redis_key, payload)
         else:
-            await self._client.set(redis_key, payload, px=max(1, int(ttl * 1000)))
+            await self._client.set(redis_key, payload, px=max(1, int(resolved_ttl * 1000)))
         await self._client.sadd(self._key("state", "keys"), key)
         if key.startswith("workers:jobs:"):
             await self._index_worker_job_state(key, value)
@@ -149,12 +150,14 @@ class RedisStateStore(_RedisBackend):
             await self._client.zrem(self._key("state", "worker_jobs"), key)
             await self._client.srem(self._key("state", "worker_jobs_active"), key)
 
-    async def update(self, key: str, fn: UpdateFn, *, ttl: float | None = None) -> Any:
+    async def update(self, key: str, fn: UpdateFn, *, ttl: TTL = None) -> Any:
         async with self._client.lock(self._key("state", "locks", key), timeout=10):
             current = await self.get(key)
             next_value = fn(current)
             if inspect.isawaitable(next_value):
                 next_value = await next_value
+            # `set` resolves a callable ttl against next_value, so terminal TTL is
+            # applied based on the post-`fn` state.
             await self.set(key, next_value, ttl=ttl)
             return next_value
 

--- a/skrift/workers/sqlalchemy.py
+++ b/skrift/workers/sqlalchemy.py
@@ -21,7 +21,7 @@ from skrift.db.models.worker import (
     WorkerQueueRecord,
     WorkerStateRecord,
 )
-from skrift.workers.interfaces import BackendCapabilities, UpdateFn
+from skrift.workers.interfaces import TTL, BackendCapabilities, UpdateFn, resolve_ttl
 from skrift.workers.models import (
     ClaimedJob,
     DeadJobEntry,
@@ -98,8 +98,9 @@ class SQLAlchemyStateStore(_SQLAlchemyBackend):
                 return None
             return _value_from_json(record.value)
 
-    async def set(self, key: str, value: Any, *, ttl: float | None = None) -> None:
-        expires_at = _now() + timedelta(seconds=ttl) if ttl is not None else None
+    async def set(self, key: str, value: Any, *, ttl: TTL = None) -> None:
+        resolved_ttl = resolve_ttl(ttl, value)
+        expires_at = _now() + timedelta(seconds=resolved_ttl) if resolved_ttl is not None else None
         async with self._session_maker() as session:
             result = await session.execute(
                 select(WorkerStateRecord).where(WorkerStateRecord.key == key)
@@ -123,8 +124,7 @@ class SQLAlchemyStateStore(_SQLAlchemyBackend):
             await session.execute(delete(WorkerStateRecord).where(WorkerStateRecord.key == key))
             await session.commit()
 
-    async def update(self, key: str, fn: UpdateFn, *, ttl: float | None = None) -> Any:
-        expires_at = _now() + timedelta(seconds=ttl) if ttl is not None else None
+    async def update(self, key: str, fn: UpdateFn, *, ttl: TTL = None) -> Any:
         async with self._session_maker() as session:
             result = await session.execute(
                 select(WorkerStateRecord)
@@ -140,6 +140,10 @@ class SQLAlchemyStateStore(_SQLAlchemyBackend):
             next_value = fn(current_value)
             if inspect.isawaitable(next_value):
                 next_value = await next_value
+            resolved_ttl = resolve_ttl(ttl, next_value)
+            expires_at = (
+                _now() + timedelta(seconds=resolved_ttl) if resolved_ttl is not None else None
+            )
             if record is None:
                 session.add(
                     WorkerStateRecord(

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -423,6 +423,37 @@ async def test_agent_runstate_is_snapshotted_to_archive():
     assert snapshot.session_id == session.id
 
 
+async def test_load_runstate_falls_back_to_archive_after_hot_copy_expires():
+    agent = skrift.Agent(TestModel(custom_output_text="hello"), name="demo")
+    session = await agent.run("hi", actor="ada")
+    runtime = skrift.get_runtime()
+
+    # Simulate the bounded terminal TTL lapsing on the hot copy.
+    await runtime.state_store.delete(runstate_key(session.id))
+    assert await runtime.state_store.get(runstate_key(session.id)) is None
+
+    restored = await load_runstate(session.id)
+
+    assert restored is not None
+    assert restored.session_id == session.id
+
+
+def test_runstate_ttl_uses_terminal_vs_active_window(monkeypatch):
+    import skrift.agents.state as agent_state
+    from skrift.agents.models import RunState
+    from skrift.config import WorkerRetentionConfig
+    from skrift.workers.models import utcnow
+
+    retention = WorkerRetentionConfig(terminal_runstate_ttl=60.0, active_runstate_ttl=600.0)
+    monkeypatch.setattr(agent_state, "get_worker_retention_config", lambda: retention)
+
+    active = RunState(session_id="s", agent_name="demo")
+    assert agent_state._runstate_ttl(active) == 600.0
+
+    terminal = RunState(session_id="s", agent_name="demo", terminal_at=utcnow())
+    assert agent_state._runstate_ttl(terminal) == 60.0
+
+
 async def test_configured_blob_backend_is_applied():
     configure_agent_runtime(
         AgentsConfig(blob_backend="skrift.agents.blob:ArchiveBlobStore")

--- a/tests/test_worker_backend_contracts.py
+++ b/tests/test_worker_backend_contracts.py
@@ -81,6 +81,19 @@ async def _assert_state_store_contract(store) -> None:
     await asyncio.sleep(0.02)
     assert await store.get("jobs:short") is None
 
+    # Callable TTL is resolved against the value being written (post-`fn` for update).
+    def ttl_for(value):
+        return 0.01 if value == "expire" else None
+
+    await store.set("jobs:keep", "stay", ttl=ttl_for)
+    await store.update("jobs:keep", lambda _v: "expire", ttl=ttl_for)
+    await asyncio.sleep(0.02)
+    assert await store.get("jobs:keep") is None
+
+    await store.set("jobs:persist", "stay", ttl=ttl_for)
+    await asyncio.sleep(0.02)
+    assert await store.get("jobs:persist") == "stay"
+
 
 async def _assert_event_log_contract(log) -> None:
     assert await log.append("contract", {"n": 1}) == 0


### PR DESCRIPTION
## Summary
Releases the fix for #145: terminal agent `RunState` blobs persisted in Redis forever (no TTL), growing the working set until the instance hit `maxmemory` and rejected all writes under `noeviction`. This release gives terminal runstate a bounded TTL while keeping active sessions alive and making expiry non-destructive via an archive read-through.

## Changes

### Bug Fixes
- Terminal `RunState` blobs now expire from Redis via a bounded TTL instead of accumulating indefinitely, preventing the OOM-wedge that took down mail ingestion in production (#145).

### New Features
- New `WorkerRetentionConfig` fields: `terminal_runstate_ttl` (default 24h, applied once a session is terminal) and `active_runstate_ttl` (default 7d, nullable sliding TTL refreshed on every write to a live session so a wedged session can't leak).

### Improvements
- State-store `set`/`update` now accept a callable `ttl` resolved against the value being written, so the terminal-vs-active TTL is chosen from the post-update state atomically within the existing lock/transaction (in-memory, Redis, and SQLAlchemy backends).
- `load_runstate` falls back to the durable archive snapshot when the hot copy has expired, keeping terminal sessions readable and improving existence-check correctness.
- Docs: documented the two new retention fields and the `active_runstate_ttl: null` opt-out.

## Release version
`0.2.0a1` -> `0.2.0a2`

🤖 Generated with [Claude Code](https://claude.com/claude-code)