### PR TITLE
Release v0.2.0a6 — multi-window rate limiting, dummy-login admin toggle, error-page fix

### DIFF
--- a/.claude/skills/skrift/SKILL.md
+++ b/.claude/skills/skrift/SKILL.md
@@ -203,6 +203,51 @@ middleware:
 
 `skrift/middleware/security.py` — ASGI middleware injecting CSP, HSTS, X-Frame-Options, etc. CSP nonces are auto-generated per request (see `/skrift-frontend` for usage). HSTS excluded in debug mode.
 
+## Rate Limiting
+
+Per-client sliding-window limits. The backend is chosen once from `redis.url`
+(shared across replicas) vs in-memory (process-local) — the built-in
+middleware, the failed-auth tracker, and any app code all use the same one, so
+setting `redis.url` makes every limiter distributed with no divergence.
+
+Declarative route rules in `app.yaml` (`skrift/config.py:RateLimitConfig`):
+
+```yaml
+rate_limit:
+  enabled: true
+  default: { limit: 120, per: minute }   # unmatched routes
+  auth:    { limit: 5,   per: minute }   # /auth/*
+  rules:
+    - match: { path: /book/inquiry, method: POST }
+      key: ip                              # or api_key (bearer / X-API-Key, IP fallback)
+      limits:                              # AND-logic; denied requests record nothing
+        - { limit: 1, per: minute }
+        - { limit: 6, per: hour }
+```
+
+`per` is `second|minute|hour|day` or a number of seconds. Most-specific rule
+wins (explicit `rules` > legacy `paths` prefixes > `/auth` > `default`); a
+matched rule's limits replace the default. Legacy `requests_per_minute` /
+`auth_requests_per_minute` / `paths` still work. Over-limit → `429` with a
+`Retry-After` for the binding (longest-blocking) window.
+
+Imperative API for dynamic or per-handler limits (`skrift/ratelimit.py`):
+
+```python
+from skrift.ratelimit import get_limiter
+
+verdict = await get_limiter().check(
+    name="inquiry", key=client_ip,
+    limits=[(1, "minute"), (6, "hour")],
+)
+if not verdict.allowed:
+    raise HTTPException(status_code=429, headers={"Retry-After": str(verdict.retry_after)})
+```
+
+`check()` denies if any window is exceeded, records nothing on denial, and
+reports the binding window's `retry_after`. For the lower-level record/count or
+single-window pattern, use `get_limiter().get_counter(window_seconds, name)`.
+
 ## Error Handling
 
 Custom exception handlers in `skrift/lib/exceptions.py`. Templates: `error.html`, `error-404.html`, `error-500.html`.

--- a/docs/development/dummy-auth.md
+++ b/docs/development/dummy-auth.md
@@ -47,7 +47,12 @@ This makes testing predictable—you can create test users and always log back i
 
 ## Testing Different Roles
 
-To test role-based features:
+The dummy login form has a **"Make this account an admin"** toggle. It's applied
+on every login: checking it grants the admin role, leaving it unchecked removes
+the admin role from the account. This lets you flip an account between admin and
+non-admin without touching the admin panel.
+
+To test other role-based features:
 
 1. Log in as any user via dummy auth
 2. Use the admin panel to assign roles to that user

--- a/docs/reference/security-features.md
+++ b/docs/reference/security-features.md
@@ -127,45 +127,116 @@ security_headers:
 
 ## Rate Limiting
 
-### RateLimitConfig
+Rate limiting supports **declarative multi-window route rules** in config and an
+**imperative limiter API** for dynamic or per-handler limits. Both run through a
+single backend-aware limiter, so the choice of backend is made in exactly one
+place.
 
-Configuration model in `skrift/config.py`:
+### Backend selection
 
-```python
-class RateLimitConfig(BaseModel):
-    enabled: bool = True
-    requests_per_minute: int = 60
-    auth_requests_per_minute: int = 10
-    paths: dict[str, int] = {}
-```
-
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| `enabled` | `bool` | `True` | Enable/disable rate limiting |
-| `requests_per_minute` | `int` | `60` | Default limit for all paths |
-| `auth_requests_per_minute` | `int` | `10` | Stricter limit for `/auth/*` paths |
-| `paths` | `dict[str, int]` | `{}` | Per-path-prefix overrides (e.g., `{"/api": 120}`) |
+The limiter uses **Redis** when `redis.url` is set (counts are shared across all
+replicas) and an **in-memory** counter otherwise (process-local). This applies
+to every limiter — the built-in middleware, the failed-auth tracker, and any app
+code that calls `get_limiter()` — so setting `redis.url` makes them all
+distributed at once, with no silent divergence.
 
 ### How It Works
 
-- **Sliding window**: Uses a 60-second sliding window per IP address
-- **Per-IP isolation**: Each client IP has independent rate counters
-- **Auth auto-detection**: Paths starting with `/auth` automatically use `auth_requests_per_minute`
-- **Longest prefix match**: Custom path overrides use longest-matching prefix
-- **Proxy support**: Reads `X-Forwarded-For` header for client IP when behind a reverse proxy
-- **429 response**: Returns `429 Too Many Requests` with a `Retry-After` header when the limit is exceeded
+- **Sliding window**: per-key sliding windows; multiple windows can apply to one route
+- **Multi-window AND-logic**: a request is denied if *any* window is exceeded
+- **All-or-nothing recording**: a denied request records nothing — being blocked by one window never consumes a slot in another
+- **Per-client isolation**: each client (IP or API key) has independent counters
+- **Auth auto-detection**: paths starting with `/auth` use the stricter auth window
+- **Most-specific rule wins**: explicit rules → legacy path prefixes (longest wins) → `/auth` → default; a matched rule's limits *replace* the default rather than stacking
+- **Proxy support**: uses the resolved client IP (`X-Forwarded-For` honored only behind trusted proxies)
+- **429 response**: returns `429 Too Many Requests` with a `Retry-After` header reflecting the binding (longest-blocking) window
 
-### Example app.yaml Configuration
+### Declarative configuration
 
 ```yaml
 rate_limit:
   enabled: true
+  default: { limit: 120, per: minute }   # applies to unmatched routes
+  auth:    { limit: 5,   per: minute }   # applies to /auth/*
+  rules:
+    # Anonymous lead-capture endpoint: 1/min AND 6/hr per client IP.
+    - match: { path: /book/inquiry, method: POST }
+      key: ip
+      limits:
+        - { limit: 1, per: minute }
+        - { limit: 6, per: hour }
+    # Prefix match (all methods) with an explicit per-second cap.
+    - match: { path: /api/, prefix: true }
+      key: api_key                        # bearer token / X-API-Key, falls back to IP
+      limits:
+        - { limit: 20, per: second }
+```
+
+`per` accepts `second`, `minute`, `hour`, `day`, or an explicit number of
+seconds. `key` is `ip` (default) or `api_key`. `match` selects requests by exact
+`path` (or `prefix: true`) and optional `method`.
+
+### Configuration fields
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `enabled` | `bool` | `True` | Enable/disable rate limiting |
+| `default` | window | — | Default window for unmatched routes |
+| `auth` | window | — | Window for `/auth/*` paths |
+| `rules` | list | `[]` | Declarative multi-window route rules |
+| `requests_per_minute` | `int` | `60` | **Legacy** default (used when `default` is unset) |
+| `auth_requests_per_minute` | `int` | `10` | **Legacy** auth limit (used when `auth` is unset) |
+| `paths` | `dict[str, int]` | `{}` | **Legacy** per-prefix per-minute overrides |
+
+### Migration from the legacy keys
+
+The legacy `requests_per_minute`, `auth_requests_per_minute`, and `paths` keys
+still work unchanged — they are treated as single per-minute windows. To adopt
+multiple windows or non-minute periods, move them to `default`/`auth`/`rules`:
+
+```yaml
+# Before
+rate_limit:
   requests_per_minute: 120
   auth_requests_per_minute: 5
   paths:
     /api: 200
-    /webhooks: 30
+
+# After
+rate_limit:
+  default: { limit: 120, per: minute }
+  auth:    { limit: 5,   per: minute }
+  rules:
+    - match: { path: /api, prefix: true }
+      limits: [ { limit: 200, per: minute } ]
 ```
+
+### Imperative limiter API
+
+For limits that can't be expressed as static route config (per-user actions,
+limits enforced inside a handler or guard, background jobs), call the shared
+limiter directly. It uses the same backend as everything else:
+
+```python
+from skrift.ratelimit import get_limiter
+from litestar.exceptions import HTTPException
+
+verdict = await get_limiter().check(
+    name="inquiry",                       # namespace for the counter
+    key=client_ip,                        # caller identity
+    limits=[(1, "minute"), (6, "hour")],  # one or more (limit, window) pairs
+)
+if not verdict.allowed:
+    raise HTTPException(
+        status_code=429,
+        headers={"Retry-After": str(verdict.retry_after)},
+    )
+```
+
+`check()` evaluates every window, denies if any is exceeded, records nothing on
+denial, and reports `retry_after` (seconds) for the binding window. For the
+lower-level `record`/`count` or single-window `check_and_record` pattern (e.g. a
+failed-attempt tracker), use `get_limiter().get_counter(window_seconds, name)`.
 
 ## CSRF Protection
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "skrift"
-version = "0.2.0a5"
+version = "0.2.0a6"
 description = "A lightweight async Python CMS for crafting modern websites"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/skrift/asgi.py
+++ b/skrift/asgi.py
@@ -43,7 +43,7 @@ from skrift.app_factory import (
     update_template_directories,
 )
 from skrift.config import DatabaseConfig, get_config_path, get_settings, is_config_valid
-from skrift.lib.sliding_window import InMemorySlidingWindowCounter, SlidingWindowCounter
+from skrift.ratelimit import RateLimiter, set_limiter
 from skrift.lib.trusted_proxy import TrustedProxyManager
 from skrift.middleware.client_ip import ClientIPMiddleware
 from skrift.middleware.rate_limit import RateLimitMiddleware
@@ -799,37 +799,14 @@ def create_app() -> ASGIApp:
         DefineMiddleware(ClientIPMiddleware, manager=trusted_proxy_manager)
     ]
 
-    # Sliding-window counter backend (shared by rate limit + failed-auth limiter).
-    # Redis is used when settings.redis.url is set; otherwise falls back to a
-    # process-local counter (not shared across replicas).
-    _redis_client = None
-    if settings.redis.url:
-        try:
-            from redis.asyncio import from_url as _redis_from_url
-
-            from skrift.lib.sliding_window_redis import RedisSlidingWindowCounter
-
-            _redis_client = _redis_from_url(settings.redis.url)
-            _rate_limit_counter: SlidingWindowCounter = RedisSlidingWindowCounter(
-                _redis_client,
-                window=60.0,
-                prefix=settings.redis.make_key("skrift", "ratelimit"),
-            )
-            _failed_auth_counter: SlidingWindowCounter = RedisSlidingWindowCounter(
-                _redis_client,
-                window=60.0,
-                prefix=settings.redis.make_key("skrift", "failed_auth"),
-            )
-            logger.info("Rate limiter backend: Redis (%s)", settings.redis.url)
-        except ImportError:
-            logger.warning(
-                "redis.asyncio not available; falling back to in-memory rate limiter"
-            )
-            _rate_limit_counter = InMemorySlidingWindowCounter(window=60.0)
-            _failed_auth_counter = InMemorySlidingWindowCounter(window=60.0)
-    else:
-        _rate_limit_counter = InMemorySlidingWindowCounter(window=60.0)
-        _failed_auth_counter = InMemorySlidingWindowCounter(window=60.0)
+    # Backend-aware rate limiter — the single place that picks Redis (shared
+    # across replicas) vs in-memory. The built-in middleware, the failed-auth
+    # tracker, and any app code all obtain their counters from it via
+    # get_limiter(), so they never diverge on the backend. Built once here and
+    # installed as the process-wide singleton.
+    rate_limiter = RateLimiter.from_settings(settings)
+    set_limiter(rate_limiter)
+    _redis_client = rate_limiter.redis_client
 
     # Rate limiting middleware
     rate_limit_middleware = []
@@ -837,10 +814,8 @@ def create_app() -> ASGIApp:
         rate_limit_middleware = [
             DefineMiddleware(
                 RateLimitMiddleware,
-                requests_per_minute=settings.rate_limit.requests_per_minute,
-                auth_requests_per_minute=settings.rate_limit.auth_requests_per_minute,
-                paths=settings.rate_limit.paths,
-                counter=_rate_limit_counter,
+                config=settings.rate_limit,
+                limiter=rate_limiter,
             )
         ]
 
@@ -1198,9 +1173,12 @@ def create_app() -> ASGIApp:
         app.state.bot_detection_store = bot_state_store
 
     # Install the shared failed-auth limiter on app.state so the notification
-    # webhook uses the Redis-backed counter when configured.
-    from skrift.controllers.notification_webhook import _FailedAuthLimiter
-    app.state.failed_auth_limiter = _FailedAuthLimiter(counter=_failed_auth_counter)
+    # webhook uses the same backend (Redis when configured) as every other
+    # limiter, via a counter obtained from the shared rate limiter.
+    from skrift.auth.failed_auth import FailedAuthLimiter
+    app.state.failed_auth_limiter = FailedAuthLimiter(
+        counter=rate_limiter.get_counter(60.0, "failed_auth")
+    )
 
     from skrift.middleware.storage import StorageFilesMiddleware
     from skrift.middleware.static import StaticFilesMiddleware

--- a/skrift/auth/failed_auth.py
+++ b/skrift/auth/failed_auth.py
@@ -1,0 +1,36 @@
+"""Per-IP failed-auth tracker.
+
+A thin wrapper over a :class:`~skrift.lib.sliding_window.SlidingWindowCounter`
+that records *only failed* attempts and blocks an IP once it crosses a
+threshold within the window. The counter is supplied by the shared rate
+limiter (:func:`skrift.ratelimit.get_limiter`), so it follows the same
+Redis-vs-in-memory backend selection as every other limiter.
+"""
+
+from __future__ import annotations
+
+from skrift.lib.sliding_window import InMemorySlidingWindowCounter, SlidingWindowCounter
+
+
+class FailedAuthLimiter:
+    """Per-IP sliding window that tracks failed auth attempts.
+
+    Only records *failed* attempts; successful requests don't touch it.
+    """
+
+    def __init__(
+        self,
+        max_failures: int = 1,
+        window: float = 60.0,
+        counter: SlidingWindowCounter | None = None,
+    ) -> None:
+        self.max_failures = max_failures
+        self._counter: SlidingWindowCounter = (
+            counter or InMemorySlidingWindowCounter(window=window)
+        )
+
+    async def record_failure(self, ip: str) -> None:
+        await self._counter.record(ip)
+
+    async def is_blocked(self, ip: str) -> bool:
+        return await self._counter.count(ip) >= self.max_failures

--- a/skrift/claude_skill/skrift/SKILL.md
+++ b/skrift/claude_skill/skrift/SKILL.md
@@ -203,6 +203,51 @@ middleware:
 
 `skrift/middleware/security.py` — ASGI middleware injecting CSP, HSTS, X-Frame-Options, etc. CSP nonces are auto-generated per request (see `/skrift-frontend` for usage). HSTS excluded in debug mode.
 
+## Rate Limiting
+
+Per-client sliding-window limits. The backend is chosen once from `redis.url`
+(shared across replicas) vs in-memory (process-local) — the built-in
+middleware, the failed-auth tracker, and any app code all use the same one, so
+setting `redis.url` makes every limiter distributed with no divergence.
+
+Declarative route rules in `app.yaml` (`skrift/config.py:RateLimitConfig`):
+
+```yaml
+rate_limit:
+  enabled: true
+  default: { limit: 120, per: minute }   # unmatched routes
+  auth:    { limit: 5,   per: minute }   # /auth/*
+  rules:
+    - match: { path: /book/inquiry, method: POST }
+      key: ip                              # or api_key (bearer / X-API-Key, IP fallback)
+      limits:                              # AND-logic; denied requests record nothing
+        - { limit: 1, per: minute }
+        - { limit: 6, per: hour }
+```
+
+`per` is `second|minute|hour|day` or a number of seconds. Most-specific rule
+wins (explicit `rules` > legacy `paths` prefixes > `/auth` > `default`); a
+matched rule's limits replace the default. Legacy `requests_per_minute` /
+`auth_requests_per_minute` / `paths` still work. Over-limit → `429` with a
+`Retry-After` for the binding (longest-blocking) window.
+
+Imperative API for dynamic or per-handler limits (`skrift/ratelimit.py`):
+
+```python
+from skrift.ratelimit import get_limiter
+
+verdict = await get_limiter().check(
+    name="inquiry", key=client_ip,
+    limits=[(1, "minute"), (6, "hour")],
+)
+if not verdict.allowed:
+    raise HTTPException(status_code=429, headers={"Retry-After": str(verdict.retry_after)})
+```
+
+`check()` denies if any window is exceeded, records nothing on denial, and
+reports the binding window's `retry_after`. For the lower-level record/count or
+single-window pattern, use `get_limiter().get_counter(window_seconds, name)`.
+
 ## Error Handling
 
 Custom exception handlers in `skrift/lib/exceptions.py`. Templates: `error.html`, `error-404.html`, `error-500.html`.

--- a/skrift/config.py
+++ b/skrift/config.py
@@ -1,5 +1,6 @@
 import os
 import re
+from dataclasses import dataclass
 from functools import lru_cache
 from pathlib import Path
 from typing import Literal
@@ -488,13 +489,177 @@ class SessionConfig(BaseModel):
     idle_timeout: int = 0
 
 
+# Friendly window-period names → seconds, for rate-limit windows.
+_RATE_LIMIT_PERIODS: dict[str, float] = {
+    "second": 1.0,
+    "minute": 60.0,
+    "hour": 3600.0,
+    "day": 86400.0,
+}
+
+
+def normalize_window(period: str | int | float) -> float:
+    """Resolve a rate-limit window period to seconds.
+
+    Accepts a friendly name (``"second" | "minute" | "hour" | "day"``) or an
+    explicit number of seconds.
+    """
+    if isinstance(period, bool):  # guard: bool is an int subclass
+        raise ValueError(f"Invalid rate-limit period: {period!r}")
+    if isinstance(period, (int, float)):
+        return float(period)
+    try:
+        return _RATE_LIMIT_PERIODS[period]
+    except KeyError as exc:
+        raise ValueError(
+            f"Unknown rate-limit period {period!r}; "
+            f"use seconds or one of {sorted(_RATE_LIMIT_PERIODS)}"
+        ) from exc
+
+
+@dataclass(frozen=True)
+class ResolvedRateLimit:
+    """The rate-limit policy that applies to one request.
+
+    ``limits`` is a list of ``(limit, window_seconds)`` pairs evaluated with
+    AND-logic; ``name`` namespaces the counter; ``key`` selects the caller
+    identity ("ip" or "api_key").
+    """
+
+    name: str
+    key: str
+    limits: list[tuple[int, float]]
+
+
+class RateLimitWindow(BaseModel):
+    """A single ``(limit, period)`` window."""
+
+    limit: int
+    per: str | int | float = "minute"
+
+    @model_validator(mode="after")
+    def _validate_period(self) -> "RateLimitWindow":
+        normalize_window(self.per)  # raises ValueError on an unknown period
+        return self
+
+    @property
+    def pair(self) -> tuple[int, float]:
+        return (self.limit, normalize_window(self.per))
+
+
+class RateLimitMatch(BaseModel):
+    """Which requests a rule applies to."""
+
+    path: str | None = None
+    method: str | None = None  # e.g. "POST"; None matches any method
+    prefix: bool = False  # match ``path`` as a prefix instead of exact
+
+
+class RateLimitRule(BaseModel):
+    """A declarative rate-limit rule: match → key → one or more windows."""
+
+    match: RateLimitMatch = RateLimitMatch()
+    key: Literal["ip", "api_key"] = "ip"
+    limits: list[RateLimitWindow]
+    name: str | None = None  # explicit counter namespace; derived if omitted
+
+
 class RateLimitConfig(BaseModel):
-    """Rate limiting configuration."""
+    """Rate limiting configuration.
+
+    Supports declarative multi-window rules (``default``/``auth``/``rules``)
+    while keeping the legacy single-per-minute keys
+    (``requests_per_minute``/``auth_requests_per_minute``/``paths``) working as
+    sugar. :meth:`resolve` compiles both into the single policy that applies
+    to a given request.
+    """
 
     enabled: bool = True
+
+    # Declarative (preferred).
+    default: RateLimitWindow | None = None
+    auth: RateLimitWindow | None = None
+    rules: list[RateLimitRule] = []
+
+    # Legacy single-per-minute settings (still supported).
     requests_per_minute: int = 60
     auth_requests_per_minute: int = 10
     paths: dict[str, int] = {}  # per-path-prefix overrides, e.g. {"/api": 120}
+
+    def effective_default(self) -> RateLimitWindow:
+        return self.default or RateLimitWindow(limit=self.requests_per_minute, per="minute")
+
+    def effective_auth(self) -> RateLimitWindow:
+        return self.auth or RateLimitWindow(limit=self.auth_requests_per_minute, per="minute")
+
+    @staticmethod
+    def _rule_name(index: int, rule: RateLimitRule) -> str:
+        if rule.name:
+            return rule.name
+        method = (rule.match.method or "any").lower()
+        return f"{method}:{rule.match.path or '*'}#{index}"
+
+    def resolve(self, path: str, method: str) -> ResolvedRateLimit:
+        """Return the most-specific policy for ``(path, method)``.
+
+        Precedence (highest first): explicit ``rules`` → legacy ``paths``
+        prefixes (longest wins) → the ``/auth`` policy → the default. A
+        matched rule's limits fully replace the default rather than stacking.
+        """
+        method = (method or "").upper()
+        best_spec: tuple | None = None
+        best: ResolvedRateLimit | None = None
+
+        def consider(spec: tuple, resolved: ResolvedRateLimit) -> None:
+            nonlocal best_spec, best
+            if best_spec is None or spec > best_spec:
+                best_spec, best = spec, resolved
+
+        for index, rule in enumerate(self.rules):
+            match = rule.match
+            if match.path is not None:
+                if match.prefix:
+                    if not path.startswith(match.path):
+                        continue
+                elif path != match.path:
+                    continue
+            if match.method is not None and method != match.method.upper():
+                continue
+            spec = (
+                3,
+                1 if match.method else 0,
+                0 if match.prefix else 1,
+                len(match.path or ""),
+            )
+            consider(
+                spec,
+                ResolvedRateLimit(
+                    name=self._rule_name(index, rule),
+                    key=rule.key,
+                    limits=[window.pair for window in rule.limits],
+                ),
+            )
+
+        for prefix, limit in self.paths.items():
+            if path.startswith(prefix):
+                consider(
+                    (2, 0, 0, len(prefix)),
+                    ResolvedRateLimit(f"path:{prefix}", "ip", [(limit, 60.0)]),
+                )
+
+        if path.startswith("/auth"):
+            consider(
+                (1, 0, 0, len("/auth")),
+                ResolvedRateLimit("auth", "ip", [self.effective_auth().pair]),
+            )
+
+        consider(
+            (0, 0, 0, 0),
+            ResolvedRateLimit("default", "ip", [self.effective_default().pair]),
+        )
+
+        assert best is not None  # the default branch always matches
+        return best
 
 
 class TrustedProxySourceConfig(BaseModel):

--- a/skrift/controllers/auth.py
+++ b/skrift/controllers/auth.py
@@ -53,6 +53,8 @@ from skrift.auth.second_factors.passkey_service import (
     complete_passkey_registration as complete_passkey_registration_flow,
     get_primary_passkey_registration_state,
 )
+from skrift.auth.roles import ADMIN
+from skrift.auth.services import assign_role_to_user, remove_role_from_user
 from skrift.auth.second_factors.registry import get_second_factor_method
 from skrift.auth.second_factors.services import (
     build_second_factor_transition_decision,
@@ -1174,6 +1176,7 @@ class AuthController(Controller):
         form_data = await request.form()
         email = form_data.get("email", "").strip()
         name = form_data.get("name", "").strip()
+        make_admin = bool(form_data.get("is_admin"))
 
         if not email:
             flash_error(request, "Email is required")
@@ -1206,6 +1209,14 @@ class AuthController(Controller):
         # ``email_verified=True`` on the identity.
         assert isinstance(login_result, LoginResult)
         await db_session.commit()
+
+        # The dummy login's admin toggle is a dev convenience: flip the account
+        # between admin and non-admin on every login so testers can switch roles
+        # without touching the admin panel.
+        if make_admin:
+            await assign_role_to_user(db_session, login_result.user.id, ADMIN.name)
+        else:
+            await remove_role_from_user(db_session, login_result.user.id, ADMIN.name)
 
         flash_success(request, "Successfully logged in!")
         return await _finalize_primary_login(

--- a/skrift/controllers/notification_webhook.py
+++ b/skrift/controllers/notification_webhook.py
@@ -8,44 +8,23 @@ from litestar.response import Response
 from pydantic import BaseModel, Field
 
 from skrift import notifications as _notifications_mod
+from skrift.auth.failed_auth import FailedAuthLimiter
 from skrift.lib.client_ip import get_client_ip
 from skrift.hooks import hooks, WEBHOOK_NOTIFICATION_RECEIVED
 from skrift.notifications import Notification, NotificationMode
-from skrift.lib.sliding_window import InMemorySlidingWindowCounter, SlidingWindowCounter
 
-
-class _FailedAuthLimiter:
-    """Per-IP sliding window that tracks failed auth attempts.
-
-    Only records *failed* attempts; successful requests don't touch it.
-    """
-
-    def __init__(
-        self,
-        max_failures: int = 1,
-        window: float = 60.0,
-        counter: SlidingWindowCounter | None = None,
-    ) -> None:
-        self.max_failures = max_failures
-        self._counter: SlidingWindowCounter = (
-            counter or InMemorySlidingWindowCounter(window=window)
-        )
-
-    async def record_failure(self, ip: str) -> None:
-        await self._counter.record(ip)
-
-    async def is_blocked(self, ip: str) -> bool:
-        return await self._counter.count(ip) >= self.max_failures
+# Backwards-compatible alias; the limiter now lives in skrift.auth.failed_auth.
+_FailedAuthLimiter = FailedAuthLimiter
 
 
 # Module-level fallback used when the app hasn't installed a shared counter.
-_failed_auth_limiter = _FailedAuthLimiter()
+_failed_auth_limiter = FailedAuthLimiter()
 
 
-def _get_limiter(request: Request) -> _FailedAuthLimiter:
+def _get_limiter(request: Request) -> FailedAuthLimiter:
     """Return the app-scoped failed-auth limiter, falling back to module-level."""
     limiter = getattr(request.app.state, "failed_auth_limiter", None)
-    if isinstance(limiter, _FailedAuthLimiter):
+    if isinstance(limiter, FailedAuthLimiter):
         return limiter
     return _failed_auth_limiter
 

--- a/skrift/lib/exceptions.py
+++ b/skrift/lib/exceptions.py
@@ -2,13 +2,17 @@ import hashlib
 import logging
 from pathlib import Path
 
+from collections.abc import Callable
+
 from litestar import Request, Response
 from litestar.exceptions import HTTPException
 from litestar.status_codes import HTTP_500_INTERNAL_SERVER_ERROR
+from markupsafe import Markup
 
 from skrift.auth.session_keys import SESSION_USER_EMAIL, SESSION_USER_ID, SESSION_USER_NAME, SESSION_USER_PICTURE_URL
 from skrift.config import get_settings
 from skrift.db.services.setting_service import get_cached_site_name
+from skrift.forms.core import CSRF_FIELD_NAME, CSRF_SESSION_KEY
 from skrift.lib import observability
 
 logger = logging.getLogger(__name__)
@@ -113,6 +117,26 @@ class SessionUser:
         self.picture_url = data.get("picture_url")
 
 
+def _csrf_field_from_session(session: dict | None) -> Callable[[], Markup]:
+    """Build a ``csrf_field`` callable for error-page rendering.
+
+    The production ``csrf_field`` template global reads ``request.session``, but
+    exception handlers render outside the session middleware, so that global
+    raises ``KeyError('request')`` and turns any error page into a second 500.
+    This standalone version reads the token straight from the cookie-decoded
+    session (the same dict the handler already uses for the logged-in user),
+    so the masthead's logout form renders with a valid token.
+    """
+
+    def csrf_field() -> Markup:
+        token = (session or {}).get(CSRF_SESSION_KEY, "")
+        return Markup(
+            f'<input type="hidden" name="{CSRF_FIELD_NAME}" value="{token}">'
+        )
+
+    return csrf_field
+
+
 def _render_error_response(
     request: Request, status_code: int, detail: str, json_detail: str | None = None
 ) -> Response:
@@ -129,6 +153,7 @@ def _render_error_response(
             message=detail,
             user=user,
             site_name=get_cached_site_name,
+            csrf_field=_csrf_field_from_session(session),
         )
         return Response(
             content=content,

--- a/skrift/lib/sliding_window.py
+++ b/skrift/lib/sliding_window.py
@@ -24,6 +24,10 @@ class SlidingWindowCounter(Protocol):
 
     async def check_and_record(self, key: str, limit: int) -> tuple[bool, int]: ...
 
+    async def check_and_record_multi(
+        self, key: str, limits: list[tuple[int, float]]
+    ) -> tuple[bool, int]: ...
+
     async def record(self, key: str) -> None: ...
 
     async def count(self, key: str) -> int: ...
@@ -39,6 +43,11 @@ class InMemorySlidingWindowCounter:
     def __init__(self, window: float = 60.0, cleanup_interval: float = 60.0) -> None:
         self.window = window
         self._buckets: dict[str, list[float]] = {}
+        # Multi-window keys hold all hit timestamps in a single list; each
+        # window is evaluated as a count over a different sub-range, so they
+        # can't share the single-window cleanup (which prunes by self.window).
+        self._multi_buckets: dict[str, list[float]] = {}
+        self._max_multi_window = 0.0
         self._last_cleanup = time.monotonic()
         self._cleanup_interval = cleanup_interval
 
@@ -54,6 +63,15 @@ class InMemorySlidingWindowCounter:
                 stale_keys.append(key)
         for key in stale_keys:
             del self._buckets[key]
+
+        multi_cutoff = now - self._max_multi_window
+        stale_multi = []
+        for key, timestamps in self._multi_buckets.items():
+            self._multi_buckets[key] = [t for t in timestamps if t > multi_cutoff]
+            if not self._multi_buckets[key]:
+                stale_multi.append(key)
+        for key in stale_multi:
+            del self._multi_buckets[key]
 
     async def record(self, key: str) -> None:
         """Record a hit for *key*."""
@@ -92,4 +110,44 @@ class InMemorySlidingWindowCounter:
             return False, max(retry_after, 1)
 
         self._buckets[key].append(now)
+        return True, 0
+
+    async def check_and_record_multi(
+        self, key: str, limits: list[tuple[int, float]]
+    ) -> tuple[bool, int]:
+        """Check *key* against every ``(limit, window_seconds)`` pair.
+
+        Denies if *any* window is exceeded; records a hit only when *every*
+        window passes (all-or-nothing — a denied request consumes no slot).
+        Returns ``(allowed, retry_after_seconds)`` where retry_after reflects
+        the binding (longest-blocking) window. Atomic by virtue of running to
+        completion without awaiting between the check and the record.
+        """
+        if not limits:
+            return True, 0
+
+        now = time.monotonic()
+        max_window = max(window for _, window in limits)
+        if max_window > self._max_multi_window:
+            self._max_multi_window = max_window
+        self._cleanup_stale(now)
+
+        timestamps = [t for t in self._multi_buckets.get(key, []) if t > now - max_window]
+        self._multi_buckets[key] = timestamps
+
+        retry_after = 0
+        for limit, window in limits:
+            cutoff = now - window
+            in_window = [t for t in timestamps if t > cutoff]
+            if len(in_window) >= limit:
+                # The (count - limit + 1)-th oldest entry must age out before a
+                # new hit fits; that entry sits at index (count - limit).
+                target = in_window[len(in_window) - limit]
+                window_retry = int(target - cutoff) + 1
+                retry_after = max(retry_after, window_retry)
+
+        if retry_after:
+            return False, max(retry_after, 1)
+
+        timestamps.append(now)
         return True, 0

--- a/skrift/lib/sliding_window_redis.py
+++ b/skrift/lib/sliding_window_redis.py
@@ -60,6 +60,65 @@ return {1, 0}
 """
 
 
+# Lua script: atomic multi-window check-and-record.
+#
+# A single sorted set holds every hit timestamp for the key; each window is
+# just a count over a different time sub-range. The script denies if ANY
+# window is at/over its limit and only ZADDs when EVERY window passes — so a
+# denied request records nothing.
+#
+# KEYS[1] = sorted set key
+# ARGV[1] = now (ms since epoch)
+# ARGV[2] = max window in ms (for pruning + key expiry)
+# ARGV[3] = unique member tag
+# ARGV[4..] = flattened (window_ms, limit) pairs
+#
+# Returns { allowed, retry_after_ms } where retry_after_ms is the max across
+# all exceeded windows (the binding, longest-blocking window).
+_CHECK_AND_RECORD_MULTI_SCRIPT = """
+local key = KEYS[1]
+local now = tonumber(ARGV[1])
+local max_window = tonumber(ARGV[2])
+local member = ARGV[3]
+
+redis.call('ZREMRANGEBYSCORE', key, 0, now - max_window)
+
+local blocked = 0
+local max_retry = 0
+local i = 4
+while i <= #ARGV do
+    local window = tonumber(ARGV[i])
+    local limit = tonumber(ARGV[i + 1])
+    local cutoff = now - window
+    local count = redis.call('ZCOUNT', key, '(' .. cutoff, '+inf')
+    if count >= limit then
+        local idx = count - limit
+        local entry = redis.call(
+            'ZRANGEBYSCORE', key, '(' .. cutoff, '+inf', 'LIMIT', idx, 1, 'WITHSCORES'
+        )
+        local score = tonumber(entry[2])
+        local retry = (score + window) - now
+        if retry < 1 then
+            retry = 1
+        end
+        if retry > max_retry then
+            max_retry = retry
+        end
+        blocked = 1
+    end
+    i = i + 2
+end
+
+if blocked == 1 then
+    return {0, max_retry}
+end
+
+redis.call('ZADD', key, now, member)
+redis.call('PEXPIRE', key, max_window + 1000)
+return {1, 0}
+"""
+
+
 class RedisSlidingWindowCounter:
     """Redis-backed counterpart of :class:`InMemorySlidingWindowCounter`.
 
@@ -74,61 +133,77 @@ class RedisSlidingWindowCounter:
         self.window = window
         self._window_ms = int(window * 1000)
         self._prefix = prefix.rstrip(":")
-        self._script_sha: str | None = None
+        # Cache the loaded SHA per script source, so each Lua script is loaded
+        # once and reused across calls.
+        self._script_shas: dict[str, str] = {}
 
     def _key(self, key: str) -> str:
         return f"{self._prefix}:{key}"
 
-    async def _eval(
-        self, *, key: str, limit: int, now_ms: int, member: str
-    ) -> tuple[int, int]:
-        # Lazy-load the Lua script; fall back to EVAL on NOSCRIPT errors.
-        if self._script_sha is None:
-            self._script_sha = await self._redis.script_load(_CHECK_AND_RECORD_SCRIPT)
+    @staticmethod
+    def _member(now_ms: int) -> str:
+        # Unique per call so two hits in the same millisecond both count
+        # (sorted-set members are unique by value, not score).
+        return f"{now_ms}-{next(_record_seq)}-{uuid.uuid4().hex[:8]}"
+
+    async def _run_script(self, script: str, key: str, *args) -> list:
+        """Run a cached Lua script, reloading once on NOSCRIPT."""
+        sha = self._script_shas.get(script)
+        if sha is None:
+            sha = self._script_shas[script] = await self._redis.script_load(script)
         try:
-            result = await self._redis.evalsha(
-                self._script_sha,
-                1,
-                self._key(key),
-                self._window_ms,
-                limit,
-                now_ms,
-                member,
-            )
+            return await self._redis.evalsha(sha, 1, self._key(key), *args)
         except Exception as exc:  # noqa: BLE001
             if "NOSCRIPT" not in str(exc).upper():
                 raise
-            self._script_sha = await self._redis.script_load(_CHECK_AND_RECORD_SCRIPT)
-            result = await self._redis.evalsha(
-                self._script_sha,
-                1,
-                self._key(key),
-                self._window_ms,
-                limit,
-                now_ms,
-                member,
-            )
-        allowed, retry_ms = int(result[0]), int(result[1])
-        return allowed, retry_ms
+            sha = self._script_shas[script] = await self._redis.script_load(script)
+            return await self._redis.evalsha(sha, 1, self._key(key), *args)
+
+    @staticmethod
+    def _retry_seconds(retry_ms: int) -> int:
+        return max(1, (retry_ms + 999) // 1000)  # round up to whole seconds
 
     async def check_and_record(self, key: str, limit: int) -> tuple[bool, int]:
         now_ms = int(time.time() * 1000)
-        member = f"{now_ms}-{next(_record_seq)}-{uuid.uuid4().hex[:8]}"
-        allowed, retry_ms = await self._eval(
-            key=key, limit=limit, now_ms=now_ms, member=member
+        result = await self._run_script(
+            _CHECK_AND_RECORD_SCRIPT,
+            key,
+            self._window_ms,
+            limit,
+            now_ms,
+            self._member(now_ms),
         )
-        if allowed:
+        if int(result[0]):
             return True, 0
-        retry_seconds = max(1, (retry_ms + 999) // 1000)  # round up to whole seconds
-        return False, retry_seconds
+        return False, self._retry_seconds(int(result[1]))
+
+    async def check_and_record_multi(
+        self, key: str, limits: list[tuple[int, float]]
+    ) -> tuple[bool, int]:
+        if not limits:
+            return True, 0
+        now_ms = int(time.time() * 1000)
+        max_window_ms = int(max(window for _, window in limits) * 1000)
+        window_args: list[int] = []
+        for limit, window in limits:
+            window_args.extend((int(window * 1000), limit))
+        result = await self._run_script(
+            _CHECK_AND_RECORD_MULTI_SCRIPT,
+            key,
+            now_ms,
+            max_window_ms,
+            self._member(now_ms),
+            *window_args,
+        )
+        if int(result[0]):
+            return True, 0
+        return False, self._retry_seconds(int(result[1]))
 
     async def record(self, key: str) -> None:
         # Record a hit unconditionally.
         now_ms = int(time.time() * 1000)
         cutoff = now_ms - self._window_ms
-        # Unique per-record member so two calls within the same millisecond
-        # both count (sorted-set members are unique by value, not score).
-        member = f"{now_ms}-{next(_record_seq)}-{uuid.uuid4().hex[:8]}"
+        member = self._member(now_ms)
         k = self._key(key)
         pipe = self._redis.pipeline()
         pipe.zremrangebyscore(k, 0, cutoff)

--- a/skrift/middleware/rate_limit.py
+++ b/skrift/middleware/rate_limit.py
@@ -1,66 +1,75 @@
 """Rate limiting middleware for Skrift.
 
-Implements per-client-IP sliding window rate limiting. Auth paths get stricter
-limits, and custom per-path-prefix overrides are supported.
+Enforces declarative, multi-window per-client rate limits. For each request the
+middleware picks the most-specific matching rule from :class:`RateLimitConfig`
+and evaluates it through the shared :class:`~skrift.ratelimit.RateLimiter`, so
+the backend (in-memory vs Redis) is chosen in exactly one place and every
+limiter agrees.
 
-The counter backend is injected — in-memory by default, Redis when configured.
-See :mod:`skrift.lib.sliding_window` and
-:mod:`skrift.lib.sliding_window_redis`.
+Static route policy is pure config — see ``rate_limit.rules`` in app.yaml. For
+dynamic or per-handler limits, call ``get_limiter().check(...)`` directly.
 """
 
 from __future__ import annotations
 
 from litestar.types import ASGIApp, Receive, Scope, Send
 
+from skrift.config import RateLimitConfig
 from skrift.lib.client_ip import get_client_ip
-from skrift.lib.sliding_window import InMemorySlidingWindowCounter, SlidingWindowCounter
+from skrift.ratelimit import RateLimiter
+
+
+def _resolve_caller_key(scope: Scope, key_kind: str) -> str:
+    """Derive the caller-identity string for a rule's ``key`` strategy.
+
+    ``ip`` uses the resolved client IP. ``api_key`` uses the bearer token /
+    ``X-API-Key`` header, falling back to the client IP for anonymous callers
+    so an api_key-keyed rule still limits unauthenticated traffic.
+    """
+    if key_kind == "api_key":
+        headers = dict(scope.get("headers", []))
+        authorization = headers.get(b"authorization", b"")
+        if authorization.lower().startswith(b"bearer "):
+            return "apikey:" + authorization[7:].decode("latin-1").strip()
+        api_key_header = headers.get(b"x-api-key", b"")
+        if api_key_header:
+            return "apikey:" + api_key_header.decode("latin-1").strip()
+    return get_client_ip(scope)
 
 
 class RateLimitMiddleware:
-    """ASGI middleware that enforces per-IP request rate limits.
+    """ASGI middleware that enforces per-client multi-window rate limits.
 
     Args:
         app: The ASGI application to wrap.
-        requests_per_minute: Default limit for all paths.
-        auth_requests_per_minute: Stricter limit for /auth/* paths.
-        paths: Dict of path-prefix -> requests_per_minute overrides.
-        counter: Optional pre-built counter. Falls back to an in-memory
-            counter when ``None`` — convenient for tests.
+        config: The rate-limit configuration. Built from the legacy keyword
+            arguments when omitted.
+        limiter: The shared rate limiter. An in-memory limiter is created when
+            omitted — convenient for tests.
+        requests_per_minute: Legacy default limit (used only when ``config``
+            is not supplied).
+        auth_requests_per_minute: Legacy stricter limit for ``/auth`` paths.
+        paths: Legacy dict of path-prefix -> requests_per_minute overrides.
     """
 
     def __init__(
         self,
         app: ASGIApp,
+        config: RateLimitConfig | None = None,
+        limiter: RateLimiter | None = None,
         requests_per_minute: int = 60,
         auth_requests_per_minute: int = 10,
         paths: dict[str, int] | None = None,
-        counter: SlidingWindowCounter | None = None,
     ) -> None:
         self.app = app
-        self.requests_per_minute = requests_per_minute
-        self.auth_requests_per_minute = auth_requests_per_minute
-        self.paths = paths or {}
-        self._counter: SlidingWindowCounter = counter or InMemorySlidingWindowCounter(window=60.0)
-
-    def _get_limit(self, path: str) -> tuple[str, int]:
-        """Determine the rate limit and bucket suffix for a path.
-
-        Returns (bucket_suffix, limit_per_minute).
-        """
-        # Check custom path prefixes first (longest match wins)
-        best_match = ""
-        for prefix, limit in self.paths.items():
-            if path.startswith(prefix) and len(prefix) > len(best_match):
-                best_match = prefix
-
-        if best_match:
-            return best_match, self.paths[best_match]
-
-        # Auth paths get stricter limits
-        if path.startswith("/auth"):
-            return "/auth", self.auth_requests_per_minute
-
-        return "", self.requests_per_minute
+        self.config = config or RateLimitConfig(
+            requests_per_minute=requests_per_minute,
+            auth_requests_per_minute=auth_requests_per_minute,
+            paths=paths or {},
+        )
+        # An in-memory limiter keeps the middleware self-contained for tests
+        # and apps that never set redis.url.
+        self.limiter = limiter or RateLimiter(redis_client=None)
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         if scope["type"] != "http":
@@ -68,18 +77,18 @@ class RateLimitMiddleware:
             return
 
         path = scope.get("path", "/")
-        ip = get_client_ip(scope)
-        bucket_suffix, limit = self._get_limit(path)
-        key = f"{ip}:{bucket_suffix}"
-        allowed, retry_after = await self._counter.check_and_record(key, limit)
+        method = scope.get("method", "GET")
+        rule = self.config.resolve(path, method)
+        caller_key = _resolve_caller_key(scope, rule.key)
+        verdict = await self.limiter.check(rule.name, caller_key, rule.limits)
 
-        if not allowed:
+        if not verdict.allowed:
             await send({
                 "type": "http.response.start",
                 "status": 429,
                 "headers": [
                     (b"content-type", b"text/plain; charset=utf-8"),
-                    (b"retry-after", str(retry_after).encode()),
+                    (b"retry-after", str(verdict.retry_after).encode()),
                 ],
             })
             await send({

--- a/skrift/ratelimit.py
+++ b/skrift/ratelimit.py
@@ -1,0 +1,207 @@
+"""Backend-aware rate limiting primitive.
+
+This is the single place that decides whether rate limiting runs on Redis
+(shared across replicas) or in-memory (process-local), so every limiter —
+the built-in middleware, the failed-auth tracker, and any app code — agrees
+on the backend. Set ``redis.url`` and they all go distributed; leave it unset
+and they all stay per-process. No consumer constructs counters or reads
+``settings.redis`` directly.
+
+Two surfaces:
+
+* :func:`get_limiter` → :class:`RateLimiter` for the common case::
+
+      from skrift.ratelimit import get_limiter
+
+      verdict = await get_limiter().check(
+          name="capture",                       # namespace for keys
+          key=client_ip,                        # caller identity
+          limits=[(1, "minute"), (6, "hour")],  # one or more (limit, window)
+      )
+      if not verdict.allowed:
+          raise TooManyRequests(retry_after=verdict.retry_after)
+
+* :meth:`RateLimiter.get_counter` for the lower-level ``record``/``count`` or
+  single-window ``check_and_record`` pattern (e.g. the failed-auth tracker).
+
+The ``check`` call evaluates every ``(limit, window)`` pair, denies if any is
+exceeded, records nothing on denial, and reports ``retry_after`` for the
+binding (longest-blocking) window.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+
+from skrift.config import RedisConfig, get_settings, normalize_window
+from skrift.lib.sliding_window import InMemorySlidingWindowCounter, SlidingWindowCounter
+
+logger = logging.getLogger(__name__)
+
+# normalize_window is re-exported from config so callers can import it from
+# either module; config owns it to avoid an import cycle (config can't import
+# this module).
+__all__ = [
+    "RateLimiter",
+    "Verdict",
+    "get_limiter",
+    "set_limiter",
+    "reset_limiter",
+    "normalize_window",
+]
+
+# Redis key namespace for limiter counters: e.g. "skrift:ratelimit:<name>:<key>".
+_KEY_NAMESPACE = ("skrift", "ratelimit")
+
+# Nominal window for the per-name multi-window counter. The multi-window check
+# carries its own windows, so this only affects the counter's single-window
+# bookkeeping (unused on the ``check`` path).
+_MULTI_COUNTER_WINDOW = 60.0
+
+
+@dataclass(frozen=True)
+class Verdict:
+    """Outcome of a rate-limit check.
+
+    ``retry_after`` is the number of seconds until the binding window frees up;
+    it is 0 when ``allowed`` is True.
+    """
+
+    allowed: bool
+    retry_after: int = 0
+
+
+class RateLimiter:
+    """Owns backend selection and reuses a single Redis client process-wide.
+
+    Prefer :func:`get_limiter` over constructing this directly; the explicit
+    constructor exists for wiring and tests.
+    """
+
+    def __init__(
+        self,
+        *,
+        redis_client: object | None = None,
+        redis_config: RedisConfig | None = None,
+    ) -> None:
+        self._redis_client = redis_client
+        self._redis_config = redis_config or RedisConfig()
+        self._counters: dict[tuple[str, float], SlidingWindowCounter] = {}
+        self._multi_counters: dict[str, SlidingWindowCounter] = {}
+
+    @classmethod
+    def from_settings(cls, settings) -> "RateLimiter":
+        """Build a limiter from app settings, choosing Redis vs in-memory."""
+        redis_client = None
+        if settings.redis.url:
+            try:
+                from redis.asyncio import from_url as redis_from_url
+
+                redis_client = redis_from_url(settings.redis.url)
+                logger.info("Rate limiter backend: Redis (%s)", settings.redis.url)
+            except ImportError:
+                logger.warning(
+                    "redis.asyncio not available; falling back to in-memory rate limiter"
+                )
+        return cls(redis_client=redis_client, redis_config=settings.redis)
+
+    @property
+    def backend(self) -> str:
+        return "redis" if self._redis_client is not None else "memory"
+
+    @property
+    def redis_client(self) -> object | None:
+        """The shared Redis client, or None on the in-memory backend.
+
+        Exposed so other Redis-backed features can reuse the one connection.
+        """
+        return self._redis_client
+
+    def _make_counter(self, window: float, name: str) -> SlidingWindowCounter:
+        if self._redis_client is not None:
+            from skrift.lib.sliding_window_redis import RedisSlidingWindowCounter
+
+            prefix = self._redis_config.make_key(*_KEY_NAMESPACE, name)
+            return RedisSlidingWindowCounter(
+                self._redis_client, window=window, prefix=prefix
+            )
+        return InMemorySlidingWindowCounter(window=window)
+
+    def get_counter(self, window: float, name: str) -> SlidingWindowCounter:
+        """Return a namespaced single-window counter, reused across calls.
+
+        For callers that need the ``record``/``count`` or ``check_and_record``
+        surface directly. ``window`` is in seconds.
+        """
+        cache_key = (name, window)
+        counter = self._counters.get(cache_key)
+        if counter is None:
+            counter = self._counters[cache_key] = self._make_counter(window, name)
+        return counter
+
+    def _multi_counter(self, name: str) -> SlidingWindowCounter:
+        # One stable counter per name, independent of the limits passed to
+        # check(), so multi-window state for a name never splits.
+        counter = self._multi_counters.get(name)
+        if counter is None:
+            counter = self._multi_counters[name] = self._make_counter(
+                _MULTI_COUNTER_WINDOW, name
+            )
+        return counter
+
+    async def check(
+        self,
+        name: str,
+        key: str,
+        limits: list[tuple[int, str | int | float]],
+    ) -> Verdict:
+        """Check ``key`` under ``name`` against one or more ``(limit, window)``.
+
+        Denies if any window is exceeded; records a hit only when all windows
+        pass (a denied request consumes no slot). ``window`` may be a friendly
+        period name or seconds.
+        """
+        if not limits:
+            return Verdict(allowed=True)
+        normalized = [(limit, normalize_window(period)) for limit, period in limits]
+        counter = self._multi_counter(name)
+        allowed, retry_after = await counter.check_and_record_multi(key, normalized)
+        return Verdict(allowed=allowed, retry_after=retry_after)
+
+    async def aclose(self) -> None:
+        """Close the shared Redis client, if any."""
+        client = self._redis_client
+        if client is not None and hasattr(client, "aclose"):
+            await client.aclose()
+
+
+_limiter: RateLimiter | None = None
+
+
+def get_limiter() -> RateLimiter:
+    """Return the process-wide rate limiter, building it on first use."""
+    global _limiter
+    if _limiter is None:
+        _limiter = RateLimiter.from_settings(get_settings())
+    return _limiter
+
+
+def set_limiter(limiter: RateLimiter) -> None:
+    """Install a pre-built limiter as the process-wide singleton.
+
+    Used by app startup so the limiter and its Redis client are created once
+    and shared, rather than lazily rebuilt.
+    """
+    global _limiter
+    _limiter = limiter
+
+
+def reset_limiter() -> None:
+    """Drop the cached limiter so the next ``get_limiter`` rebuilds it.
+
+    Called when settings are reloaded (e.g. in tests). Does not close the
+    Redis client — app shutdown owns that via :meth:`RateLimiter.aclose`.
+    """
+    global _limiter
+    _limiter = None

--- a/skrift/templates/auth/dummy_login.html
+++ b/skrift/templates/auth/dummy_login.html
@@ -44,6 +44,18 @@
         color: var(--sk-color-muted, #666);
     }
 
+    .admin-toggle label {
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+        cursor: pointer;
+    }
+
+    .admin-toggle input[type="checkbox"] {
+        width: auto;
+        margin: 0;
+    }
+
     .submit-btn {
         width: 100%;
         padding: 1rem;
@@ -92,6 +104,14 @@
                 <label for="name">Name</label>
                 <input type="text" id="name" name="name" placeholder="Test User">
                 <small>Optional. Defaults to email username if not provided.</small>
+            </div>
+
+            <div class="form-group admin-toggle">
+                <label for="is_admin">
+                    <input type="checkbox" id="is_admin" name="is_admin" value="1">
+                    Make this account an admin
+                </label>
+                <small>Grants the admin role on login. Unchecking removes it.</small>
             </div>
 
             <button type="submit" class="submit-btn">Login</button>

--- a/tests/test_auth_controller.py
+++ b/tests/test_auth_controller.py
@@ -1,14 +1,20 @@
 """Tests for the authentication controller."""
 
+import contextlib
+
 import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
+from litestar.response import Redirect
+
 from skrift.controllers.auth import (
+    AuthController,
     _finalize_primary_login,
     _set_login_session,
     _exchange_and_fetch,
 )
+from skrift.auth.oauth_account_service import LoginResult
 from skrift.lib.redirects import (
     get_safe_redirect_url as _get_safe_redirect_url,
     is_safe_redirect_url as _is_safe_redirect_url,
@@ -660,3 +666,99 @@ class TestVerifyMethodPage:
         assert isinstance(result, TemplateResponse)
         assert result.template_name == "auth/verify_passkey.html"
         assert result.context["factor_key"] == "passkey"
+
+
+class TestDummyLoginAdminToggle:
+    """The dummy login's admin toggle assigns or removes the admin role."""
+
+    @staticmethod
+    def _make_request(form_data: dict):
+        request = MagicMock()
+        request.session = {}
+
+        async def _form():
+            return form_data
+
+        request.form = _form
+        return request
+
+    @staticmethod
+    def _patches(login_result, assign_mock, remove_mock):
+        settings = MagicMock()
+        settings.auth.get_method_keys.return_value = ["dummy"]
+
+        async def _valid_csrf(_req):
+            return True
+
+        async def _find_or_create(_db, _identity):
+            return login_result
+
+        async def _finalize(*_args, **_kwargs):
+            return Redirect(path="/")
+
+        return [
+            patch("skrift.controllers.auth.get_settings", return_value=settings),
+            patch("skrift.controllers.auth.verify_csrf", new=_valid_csrf),
+            patch(
+                "skrift.controllers.auth.find_or_create_user_for_identity",
+                new=_find_or_create,
+            ),
+            patch("skrift.controllers.auth._finalize_primary_login", new=_finalize),
+            patch("skrift.controllers.auth.flash_success"),
+            patch("skrift.controllers.auth.assign_role_to_user", new=assign_mock),
+            patch("skrift.controllers.auth.remove_role_from_user", new=remove_mock),
+        ]
+
+    @pytest.mark.asyncio
+    async def test_toggle_on_assigns_admin_role(self):
+        user = MagicMock()
+        user.id = uuid4()
+        login_result = LoginResult(
+            user=user,
+            identity_record=None,
+            is_new_user=True,
+            method_key="dummy",
+            method_type="dummy",
+        )
+
+        assign_mock = AsyncMock(return_value=True)
+        remove_mock = AsyncMock(return_value=True)
+
+        auth = AuthController(owner=MagicMock())
+        request = self._make_request({"email": "admin@example.com", "is_admin": "1"})
+        db_session = AsyncMock()
+
+        with contextlib.ExitStack() as stack:
+            for p in self._patches(login_result, assign_mock, remove_mock):
+                stack.enter_context(p)
+            await AuthController.dummy_login_submit.fn(auth, request, db_session)
+
+        assign_mock.assert_awaited_once_with(db_session, user.id, "admin")
+        remove_mock.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_toggle_off_removes_admin_role(self):
+        user = MagicMock()
+        user.id = uuid4()
+        login_result = LoginResult(
+            user=user,
+            identity_record=None,
+            is_new_user=False,
+            method_key="dummy",
+            method_type="dummy",
+        )
+
+        assign_mock = AsyncMock(return_value=True)
+        remove_mock = AsyncMock(return_value=True)
+
+        auth = AuthController(owner=MagicMock())
+        request = self._make_request({"email": "user@example.com"})
+        db_session = AsyncMock()
+
+        with contextlib.ExitStack() as stack:
+            for p in self._patches(login_result, assign_mock, remove_mock):
+                stack.enter_context(p)
+            await AuthController.dummy_login_submit.fn(auth, request, db_session)
+
+        remove_mock.assert_awaited_once_with(db_session, user.id, "admin")
+        assign_mock.assert_not_awaited()

--- a/tests/test_exception_handlers.py
+++ b/tests/test_exception_handlers.py
@@ -84,3 +84,74 @@ class TestInternalServerErrorHandler:
 
         assert response.status_code == 500
         assert response.content == {"status_code": 500, "detail": "Internal Server Error"}
+
+
+class TestHtmlErrorPageRendering:
+    """The HTML error page extends base.html, whose masthead renders
+    ``{{ csrf_field() }}`` inside the logout form for logged-in users. The
+    production ``csrf_field`` global reads ``context["request"]``, but the
+    exception handler renders the template outside the request/session
+    middleware. The handler must supply a ``csrf_field`` that works without a
+    request, or the error page itself blows up into a second 500."""
+
+    @staticmethod
+    def _request_with_csrf_global_engine(template_src: str):
+        """A request whose template engine mimics production: a ``csrf_field``
+        global that reads ``context["request"]`` (and so raises if ``request``
+        is absent from the render context)."""
+        from jinja2 import DictLoader, Environment, pass_context
+
+        from skrift.forms.core import csrf_field as production_csrf_field
+
+        environment = Environment(
+            loader=DictLoader({"error.html": template_src}), autoescape=True
+        )
+
+        @pass_context
+        def _csrf_field_ctx(context):
+            return production_csrf_field(context["request"])
+
+        environment.globals["csrf_field"] = _csrf_field_ctx
+
+        request = MagicMock()
+        request.headers.get.return_value = "text/html"
+        request.app.template_engine.get_template.return_value = environment.get_template(
+            "error.html"
+        )
+        return request
+
+    def test_logged_in_error_page_renders_csrf_field(self):
+        from skrift.auth.session_keys import SESSION_USER_ID
+        from skrift.forms.core import CSRF_SESSION_KEY
+        from skrift.lib.exceptions import _render_error_response
+
+        template_src = "<nav>{% if user %}{{ csrf_field() }}{% endif %}</nav>"
+        request = self._request_with_csrf_global_engine(template_src)
+        session = {SESSION_USER_ID: "user-1", CSRF_SESSION_KEY: "token-abc"}
+
+        with patch(
+            "skrift.lib.exceptions._get_session_from_cookie", return_value=session
+        ), patch(
+            "skrift.lib.exceptions._resolve_error_template", return_value="error.html"
+        ):
+            response = _render_error_response(request, 401, "Not authorized")
+
+        body = str(response.content)
+        assert response.status_code == 401
+        assert 'name="_csrf"' in body
+        assert "token-abc" in body
+
+    def test_anonymous_error_page_renders_without_request(self):
+        from skrift.lib.exceptions import _render_error_response
+
+        template_src = "<nav>{% if user %}{{ csrf_field() }}{% endif %}</nav>"
+        request = self._request_with_csrf_global_engine(template_src)
+
+        with patch(
+            "skrift.lib.exceptions._get_session_from_cookie", return_value=None
+        ), patch(
+            "skrift.lib.exceptions._resolve_error_template", return_value="error.html"
+        ):
+            response = _render_error_response(request, 404, "Not found")
+
+        assert response.status_code == 404

--- a/tests/test_rate_limit.py
+++ b/tests/test_rate_limit.py
@@ -5,7 +5,12 @@ from litestar import Litestar, get
 from litestar.middleware import DefineMiddleware
 from litestar.testing import TestClient
 
-from skrift.config import RateLimitConfig
+from skrift.config import (
+    RateLimitConfig,
+    RateLimitMatch,
+    RateLimitRule,
+    RateLimitWindow,
+)
 from skrift.middleware.rate_limit import RateLimitMiddleware
 
 
@@ -28,6 +33,104 @@ class TestRateLimitConfig:
         assert config.requests_per_minute == 120
         assert config.auth_requests_per_minute == 20
         assert config.paths == {"/api": 200}
+
+
+class TestRateLimitConfigResolve:
+    """The config compiles legacy + declarative settings into a single rule
+    per request via resolve(path, method)."""
+
+    def test_default_window_from_legacy(self):
+        config = RateLimitConfig(requests_per_minute=60)
+        resolved = config.resolve("/home", "GET")
+        assert resolved.name == "default"
+        assert resolved.key == "ip"
+        assert resolved.limits == [(60, 60.0)]
+
+    def test_auth_window_from_legacy(self):
+        config = RateLimitConfig(auth_requests_per_minute=10)
+        resolved = config.resolve("/auth/login", "POST")
+        assert resolved.name == "auth"
+        assert resolved.limits == [(10, 60.0)]
+
+    def test_legacy_path_prefix_wins_over_default(self):
+        config = RateLimitConfig(requests_per_minute=100, paths={"/api": 2})
+        resolved = config.resolve("/api/data", "GET")
+        assert resolved.limits == [(2, 60.0)]
+        # Non-matching path falls back to default.
+        assert config.resolve("/home", "GET").limits == [(100, 60.0)]
+
+    def test_longest_legacy_prefix_wins(self):
+        config = RateLimitConfig(paths={"/api": 100, "/api/admin": 5})
+        assert config.resolve("/api/admin/x", "GET").limits == [(5, 60.0)]
+
+    def test_new_style_default_and_auth(self):
+        config = RateLimitConfig(
+            default={"limit": 120, "per": "minute"},
+            auth={"limit": 30, "per": "minute"},
+        )
+        assert config.resolve("/x", "GET").limits == [(120, 60.0)]
+        assert config.resolve("/auth/x", "GET").limits == [(30, 60.0)]
+
+    def test_declarative_multi_window_rule(self):
+        config = RateLimitConfig(
+            rules=[
+                {
+                    "match": {"path": "/book/inquiry", "method": "POST"},
+                    "key": "ip",
+                    "limits": [
+                        {"limit": 1, "per": "minute"},
+                        {"limit": 6, "per": "hour"},
+                    ],
+                }
+            ]
+        )
+        resolved = config.resolve("/book/inquiry", "POST")
+        assert resolved.key == "ip"
+        assert resolved.limits == [(1, 60.0), (6, 3600.0)]
+
+    def test_rule_method_mismatch_falls_through_to_default(self):
+        config = RateLimitConfig(
+            requests_per_minute=50,
+            rules=[
+                {
+                    "match": {"path": "/book/inquiry", "method": "POST"},
+                    "limits": [{"limit": 1, "per": "minute"}],
+                }
+            ],
+        )
+        # GET doesn't match the POST-only rule.
+        assert config.resolve("/book/inquiry", "GET").limits == [(50, 60.0)]
+
+    def test_explicit_rule_outranks_legacy_path(self):
+        config = RateLimitConfig(
+            paths={"/api": 100},
+            rules=[
+                {
+                    "match": {"path": "/api/expensive", "method": "POST"},
+                    "limits": [{"limit": 1, "per": "minute"}],
+                }
+            ],
+        )
+        assert config.resolve("/api/expensive", "POST").limits == [(1, 60.0)]
+
+    def test_window_seconds_escape_hatch(self):
+        config = RateLimitConfig(
+            rules=[
+                {
+                    "match": {"path": "/x"},
+                    "limits": [{"limit": 3, "per": 90}],
+                }
+            ]
+        )
+        assert config.resolve("/x", "GET").limits == [(3, 90.0)]
+
+    def test_invalid_period_rejected(self):
+        import pytest as _pytest
+
+        with _pytest.raises(Exception):
+            RateLimitConfig(
+                rules=[{"match": {"path": "/x"}, "limits": [{"limit": 1, "per": "week"}]}]
+            )
 
 
 class TestRateLimitMiddleware:
@@ -338,4 +441,53 @@ class TestRateLimitIntegration:
             # General path should still work
             resp = client.get("/public/test")
             assert resp.status_code == 200
+
+
+class TestDeclarativeMultiWindowRule:
+    """The motivating example from issue #153: a public, anonymous lead-capture
+    endpoint capped at 1/min AND 6/hr per IP — expressed in config alone."""
+
+    def _create_app(self) -> Litestar:
+        from litestar import post
+
+        @post("/book/inquiry")
+        async def inquiry() -> str:
+            return "ok"
+
+        @get("/other")
+        async def other() -> str:
+            return "ok"
+
+        config = RateLimitConfig(
+            requests_per_minute=1000,  # generous default
+            rules=[
+                RateLimitRule(
+                    match=RateLimitMatch(path="/book/inquiry", method="POST"),
+                    key="ip",
+                    limits=[
+                        RateLimitWindow(limit=1, per="minute"),
+                        RateLimitWindow(limit=6, per="hour"),
+                    ],
+                )
+            ],
+        )
+        return Litestar(
+            route_handlers=[inquiry, other],
+            middleware=[DefineMiddleware(RateLimitMiddleware, config=config)],
+        )
+
+    def test_minute_window_enforced(self):
+        app = self._create_app()
+        with TestClient(app) as client:
+            assert client.post("/book/inquiry").status_code == 201
+            resp = client.post("/book/inquiry")
+            assert resp.status_code == 429
+            assert "retry-after" in resp.headers
+
+    def test_other_routes_unaffected(self):
+        app = self._create_app()
+        with TestClient(app) as client:
+            # The default (1000/min) governs unmatched routes.
+            for _ in range(5):
+                assert client.get("/other").status_code == 200
 

--- a/tests/test_rate_limit_e2e.py
+++ b/tests/test_rate_limit_e2e.py
@@ -1,0 +1,170 @@
+"""End-to-end rate limiting tests.
+
+These exercise the *whole stack* the way ``skrift.asgi.create_app`` wires it —
+a real ``Settings`` object → ``RateLimiter.from_settings(settings)`` →
+``DefineMiddleware(RateLimitMiddleware, config=settings.rate_limit,
+limiter=...)`` → real HTTP requests through ``TestClient``. The isolated unit
+tests live in ``test_rate_limit.py`` / ``test_ratelimit.py`` /
+``test_sliding_window.py``; these prove the construction path and the
+distributed (Redis) path work together, not just in isolation.
+"""
+
+from __future__ import annotations
+
+import pytest
+from litestar import Litestar, get, post
+from litestar.middleware import DefineMiddleware
+from litestar.testing import TestClient
+
+from skrift.auth.failed_auth import FailedAuthLimiter
+from skrift.config import RateLimitConfig, Settings
+from skrift.middleware.rate_limit import RateLimitMiddleware
+from skrift.ratelimit import RateLimiter
+
+try:
+    import fakeredis.aioredis as fake_aioredis
+
+    HAS_FAKEREDIS = True
+except ImportError:
+    HAS_FAKEREDIS = False
+
+
+def _handlers():
+    @post("/book/inquiry")
+    async def inquiry() -> str:
+        return "ok"
+
+    @get("/public")
+    async def public() -> str:
+        return "ok"
+
+    @get("/auth/login")
+    async def auth_login() -> str:
+        return "ok"
+
+    return [inquiry, public, auth_login]
+
+
+def _build_app(settings: Settings, limiter: RateLimiter | None = None) -> Litestar:
+    """Wire rate limiting exactly as create_app does."""
+    rate_limiter = limiter or RateLimiter.from_settings(settings)
+    return Litestar(
+        route_handlers=_handlers(),
+        middleware=[
+            DefineMiddleware(
+                RateLimitMiddleware,
+                config=settings.rate_limit,
+                limiter=rate_limiter,
+            )
+        ],
+    )
+
+
+class TestDeclarativeRuleEndToEnd:
+    """A declarative multi-window rule, carried through Settings and the
+    from_settings() limiter, enforces a real 429 over HTTP."""
+
+    def test_inquiry_minute_window_enforced_via_settings(self):
+        settings = Settings(
+            secret_key="test",
+            rate_limit=RateLimitConfig(
+                requests_per_minute=1000,
+                rules=[
+                    {
+                        "match": {"path": "/book/inquiry", "method": "POST"},
+                        "key": "ip",
+                        "limits": [
+                            {"limit": 1, "per": "minute"},
+                            {"limit": 6, "per": "hour"},
+                        ],
+                    }
+                ],
+            ),
+        )
+        with TestClient(_build_app(settings)) as client:
+            assert client.post("/book/inquiry").status_code == 201
+            blocked = client.post("/book/inquiry")
+            assert blocked.status_code == 429
+            assert int(blocked.headers["retry-after"]) >= 1
+            # The generous default still governs other routes.
+            assert client.get("/public").status_code == 200
+
+    def test_no_redis_url_uses_memory_backend(self):
+        settings = Settings(secret_key="test", rate_limit=RateLimitConfig())
+        limiter = RateLimiter.from_settings(settings)
+        assert limiter.backend == "memory"
+
+
+class TestLegacyConfigEndToEnd:
+    """Legacy requests_per_minute / auth_requests_per_minute, parsed into
+    Settings, still enforce limits over real HTTP (back-compat)."""
+
+    def test_auth_path_stricter_than_default(self):
+        settings = Settings(
+            secret_key="test",
+            rate_limit=RateLimitConfig(
+                requests_per_minute=100,
+                auth_requests_per_minute=2,
+            ),
+        )
+        with TestClient(_build_app(settings)) as client:
+            for _ in range(2):
+                assert client.get("/auth/login").status_code == 200
+            assert client.get("/auth/login").status_code == 429
+            # Default bucket is independent and far from its limit.
+            assert client.get("/public").status_code == 200
+
+
+@pytest.mark.skipif(not HAS_FAKEREDIS, reason="fakeredis not installed")
+class TestRedisBackedEndToEnd:
+    """The distributed path: limiters backed by one Redis enforce a single
+    combined limit across replicas, end-to-end over HTTP."""
+
+    def test_two_replicas_share_one_limit(self):
+        client_redis = fake_aioredis.FakeRedis()
+        settings = Settings(
+            secret_key="test",
+            rate_limit=RateLimitConfig(
+                rules=[
+                    {
+                        "match": {"path": "/book/inquiry", "method": "POST"},
+                        "limits": [{"limit": 1, "per": "minute"}],
+                    }
+                ],
+            ),
+        )
+        # Two app instances ("replicas") pointed at the same Redis. from_settings'
+        # url->client wiring is unit-tested separately; here we inject the shared
+        # fake client to drive the full middleware->limiter->Redis path.
+        from skrift.config import RedisConfig
+
+        replica_a = _build_app(
+            settings, RateLimiter(redis_client=client_redis, redis_config=RedisConfig())
+        )
+        replica_b = _build_app(
+            settings, RateLimiter(redis_client=client_redis, redis_config=RedisConfig())
+        )
+        with TestClient(replica_a) as ca, TestClient(replica_b) as cb:
+            # First hit on replica A consumes the single per-minute slot...
+            assert ca.post("/book/inquiry").status_code == 201
+            # ...so replica B (same client IP, same Redis) is blocked.
+            assert cb.post("/book/inquiry").status_code == 429
+
+    @pytest.mark.asyncio
+    async def test_all_limiters_share_the_one_backend(self):
+        """Setting redis.url must make EVERY limiter distributed — the
+        middleware's check and the failed-auth tracker write to the same Redis,
+        with no silent in-memory divergence."""
+        client_redis = fake_aioredis.FakeRedis()
+        from skrift.config import RedisConfig
+
+        limiter = RateLimiter(redis_client=client_redis, redis_config=RedisConfig())
+        failed_auth = FailedAuthLimiter(counter=limiter.get_counter(60.0, "failed_auth"))
+
+        await limiter.check("default", "1.2.3.4", [(5, "minute")])
+        await failed_auth.record_failure("1.2.3.4")
+
+        keys = [k.decode() if isinstance(k, bytes) else k for k in await client_redis.keys("*")]
+        assert any(k.startswith("skrift:ratelimit:default:") for k in keys), keys
+        assert any(k.startswith("skrift:ratelimit:failed_auth:") for k in keys), keys
+        await client_redis.aclose()

--- a/tests/test_ratelimit.py
+++ b/tests/test_ratelimit.py
@@ -1,0 +1,166 @@
+"""Tests for the backend-aware rate limiter primitive (skrift.ratelimit)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from skrift.config import RedisConfig
+from skrift.ratelimit import (
+    RateLimiter,
+    Verdict,
+    get_limiter,
+    normalize_window,
+    reset_limiter,
+)
+
+try:
+    import fakeredis.aioredis as fake_aioredis
+
+    HAS_FAKEREDIS = True
+except ImportError:
+    HAS_FAKEREDIS = False
+
+
+class TestNormalizeWindow:
+    def test_named_periods(self):
+        assert normalize_window("second") == 1.0
+        assert normalize_window("minute") == 60.0
+        assert normalize_window("hour") == 3600.0
+        assert normalize_window("day") == 86400.0
+
+    def test_numeric_passthrough(self):
+        assert normalize_window(30) == 30.0
+        assert normalize_window(90.5) == 90.5
+
+    def test_unknown_period_raises(self):
+        with pytest.raises(ValueError):
+            normalize_window("fortnight")
+
+
+class TestInMemoryLimiter:
+    @pytest.mark.asyncio
+    async def test_single_window_allows_then_blocks(self):
+        limiter = RateLimiter(redis_client=None)
+        v1 = await limiter.check("capture", "1.2.3.4", [(1, "minute")])
+        assert isinstance(v1, Verdict)
+        assert v1.allowed is True
+        assert v1.retry_after == 0
+
+        v2 = await limiter.check("capture", "1.2.3.4", [(1, "minute")])
+        assert v2.allowed is False
+        assert 1 <= v2.retry_after <= 60
+
+    @pytest.mark.asyncio
+    async def test_multi_window_and_logic(self):
+        # 1/min + 6/hr per the motivating example.
+        limiter = RateLimiter(redis_client=None)
+        limits = [(1, "minute"), (6, "hour")]
+        assert (await limiter.check("inquiry", "ip", limits)).allowed is True
+        assert (await limiter.check("inquiry", "ip", limits)).allowed is False
+
+    @pytest.mark.asyncio
+    async def test_names_are_isolated(self):
+        limiter = RateLimiter(redis_client=None)
+        await limiter.check("a", "ip", [(1, "minute")])
+        # Same key, different name → independent bucket.
+        assert (await limiter.check("b", "ip", [(1, "minute")])).allowed is True
+
+    @pytest.mark.asyncio
+    async def test_keys_are_isolated(self):
+        limiter = RateLimiter(redis_client=None)
+        await limiter.check("a", "ip1", [(1, "minute")])
+        assert (await limiter.check("a", "ip2", [(1, "minute")])).allowed is True
+
+    def test_backend_label(self):
+        assert RateLimiter(redis_client=None).backend == "memory"
+
+    @pytest.mark.asyncio
+    async def test_get_counter_reuses_instance(self):
+        limiter = RateLimiter(redis_client=None)
+        c1 = limiter.get_counter(60.0, "failed_auth")
+        c2 = limiter.get_counter(60.0, "failed_auth")
+        assert c1 is c2
+        # record/count surface works for the failed-auth style consumer
+        await c1.record("ip")
+        assert await c1.count("ip") == 1
+
+
+@pytest.mark.skipif(not HAS_FAKEREDIS, reason="fakeredis not installed")
+class TestRedisLimiter:
+    @pytest.mark.asyncio
+    async def test_backend_label_and_check(self):
+        client = fake_aioredis.FakeRedis()
+        limiter = RateLimiter(redis_client=client, redis_config=RedisConfig(prefix="myapp"))
+        try:
+            assert limiter.backend == "redis"
+            limits = [(1, "minute"), (6, "hour")]
+            assert (await limiter.check("inquiry", "ip", limits)).allowed is True
+            assert (await limiter.check("inquiry", "ip", limits)).allowed is False
+        finally:
+            await limiter.aclose()
+
+    @pytest.mark.asyncio
+    async def test_key_namespacing_includes_prefix_and_name(self):
+        client = fake_aioredis.FakeRedis()
+        limiter = RateLimiter(redis_client=client, redis_config=RedisConfig(prefix="myapp"))
+        try:
+            await limiter.check("inquiry", "1.2.3.4", [(5, "minute")])
+            keys = [k.decode() if isinstance(k, bytes) else k for k in await client.keys("*")]
+            assert any(
+                k.startswith("myapp:skrift:ratelimit:inquiry:") and "1.2.3.4" in k
+                for k in keys
+            ), keys
+        finally:
+            await limiter.aclose()
+
+    @pytest.mark.asyncio
+    async def test_two_limiters_share_redis_state(self):
+        client = fake_aioredis.FakeRedis()
+        a = RateLimiter(redis_client=client, redis_config=RedisConfig())
+        b = RateLimiter(redis_client=client, redis_config=RedisConfig())
+        try:
+            assert (await a.check("inquiry", "ip", [(1, "minute")])).allowed is True
+            # Second replica sees the first replica's hit.
+            assert (await b.check("inquiry", "ip", [(1, "minute")])).allowed is False
+        finally:
+            await client.aclose()
+
+
+class TestFromSettings:
+    def test_no_redis_url_uses_memory(self):
+        settings = MagicMock()
+        settings.redis.url = ""
+        settings.redis = RedisConfig(url="")
+        limiter = RateLimiter.from_settings(settings)
+        assert limiter.backend == "memory"
+
+
+class TestGetLimiterSingleton:
+    def teardown_method(self):
+        reset_limiter()
+
+    def test_returns_same_instance(self, monkeypatch):
+        from skrift import ratelimit
+
+        settings = MagicMock()
+        settings.redis = RedisConfig(url="")
+        monkeypatch.setattr(ratelimit, "get_settings", lambda: settings)
+        reset_limiter()
+
+        first = get_limiter()
+        second = get_limiter()
+        assert first is second
+
+    def test_reset_rebuilds(self, monkeypatch):
+        from skrift import ratelimit
+
+        settings = MagicMock()
+        settings.redis = RedisConfig(url="")
+        monkeypatch.setattr(ratelimit, "get_settings", lambda: settings)
+        reset_limiter()
+
+        first = get_limiter()
+        reset_limiter()
+        assert get_limiter() is not first

--- a/tests/test_sliding_window.py
+++ b/tests/test_sliding_window.py
@@ -103,6 +103,127 @@ class TestSharedBehavior:
 
 
 # ---------------------------------------------------------------------------
+# Multi-window check-and-record: AND-logic across several (limit, window) pairs.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+class TestMultiWindowSharedBehavior:
+    @pytest.mark.asyncio
+    async def test_allows_when_every_window_under_limit(self, backend):
+        counter, client = await _build_backend(backend)
+        try:
+            allowed, retry_after = await counter.check_and_record_multi(
+                "alice", [(5, 60.0), (10, 3600.0)]
+            )
+            assert allowed is True
+            assert retry_after == 0
+        finally:
+            if client is not None:
+                await client.aclose()
+
+    @pytest.mark.asyncio
+    async def test_denied_when_tightest_window_exceeded(self, backend):
+        # 1/min + 6/hr: the second call within the minute is blocked by the
+        # minute window even though the hour window still has room.
+        counter, client = await _build_backend(backend)
+        try:
+            allowed, _ = await counter.check_and_record_multi(
+                "bob", [(1, 60.0), (6, 3600.0)]
+            )
+            assert allowed is True
+            allowed, retry_after = await counter.check_and_record_multi(
+                "bob", [(1, 60.0), (6, 3600.0)]
+            )
+            assert allowed is False
+            assert 1 <= retry_after <= 60
+        finally:
+            if client is not None:
+                await client.aclose()
+
+    @pytest.mark.asyncio
+    async def test_retry_after_reports_binding_longest_window(self, backend):
+        # Both windows have limit 1; the second call is blocked by both, and
+        # Retry-After must reflect the longer (hour) window, not the minute.
+        counter, client = await _build_backend(backend)
+        try:
+            await counter.check_and_record_multi("carol", [(1, 60.0), (1, 3600.0)])
+            allowed, retry_after = await counter.check_and_record_multi(
+                "carol", [(1, 60.0), (1, 3600.0)]
+            )
+            assert allowed is False
+            assert retry_after > 60  # bound by the hour window, not the minute
+        finally:
+            if client is not None:
+                await client.aclose()
+
+    @pytest.mark.asyncio
+    async def test_keys_isolated(self, backend):
+        counter, client = await _build_backend(backend)
+        try:
+            allowed, _ = await counter.check_and_record_multi("alice", [(1, 60.0)])
+            assert allowed is True
+            allowed, _ = await counter.check_and_record_multi("alice", [(1, 60.0)])
+            assert allowed is False
+            # bob has his own bucket
+            allowed, _ = await counter.check_and_record_multi("bob", [(1, 60.0)])
+            assert allowed is True
+        finally:
+            if client is not None:
+                await client.aclose()
+
+
+class TestMultiWindowAllOrNothingInMemory:
+    """A denied multi-window call must record nothing — being blocked by the
+    hour window must not consume a minute slot."""
+
+    @pytest.mark.asyncio
+    async def test_denied_call_records_nothing(self):
+        counter = InMemorySlidingWindowCounter(window=60.0)
+        # 5/min + 1/hr: first call allowed (records one hit), second call is
+        # blocked by the hour window. It must not add a hit.
+        limits = [(5, 60.0), (1, 3600.0)]
+        allowed, _ = await counter.check_and_record_multi("ip", limits)
+        assert allowed is True
+        allowed, _ = await counter.check_and_record_multi("ip", limits)
+        assert allowed is False
+        # Exactly one hit was ever recorded for this key.
+        assert sum(len(v) for v in counter._multi_buckets.values()) == 1
+
+
+@pytest.mark.skipif(not HAS_FAKEREDIS, reason="fakeredis not installed")
+class TestMultiWindowAllOrNothingRedis:
+    @pytest.mark.asyncio
+    async def test_denied_call_records_nothing(self):
+        client = fake_aioredis.FakeRedis()
+        counter = RedisSlidingWindowCounter(client, window=60.0, prefix="test")
+        try:
+            limits = [(5, 60.0), (1, 3600.0)]
+            allowed, _ = await counter.check_and_record_multi("ip", limits)
+            assert allowed is True
+            allowed, _ = await counter.check_and_record_multi("ip", limits)
+            assert allowed is False
+            # Only the allowed call left a member in the sorted set.
+            assert await client.zcard("test:ip") == 1
+        finally:
+            await client.aclose()
+
+    @pytest.mark.asyncio
+    async def test_atomic_multi_window_race(self):
+        client = fake_aioredis.FakeRedis()
+        counter = RedisSlidingWindowCounter(client, window=60.0, prefix="test")
+        try:
+            results = await asyncio.gather(*[
+                counter.check_and_record_multi("contested", [(5, 60.0), (100, 3600.0)])
+                for _ in range(20)
+            ])
+            allowed_count = sum(1 for allowed, _ in results if allowed)
+            assert allowed_count == 5
+        finally:
+            await client.aclose()
+
+
+# ---------------------------------------------------------------------------
 # Redis-specific: shared state across counter instances (the whole point).
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Alpha release bundling new rate-limiting capabilities, a dev-only dummy-login admin toggle, and a fix for error pages crashing for logged-in users.

## Changes

### New Features
- **Declarative multi-window rate limiting** (#153): `rate_limit` config now supports `default`/`auth` windows and `rules` with multiple `(limit, per)` windows per route, method/path matching, and `ip`/`api_key` keying. Legacy `requests_per_minute`/`auth_requests_per_minute`/`paths` keys still work.
- **Backend-aware limiter primitive**: new `skrift.ratelimit.get_limiter()` exposing `check(name, key, limits)` (multi-window AND-logic, all-or-nothing recording, binding-window `Retry-After`) and `get_counter(window, name)`. Backend (Redis vs in-memory) is chosen in one place, so setting `redis.url` makes every limiter distributed with no divergence.
- **Dummy-login admin toggle**: the dev-only dummy login can grant/remove the admin role per login.

### Bug Fixes
- **Error pages no longer crash for logged-in users**: the error template's masthead called `csrf_field()`, which read `request` from a context the exception handler didn't provide — turning any 401/403/404/500 into a second 500. The handler now supplies a session-derived CSRF field.

### Improvements
- `_FailedAuthLimiter` relocated to `skrift/auth/failed_auth.py` and reimplemented on the shared limiter backend.
- `RateLimitMiddleware` rewritten on top of `get_limiter()`.
- Docs: rate-limiting reference (declarative + imperative + migration); documented in the shipped `skrift` skill.
- End-to-end rate-limiting tests through the real `create_app` wiring, including Redis cross-replica behavior.

## Release version
`0.2.0a5` -> `0.2.0a6`