### PR TITLE
Release v0.2.0a3 — OAuth2 consent CSP fix for external clients

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "skrift"
-version = "0.2.0a2"
+version = "0.2.0a3"
 description = "A lightweight async Python CMS for crafting modern websites"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/skrift/controllers/oauth2.py
+++ b/skrift/controllers/oauth2.py
@@ -9,7 +9,7 @@ import base64
 import hashlib
 import uuid
 from datetime import datetime, timezone
-from urllib.parse import urlencode
+from urllib.parse import urlencode, urlsplit
 
 from litestar import Controller, Request, get, post
 from litestar.response import Redirect, Response, Template as TemplateResponse
@@ -22,6 +22,7 @@ from skrift.auth.tokens import create_signed_token, verify_signed_token
 from skrift.config import get_settings
 from skrift.db.services import oauth2_service
 from skrift.forms import verify_csrf
+from skrift.middleware.security import add_form_action_source, apply_csp_nonce, csp_nonce_var
 
 # Token lifetimes
 AUTH_CODE_TTL = 600        # 10 minutes
@@ -148,7 +149,44 @@ class OAuth2Controller(Controller):
                 "scope_descriptions": scope_descriptions,
                 "request": request,
             },
+            headers=self._consent_csp_headers(redirect_uri),
         )
+
+    @staticmethod
+    def _consent_csp_headers(redirect_uri: str) -> dict[str, str]:
+        """Build a per-request CSP that permits the post-consent redirect.
+
+        Browsers enforce ``form-action`` against a form submission's redirect
+        destination, not just the form's ``action`` attribute. Since consent
+        approval redirects the user-agent to the client's ``redirect_uri`` —
+        which is on an arbitrary registered origin — the global
+        ``form-action 'self'`` blocks the final navigation.
+
+        ``redirect_uri`` has already been validated against the client's
+        registered allowlist by the caller, so appending its origin introduces
+        no open-redirect risk: only registered origins can ever appear here. The
+        deployment-configured CSP (including any extra ``form-action`` sources)
+        is preserved; this only widens ``form-action`` for this one response.
+
+        Returns an empty dict when CSP is disabled, leaving the default headers
+        from :class:`SecurityHeadersMiddleware` in place.
+        """
+        security = get_settings().security_headers
+        if not security.enabled or not security.content_security_policy:
+            return {}
+
+        parts = urlsplit(redirect_uri)
+        origin = f"{parts.scheme}://{parts.netloc}"
+        csp = add_form_action_source(security.content_security_policy, origin)
+
+        # The middleware skips its own CSP (and nonce injection) once a response
+        # carries one, so re-apply the nonce here to keep nonced markup working.
+        if security.csp_nonce:
+            nonce = csp_nonce_var.get("")
+            if nonce:
+                csp = apply_csp_nonce(csp, nonce)
+
+        return {"content-security-policy": csp}
 
     @post("/authorize")
     async def authorize_post(self, request: Request, db_session: AsyncSession) -> Redirect | Response:

--- a/skrift/middleware/security.py
+++ b/skrift/middleware/security.py
@@ -19,6 +19,37 @@ from litestar.types import ASGIApp, Receive, Scope, Send
 csp_nonce_var: contextvars.ContextVar[str] = contextvars.ContextVar("csp_nonce")
 
 _SCRIPT_SRC = re.compile(r"(script-src\s)([^;]*)")
+_FORM_ACTION = re.compile(r"(form-action\s)([^;]*)")
+
+
+def apply_csp_nonce(csp: str, nonce: str) -> str:
+    """Append ``'nonce-<nonce>'`` to the ``script-src`` directive.
+
+    ``style-src`` is intentionally left untouched because CSP nonces do not
+    cover inline ``style`` attributes.
+    """
+    return _SCRIPT_SRC.sub(rf"\1\2 'nonce-{nonce}'", csp)
+
+
+def add_form_action_source(csp: str, source: str) -> str:
+    """Allow ``source`` as a ``form-action`` destination in ``csp``.
+
+    If a ``form-action`` directive is present, ``source`` is appended unless it
+    is already listed. If absent, a ``form-action 'self' <source>`` directive is
+    added so the new source is allowed without silently relaxing the rest of the
+    policy. Used by the OAuth2 authorize endpoint to permit the post-consent
+    redirect to a validated, registered client ``redirect_uri`` origin.
+    """
+    if _FORM_ACTION.search(csp):
+        def _append(match: re.Match) -> str:
+            existing = match.group(2)
+            if source in existing.split():
+                return match.group(0)
+            return f"{match.group(1)}{existing.rstrip()} {source}"
+
+        return _FORM_ACTION.sub(_append, csp)
+
+    return f"{csp.rstrip().rstrip(';')}; form-action 'self' {source}"
 
 
 class SecurityHeadersMiddleware:
@@ -69,9 +100,7 @@ class SecurityHeadersMiddleware:
             csp_header: tuple[bytes, bytes] | None = None
             if self.csp_value:
                 if nonce:
-                    csp_str = _SCRIPT_SRC.sub(
-                        rf"\1\2 'nonce-{nonce}'", self.csp_value
-                    )
+                    csp_str = apply_csp_nonce(self.csp_value, nonce)
                 else:
                     csp_str = self.csp_value
                 csp_header = (b"content-security-policy", csp_str.encode())

--- a/tests/test_oauth2_server.py
+++ b/tests/test_oauth2_server.py
@@ -8,6 +8,7 @@ import pytest
 from litestar.response import Redirect, Template as TemplateResponse
 
 from skrift.auth.scopes import SCOPE_DEFINITIONS, register_scope, get_scope_definition
+from skrift.config import SecurityHeadersConfig
 from skrift.auth.tokens import create_signed_token, verify_signed_token
 from skrift.controllers.oauth2 import (
     OAuth2Controller,
@@ -27,6 +28,7 @@ def _make_settings():
     """Create a mock settings object."""
     settings = MagicMock()
     settings.secret_key = SECRET
+    settings.security_headers = SecurityHeadersConfig()
     return settings
 
 
@@ -286,13 +288,42 @@ class TestAuthorizeGet:
         db_session = AsyncMock()
         client = _mock_client(redirect_uris=["http://localhost/cb"])
 
-        with patch("skrift.controllers.oauth2.oauth2_service") as mock_svc:
+        with patch("skrift.controllers.oauth2.oauth2_service") as mock_svc, \
+             patch("skrift.controllers.oauth2.get_settings", return_value=_make_settings()):
             mock_svc.get_client_by_client_id = AsyncMock(return_value=client)
             result = await OAuth2Controller.authorize_get.fn(controller, request, db_session)
 
         assert isinstance(result, TemplateResponse)
         assert result.template_name == "oauth/authorize.html"
         assert session["oauth_authorize"]["client_id"] == "abc"
+
+    @pytest.mark.asyncio
+    async def test_consent_csp_allows_redirect_uri_origin(self):
+        """Consent response CSP widens form-action to the client redirect origin."""
+        controller = OAuth2Controller(owner=MagicMock())
+        request = MagicMock()
+        request.query_params = {
+            "response_type": "code",
+            "client_id": "abc",
+            "redirect_uri": "https://runhacks.sh/auth/callback",
+            "state": "xyz",
+            "scope": "openid profile",
+            "code_challenge": "challenge",
+            "code_challenge_method": "S256",
+        }
+        request.session = {"user_id": "user-123"}
+        db_session = AsyncMock()
+        client = _mock_client(redirect_uris=["https://runhacks.sh/auth/callback"])
+
+        with patch("skrift.controllers.oauth2.oauth2_service") as mock_svc, \
+             patch("skrift.controllers.oauth2.get_settings", return_value=_make_settings()):
+            mock_svc.get_client_by_client_id = AsyncMock(return_value=client)
+            result = await OAuth2Controller.authorize_get.fn(controller, request, db_session)
+
+        csp = dict(result.headers)["content-security-policy"]
+        assert "form-action 'self' https://runhacks.sh" in csp
+        # The client's path must not leak into the origin source.
+        assert "https://runhacks.sh/auth/callback" not in csp
 
 
 class TestAuthorizePost:

--- a/tests/test_security_headers.py
+++ b/tests/test_security_headers.py
@@ -3,7 +3,66 @@
 import pytest
 
 from skrift.config import SecurityHeadersConfig
-from skrift.middleware.security import SecurityHeadersMiddleware, csp_nonce_var
+from skrift.middleware.security import (
+    SecurityHeadersMiddleware,
+    add_form_action_source,
+    apply_csp_nonce,
+    csp_nonce_var,
+)
+
+
+class TestAddFormActionSource:
+    """Tests for the add_form_action_source helper."""
+
+    def test_appends_to_existing_form_action(self):
+        csp = "default-src 'self'; form-action 'self'; base-uri 'self'"
+        result = add_form_action_source(csp, "https://runhacks.sh")
+        assert "form-action 'self' https://runhacks.sh" in result
+        # Other directives are untouched.
+        assert "base-uri 'self'" in result
+
+    def test_preserves_existing_extra_sources(self):
+        csp = "form-action 'self' https://checkout.stripe.com; base-uri 'self'"
+        result = add_form_action_source(csp, "https://runhacks.sh")
+        assert (
+            "form-action 'self' https://checkout.stripe.com https://runhacks.sh"
+            in result
+        )
+
+    def test_does_not_duplicate_existing_source(self):
+        csp = "form-action 'self' https://runhacks.sh"
+        result = add_form_action_source(csp, "https://runhacks.sh")
+        assert result.count("https://runhacks.sh") == 1
+
+    def test_adds_directive_when_absent(self):
+        csp = "default-src 'self'; script-src 'self'"
+        result = add_form_action_source(csp, "https://runhacks.sh")
+        assert "form-action 'self' https://runhacks.sh" in result
+
+    def test_adds_directive_when_absent_trailing_semicolon(self):
+        csp = "default-src 'self';"
+        result = add_form_action_source(csp, "https://runhacks.sh")
+        assert result == "default-src 'self'; form-action 'self' https://runhacks.sh"
+
+    def test_only_touches_form_action_not_script_src(self):
+        csp = "script-src 'self'; form-action 'self'"
+        result = add_form_action_source(csp, "https://runhacks.sh")
+        assert "script-src 'self';" in result
+        assert "script-src 'self' https://runhacks.sh" not in result
+
+
+class TestApplyCspNonce:
+    """Tests for the apply_csp_nonce helper."""
+
+    def test_appends_nonce_to_script_src(self):
+        csp = "script-src 'self'; style-src 'self' 'unsafe-inline'"
+        result = apply_csp_nonce(csp, "abc123")
+        assert "script-src 'self' 'nonce-abc123'" in result
+
+    def test_leaves_style_src_untouched(self):
+        csp = "script-src 'self'; style-src 'self' 'unsafe-inline'"
+        result = apply_csp_nonce(csp, "abc123")
+        assert "style-src 'self' 'unsafe-inline'" in result
 
 
 class TestSecurityHeadersConfig:

--- a/uv.lock
+++ b/uv.lock
@@ -1957,7 +1957,7 @@ wheels = [
 
 [[package]]
 name = "skrift"
-version = "0.2.0a1"
+version = "0.2.0a3"
 source = { editable = "." }
 dependencies = [
     { name = "advanced-alchemy" },


### PR DESCRIPTION
## Summary
Alpha release `0.2.0a3` shipping the fix for #147 — the OAuth2 authorization server now works for clients whose `redirect_uri` is on a different origin than the Skrift server.

## Changes

### Bug Fixes
- **OAuth2 consent CSP blocks external client redirects (#147).** The consent page's global `Content-Security-Policy` `form-action 'self'` was blocking the browser from following the post-consent redirect to the client's registered `redirect_uri` on another origin, silently breaking login at the final step. The `GET /oauth/authorize` handler now attaches a per-request CSP that widens `form-action` to include the **already-validated** `redirect_uri` origin (scheme + host only), preserving any deployment-configured CSP and re-applying the script nonce. Only registered client origins can ever appear, so there is no open-redirect risk.

### Improvements
- Extracted reusable `apply_csp_nonce` and `add_form_action_source` CSP helpers in `skrift/middleware/security.py`; the security middleware now uses the shared nonce helper.
- Added unit tests for the new CSP helpers and a consent-page CSP test asserting the validated origin (not the path) is added to `form-action`.

## Release version
`0.2.0a2` -> `0.2.0a3`