### PR TITLE
fix(oauth2): URL-encode the authorize URL in the login `next` param

### DIFF
--- a/skrift/controllers/oauth2.py
+++ b/skrift/controllers/oauth2.py
@@ -120,7 +120,10 @@ class OAuth2Controller(Controller):
                 "code_challenge_method": code_challenge_method,
             })
             next_url = f"/oauth/authorize?{query}"
-            return Redirect(path=f"/auth/login?next={next_url}")
+            # next_url carries its own query string; it must be encoded as a
+            # single value or its `&`-separated params (response_type, ...) leak
+            # out of `next` and are lost across the login round-trip.
+            return Redirect(path=f"/auth/login?{urlencode({'next': next_url})}")
 
         # Store params in session for POST consent
         request.session["oauth_authorize"] = {

--- a/tests/test_oauth2_server.py
+++ b/tests/test_oauth2_server.py
@@ -271,6 +271,50 @@ class TestAuthorizeGet:
         assert "/auth/login" in result.url
 
     @pytest.mark.asyncio
+    async def test_login_redirect_preserves_full_authorize_url_in_next(self):
+        """Regression: the authorize URL must be encoded as a single `next`
+        value. If it isn't, its own `&`-separated params (response_type,
+        code_challenge, ...) leak out of `next` and are dropped across the
+        login round-trip, so the post-login bounce back to /oauth/authorize
+        fails with unsupported_response_type."""
+        from urllib.parse import parse_qs, urlsplit
+
+        controller = OAuth2Controller(owner=MagicMock())
+        request = MagicMock()
+        request.query_params = {
+            "response_type": "code",
+            "client_id": "abc",
+            "redirect_uri": "http://localhost/cb",
+            "state": "xyz",
+            "scope": "openid profile email",
+            "code_challenge": "challenge",
+            "code_challenge_method": "S256",
+        }
+        request.session = {}  # No user_id
+        db_session = AsyncMock()
+        client = _mock_client(redirect_uris=["http://localhost/cb"])
+
+        with patch("skrift.controllers.oauth2.oauth2_service") as mock_svc:
+            mock_svc.get_client_by_client_id = AsyncMock(return_value=client)
+            result = await OAuth2Controller.authorize_get.fn(controller, request, db_session)
+
+        assert isinstance(result, Redirect)
+        login = urlsplit(result.url)
+        assert login.path == "/auth/login"
+        # `next` must be the ONLY query param on the login URL — nothing leaked.
+        login_params = parse_qs(login.query)
+        assert set(login_params) == {"next"}
+        # ...and it must round-trip to the complete authorize URL.
+        authorize = urlsplit(login_params["next"][0])
+        assert authorize.path == "/oauth/authorize"
+        authorize_params = parse_qs(authorize.query)
+        assert authorize_params["response_type"] == ["code"]
+        assert authorize_params["redirect_uri"] == ["http://localhost/cb"]
+        assert authorize_params["code_challenge"] == ["challenge"]
+        assert authorize_params["code_challenge_method"] == ["S256"]
+        assert authorize_params["scope"] == ["openid profile email"]
+
+    @pytest.mark.asyncio
     async def test_shows_consent_screen_when_logged_in(self):
         controller = OAuth2Controller(owner=MagicMock())
         request = MagicMock()


### PR DESCRIPTION
## Problem

External OAuth2 logins fail with `{"error":"unsupported_response_type"}` for any user **not already signed in** to the Skrift OAuth2 server.

When an unauthenticated user hits `GET /oauth/authorize`, the server redirects them to `/auth/login?next=<authorize-url>` to return after login. The authorize URL carries its own query string, but it was interpolated raw into `next`:

```python
next_url = f"/oauth/authorize?{query}"
return Redirect(path=f"/auth/login?next={next_url}")
```

So the browser reads `next` only up to the first `&` — `next` becomes `/oauth/authorize?client_id=…` and the remaining params (`response_type`, `redirect_uri`, `code_challenge`, …) split off as throwaway params on `/auth/login`. After login, the bounce back to `/oauth/authorize` is missing `response_type` → `unsupported_response_type`.

Only the **logged-out** path is affected; the consent path (already authenticated) was fine.

## Fix

Encode the authorize URL as a single `next` value:

```python
return Redirect(path=f"/auth/login?{urlencode({'next': next_url})}")
```

`urlencode` is already imported.

## Test

Adds `TestAuthorizeGet::test_login_redirect_preserves_full_authorize_url_in_next`, which asserts `next` is the only param on the login URL and round-trips to the complete authorize URL. It fails on `main` (leaked `response_type`/`redirect_uri` params) and passes with the fix. Full oauth2/auth/provider suites green (93 passed).

## Repro

Discovered against a live deployment (Skrift 0.2.0a3 acting as OAuth2 provider) where a spoke site's federated login broke for logged-out users.

🤖 Generated with [Claude Code](https://claude.com/claude-code)