### PR TITLE
Release v0.2.0a5 — OAuth2 userinfo email_verified for federated login

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "skrift"
-version = "0.2.0a4"
+version = "0.2.0a5"
 description = "A lightweight async Python CMS for crafting modern websites"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/skrift/auth/scopes.py
+++ b/skrift/auth/scopes.py
@@ -42,4 +42,4 @@ def get_scope_definition(name: str) -> ScopeDefinition | None:
 # Built-in scopes
 register_scope("openid", "Verify your identity", claims=["sub"])
 register_scope("profile", "Access your name and picture", claims=["name", "picture"])
-register_scope("email", "Access your email address", claims=["email"])
+register_scope("email", "Access your email address", claims=["email", "email_verified"])

--- a/skrift/controllers/oauth2.py
+++ b/skrift/controllers/oauth2.py
@@ -9,6 +9,7 @@ import base64
 import hashlib
 import uuid
 from datetime import datetime, timezone
+from uuid import UUID
 from urllib.parse import urlencode, urlsplit
 
 from litestar import Controller, Request, get, post
@@ -20,7 +21,7 @@ from skrift.auth.scopes import SCOPE_DEFINITIONS
 from skrift.auth.session_keys import SESSION_USER_EMAIL, SESSION_USER_ID, SESSION_USER_NAME, SESSION_USER_PICTURE_URL
 from skrift.auth.tokens import create_signed_token, verify_signed_token
 from skrift.config import get_settings
-from skrift.db.services import oauth2_service
+from skrift.db.services import oauth2_service, oauth_service
 from skrift.forms import verify_csrf
 from skrift.middleware.security import add_form_action_source, apply_csp_nonce, csp_nonce_var
 
@@ -491,7 +492,15 @@ class OAuth2Controller(Controller):
         claims: dict = {"sub": payload["user_id"]}
 
         if "email" in allowed_claims:
-            claims["email"] = payload.get("email", "")
+            email = payload.get("email", "")
+            claims["email"] = email
+            # Report verification from this server's own records — never a
+            # blanket true. ``email_verified`` is set only when the user has a
+            # linked identity whose email was attested as verified, mirroring
+            # the gate that protects the email-match auto-link path.
+            claims["email_verified"] = await oauth_service.is_email_verified_for_user(
+                db_session, UUID(payload["user_id"]), email
+            )
         if "name" in allowed_claims:
             claims["name"] = payload.get("name", "")
         if "picture" in allowed_claims:

--- a/skrift/controllers/sitemap.py
+++ b/skrift/controllers/sitemap.py
@@ -157,7 +157,7 @@ Sitemap: {sitemap_url}
             "response_types_supported": ["code"],
             "grant_types_supported": ["authorization_code", "refresh_token"],
             "scopes_supported": ["openid", "profile", "email"],
-            "claims_supported": ["sub", "name", "email", "picture"],
+            "claims_supported": ["sub", "name", "email", "email_verified", "picture"],
             "code_challenge_methods_supported": ["S256"],
             "token_endpoint_auth_methods_supported": ["client_secret_post", "none"],
         }

--- a/skrift/db/services/oauth_service.py
+++ b/skrift/db/services/oauth_service.py
@@ -3,7 +3,7 @@
 from typing import Any
 from uuid import UUID
 
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from skrift.db.models.oauth_account import OAuthAccount
@@ -50,6 +50,32 @@ async def get_oauth_accounts_by_user(
         select(OAuthAccount).where(OAuthAccount.user_id == user_id)
     )
     return list(result.scalars().all())
+
+
+async def is_email_verified_for_user(
+    db_session: AsyncSession,
+    user_id: UUID,
+    email: str,
+) -> bool:
+    """Return whether this server has verified the user controls ``email``.
+
+    True only when the user has a linked :class:`OAuthAccount` whose
+    ``provider_email`` matches ``email`` (case-insensitively) and was attested
+    as verified at link time. This is the authoritative signal for emitting an
+    ``email_verified`` OIDC claim: a blanket ``true`` would re-open the
+    account-takeover vector that the email-verification challenge closes, since
+    an address may have been recorded from a non-verifying provider.
+    """
+    if not email:
+        return False
+    result = await db_session.execute(
+        select(OAuthAccount.id).where(
+            OAuthAccount.user_id == user_id,
+            OAuthAccount.provider_email_verified.is_(True),
+            func.lower(OAuthAccount.provider_email) == email.lower(),
+        )
+    )
+    return result.first() is not None
 
 
 async def get_provider_metadata(

--- a/tests/test_oauth2_server.py
+++ b/tests/test_oauth2_server.py
@@ -653,9 +653,10 @@ class TestUserInfo:
     @pytest.mark.asyncio
     async def test_valid_access_token_all_scopes(self):
         settings = _make_settings()
+        user_id = "00000000-0000-0000-0000-000000000123"
         access = create_signed_token({
             "type": "access",
-            "user_id": "user-123",
+            "user_id": user_id,
             "email": "test@test.com",
             "name": "Test User",
             "picture_url": "https://pic.url",
@@ -669,14 +670,17 @@ class TestUserInfo:
         db_session = AsyncMock()
 
         with patch("skrift.controllers.oauth2.get_settings", return_value=settings), \
-             patch("skrift.controllers.oauth2.oauth2_service") as mock_svc:
+             patch("skrift.controllers.oauth2.oauth2_service") as mock_svc, \
+             patch("skrift.controllers.oauth2.oauth_service") as mock_oauth_svc:
             mock_svc.is_token_revoked = AsyncMock(return_value=False)
+            mock_oauth_svc.is_email_verified_for_user = AsyncMock(return_value=True)
             result = await OAuth2Controller.userinfo.fn(controller, request, db_session)
 
         assert result.status_code == 200
         body = result.content
-        assert body["sub"] == "user-123"
+        assert body["sub"] == user_id
         assert body["email"] == "test@test.com"
+        assert body["email_verified"] is True
         assert body["name"] == "Test User"
         assert body["picture"] == "https://pic.url"
 

--- a/tests/test_oauth2_userinfo_scopes.py
+++ b/tests/test_oauth2_userinfo_scopes.py
@@ -14,6 +14,7 @@ from skrift.controllers.oauth2 import ACCESS_TOKEN_TTL, OAuth2Controller
 
 
 SECRET = "test-secret-key"
+USER_ID = "00000000-0000-0000-0000-000000000042"
 
 
 def _settings():
@@ -26,7 +27,7 @@ def _access_token(scope: str) -> str:
     return create_signed_token(
         {
             "type": "access",
-            "user_id": "user-42",
+            "user_id": USER_ID,
             "email": "u@example.com",
             "name": "U User",
             "picture_url": "https://x/p.png",
@@ -38,15 +39,17 @@ def _access_token(scope: str) -> str:
     )
 
 
-async def _userinfo(token: str) -> MagicMock:
+async def _userinfo(token: str, *, email_verified: bool = True) -> MagicMock:
     controller = OAuth2Controller(owner=MagicMock())
     request = MagicMock()
     request.headers = {"authorization": f"Bearer {token}"}
     db_session = AsyncMock()
 
     with patch("skrift.controllers.oauth2.get_settings", return_value=_settings()), \
-         patch("skrift.controllers.oauth2.oauth2_service") as mock_svc:
+         patch("skrift.controllers.oauth2.oauth2_service") as mock_svc, \
+         patch("skrift.controllers.oauth2.oauth_service") as mock_oauth_svc:
         mock_svc.is_token_revoked = AsyncMock(return_value=False)
+        mock_oauth_svc.is_email_verified_for_user = AsyncMock(return_value=email_verified)
         return await OAuth2Controller.userinfo.fn(controller, request, db_session)
 
 
@@ -56,8 +59,9 @@ async def test_empty_scope_returns_only_sub():
     This is the M6 regression — the prior behavior returned everything."""
     result = await _userinfo(_access_token(""))
     assert result.status_code == 200
-    assert result.content == {"sub": "user-42"}
+    assert result.content == {"sub": USER_ID}
     assert "email" not in result.content
+    assert "email_verified" not in result.content
     assert "name" not in result.content
     assert "picture" not in result.content
 
@@ -65,20 +69,36 @@ async def test_empty_scope_returns_only_sub():
 @pytest.mark.asyncio
 async def test_openid_scope_returns_only_sub():
     result = await _userinfo(_access_token("openid"))
-    assert result.content == {"sub": "user-42"}
+    assert result.content == {"sub": USER_ID}
 
 
 @pytest.mark.asyncio
 async def test_email_scope_returns_sub_and_email():
     result = await _userinfo(_access_token("openid email"))
-    assert result.content == {"sub": "user-42", "email": "u@example.com"}
+    assert result.content == {
+        "sub": USER_ID,
+        "email": "u@example.com",
+        "email_verified": True,
+    }
+
+
+@pytest.mark.asyncio
+async def test_email_verified_reflects_server_records():
+    """`email_verified` must mirror this server's own verification state,
+    not a blanket true — issue #151."""
+    result = await _userinfo(_access_token("openid email"), email_verified=False)
+    assert result.content == {
+        "sub": USER_ID,
+        "email": "u@example.com",
+        "email_verified": False,
+    }
 
 
 @pytest.mark.asyncio
 async def test_profile_scope_returns_sub_name_picture():
     result = await _userinfo(_access_token("openid profile"))
     assert result.content == {
-        "sub": "user-42",
+        "sub": USER_ID,
         "name": "U User",
         "picture": "https://x/p.png",
     }
@@ -88,8 +108,9 @@ async def test_profile_scope_returns_sub_name_picture():
 async def test_all_scopes_returns_full_claim_set():
     result = await _userinfo(_access_token("openid profile email"))
     assert result.content == {
-        "sub": "user-42",
+        "sub": USER_ID,
         "email": "u@example.com",
+        "email_verified": True,
         "name": "U User",
         "picture": "https://x/p.png",
     }

--- a/tests/test_oauth_service_email_verified.py
+++ b/tests/test_oauth_service_email_verified.py
@@ -1,0 +1,47 @@
+"""Unit tests for ``oauth_service.is_email_verified_for_user`` (issue #151).
+
+The OAuth2 ``/oauth/userinfo`` endpoint derives the ``email_verified`` claim
+from this helper. It must report verification from THIS server's own records —
+a linked, verified identity for the address — never a blanket true.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
+
+from skrift.db.services import oauth_service
+
+
+def _session_returning(row):
+    """AsyncMock session whose execute().first() yields ``row``."""
+    session = AsyncMock()
+    result = MagicMock()
+    result.first.return_value = row
+    session.execute = AsyncMock(return_value=result)
+    return session
+
+
+@pytest.mark.asyncio
+async def test_returns_true_when_verified_account_matches():
+    session = _session_returning((uuid4(),))
+    assert await oauth_service.is_email_verified_for_user(
+        session, uuid4(), "user@example.com"
+    ) is True
+
+
+@pytest.mark.asyncio
+async def test_returns_false_when_no_matching_verified_account():
+    session = _session_returning(None)
+    assert await oauth_service.is_email_verified_for_user(
+        session, uuid4(), "user@example.com"
+    ) is False
+
+
+@pytest.mark.asyncio
+async def test_empty_email_short_circuits_without_query():
+    session = _session_returning((uuid4(),))
+    assert await oauth_service.is_email_verified_for_user(
+        session, uuid4(), ""
+    ) is False
+    session.execute.assert_not_called()


### PR DESCRIPTION
## Summary
Fixes Skrift-to-Skrift (federated) OAuth login for email-matched users. The OAuth2 server never emitted an `email_verified` claim from `/oauth/userinfo`, so the client always read it as `false` and diverted returning users to an email-verification challenge instead of logging them in (issue #151).

The server now derives `email_verified` from its **own** verification records — never a blanket `true` — so the account-takeover gate that the challenge protects stays intact.

## Changes

### Bug Fixes
- `/oauth/userinfo` now emits an `email_verified` claim when the `email` scope is granted, derived from whether the user has a linked `OAuthAccount` whose `provider_email` matches the address and was attested verified (#151).
- Added `email_verified` to the `email` scope's claims and to `claims_supported` in the OpenID discovery document.

### Improvements
- New `oauth_service.is_email_verified_for_user(...)` helper centralizes the authoritative verification lookup (case-insensitive email match against verified linked identities).
- Added unit coverage for the helper and updated userinfo tests to assert `email_verified` reflects server records (true/false), not a constant.

## Release version
`0.2.0a4` -> `0.2.0a5`

Closes #151

🤖 Generated with [Claude Code](https://claude.com/claude-code)