### PR TITLE
Bump version to 0.2.0a4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "skrift"
-version = "0.2.0a3"
+version = "0.2.0a4"
 description = "A lightweight async Python CMS for crafting modern websites"
 readme = "README.md"
 requires-python = ">=3.13"


### PR DESCRIPTION
Release 0.2.0a4. Includes the OAuth2 `next`-encoding fix (#149) so federated login works for logged-out users.