### PR TITLE
Release v0.2.0a8 — Backend-agnostic image scaling

### DIFF
--- a/docs/guides/media-and-storage.md
+++ b/docs/guides/media-and-storage.md
@@ -1,0 +1,230 @@
+# Media & Storage
+
+Skrift stores uploaded files (images, documents, video) through a pluggable
+**storage backend** and serves images at on-demand sizes that work the same
+across every backend — local disk, S3-compatible object stores, or your own.
+
+## Overview
+
+- Files are uploaded through the admin media library or the asset service and
+  recorded as `Asset` rows keyed by their content hash.
+- Each store is backed by a **storage backend**: `local`, `s3`, or a custom
+  class. Backends are addressed by name, so you can run several at once.
+- Images can be requested at a named **size** (`thumb`, `medium`, …). Variants
+  are generated lazily on first request, cached back into the same backend, and
+  served from there afterward — including straight from a CDN for remote stores.
+
+## Configuring stores
+
+Storage is configured under the top-level `storage` key in `app.yaml`. Each
+named entry under `stores` is a separate backend; `default` selects which store
+new uploads use.
+
+```yaml
+storage:
+  default: default
+  stores:
+    default:
+      backend: local
+      local_path: ./uploads
+      max_upload_size: 10485760  # 10 MB
+```
+
+| Field | Default | Description |
+|-------|---------|-------------|
+| `backend` | `local` | `local`, `s3`, or `module:ClassName` for a custom backend |
+| `local_path` | `./uploads` | Filesystem root for the `local` backend |
+| `max_upload_size` | `10485760` | Per-file upload limit in bytes |
+| `s3` | — | Nested S3 settings (see below), used when `backend: s3` |
+
+### Local backend
+
+The `local` backend stores files on disk under `local_path`, fanned out into
+two levels of content-hash subdirectories. It serves files through Skrift at
+`/storage/{store}/{key}` via `StorageFilesMiddleware`.
+
+### S3 backend
+
+The `s3` backend stores files in any S3-compatible bucket (AWS S3, MinIO,
+Cloudflare R2, …). It requires the `s3` extra:
+
+```bash
+pip install skrift[s3]
+```
+
+```yaml
+storage:
+  default: cdn
+  stores:
+    cdn:
+      backend: s3
+      s3:
+        bucket: my-bucket
+        region: us-east-1
+        acl: public-read
+        public_url: https://cdn.example.com
+```
+
+| `s3` field | Default | Description |
+|------------|---------|-------------|
+| `bucket` | `""` | Target bucket name |
+| `region` | `us-east-1` | AWS region |
+| `prefix` | `""` | Key prefix applied to every object |
+| `endpoint_url` | `""` | Custom endpoint for non-AWS providers (MinIO, R2) |
+| `access_key_id` | `""` | Access key (omit to use the ambient AWS credential chain) |
+| `secret_access_key` | `""` | Secret key |
+| `acl` | `private` | Object ACL; `public-read` serves objects via their public S3 URL |
+| `public_url` | `""` | CDN base URL placed in front of the bucket |
+| `presign_ttl` | `3600` | Lifetime (seconds) of presigned URLs for private objects |
+
+URL resolution for the S3 backend follows this order: a `public_url` CDN base if
+set, then the public S3 URL for `public-read` buckets, otherwise a short-lived
+presigned URL.
+
+!!! warning "Never commit credentials"
+    Prefer the ambient AWS credential chain (instance role, environment, or
+    `~/.aws`) over `access_key_id`/`secret_access_key` in `app.yaml`. If you do
+    set keys, keep them out of version control via environment-variable
+    interpolation.
+
+### Custom backends
+
+Set `backend` to `module:ClassName` to load your own backend. The class is
+instantiated with the `StoreConfig` and must satisfy the
+`skrift.storage.base.StorageBackend` protocol — `put`, `get`, `delete`,
+`exists`, `list_keys`, and `get_url`:
+
+```yaml
+storage:
+  stores:
+    default:
+      backend: myapp.storage:GoogleCloudBackend
+```
+
+Image sizing, the media library, and the `image_url` helper all work
+automatically with any compliant backend — there is no local-only path.
+
+## On-demand image sizing
+
+Request any image at a named size by appending `?size=<name>` to its
+`/storage/...` URL. The available sizes are defined in
+`skrift.lib.imaging.IMAGE_SIZES`:
+
+| Size | Dimensions | Typical use |
+|------|------------|-------------|
+| `icon` | 64×64 | Favicons, avatars |
+| `thumb` | 200×200 | Gallery and attachment thumbnails |
+| `small` | 400 wide | Inline content images |
+| `medium` | 800 wide | Gallery items, body images |
+| `cover` | 1200 wide | Featured/hero images |
+| `og` | 1200×630 | OpenGraph / social share images |
+
+Sizes with a single dimension are width-constrained; the height follows the
+aspect ratio. Resizing **never upscales** (smaller originals are returned
+unchanged), preserves the original format, and re-encodes JPEG/WebP at quality
+85.
+
+### How a sized request flows
+
+1. The first request for `…/{key}?size=thumb` reaches `StorageFilesMiddleware`.
+2. The middleware reads the original through the backend, resizes it off the
+   event loop, and writes the variant back into the **same backend** under a
+   `{key}.{size}` key.
+3. It then serves the result: bytes inline for backends with Skrift-internal
+   URLs (local), or a `302` redirect to the backend's URL (S3/CDN).
+4. Subsequent requests find the cached variant and skip regeneration.
+
+This keeps generation off the hot path — the expensive resize happens once, and
+warm requests for a remote store are served directly by the CDN.
+
+## Resolving URLs in code
+
+Use the asset service helpers from controllers and other server-side code
+(`skrift/db/services/asset_service.py`):
+
+```python
+from skrift.db.services.asset_service import get_asset_url, image_url
+
+storage = request.app.state.storage_manager
+
+# Original, full-size URL (backend-native: local path or CDN/presigned URL)
+url = await get_asset_url(storage, asset)
+
+# Sized URL, resolved lazily and backend-aware
+thumb = await image_url(storage, asset, "thumb")
+```
+
+`image_url` is the recommended way to produce sized image URLs:
+
+- **No size** → the backend's direct URL for the original.
+- **Variant already exists** → the backend's direct URL for the variant. For a
+  CDN-backed store this is the CDN URL, so the browser never touches Skrift — no
+  redirect.
+- **Variant missing** → the internal `/storage/{store}/{key}?size=…` URL. The
+  first visitor triggers generation and a redirect; the next render resolves to
+  the direct URL.
+
+It accepts either an `Asset` or a raw `key` (with an optional `store`):
+
+```python
+await image_url(storage, asset, "medium")
+await image_url(storage, "abc123…", "medium", store="cdn")
+```
+
+## Resolving URLs in templates
+
+!!! important "Templates render synchronously"
+    Jinja templates in Skrift render synchronously, so the **async** helpers
+    (`image_url`, `asset_url`) cannot be awaited inside a template — calling them
+    there yields a coroutine, not a URL. Resolve URLs in your controller and
+    pass the strings into the template context.
+
+The built-in controllers already do this. Public page templates receive:
+
+| Context variable | Contents |
+|------------------|----------|
+| `asset_urls` | `{asset_id: original_url}` for every attached asset |
+| `asset_image_urls` | `{asset_id: medium_url}` for image assets (pre-resolved via `image_url`) |
+| `featured_image_url` | Internal `/storage` URL for the featured asset (sized in-template for og:image) |
+| `featured_cover_url` | Pre-resolved `cover` URL for on-page display |
+
+```html
+<!-- Gallery thumbnail — already resolved, warm path goes straight to the CDN -->
+<img src="{{ asset_image_urls[asset.id | string] }}" alt="{{ asset.alt_text }}">
+
+<!-- Featured cover -->
+<img src="{{ featured_cover_url }}" alt="{{ page.title }}">
+
+<!-- Full-size original (lightbox, downloads, video) -->
+<a href="{{ asset_urls[asset.id | string] }}">Open</a>
+```
+
+### The `sized` filter
+
+For URLs you size directly in a template — favicons and og:image — use the
+`sized` filter, which appends `?size=<name>`:
+
+```html
+<link rel="icon" href="{{ favicon_url() | sized('icon') }}">
+<meta property="og:image" content="{{ og_meta.image | sized('og') }}">
+```
+
+!!! note "Apply `sized` only to internal URLs"
+    `sized` merely appends a query parameter, so it only triggers resizing when
+    applied to a Skrift-internal `/storage/...` URL — appending `?size=` to a CDN
+    URL does nothing. The built-in controllers pass internal URLs for the
+    favicon and og:image precisely for this reason. For asset images, prefer the
+    pre-resolved `image_url` context variables, which give you the warm CDN path.
+
+## Key files
+
+| File | Purpose |
+|------|---------|
+| `skrift/storage/base.py` | `StorageBackend` protocol, `StoredFile` |
+| `skrift/storage/local.py` | Local filesystem backend |
+| `skrift/storage/s3.py` | S3-compatible backend |
+| `skrift/storage/manager.py` | `StorageManager`, backend factory |
+| `skrift/lib/imaging.py` | `IMAGE_SIZES`, `resize_image()`, variant helpers |
+| `skrift/middleware/storage.py` | `StorageFilesMiddleware` — serving and on-demand sizing |
+| `skrift/db/services/asset_service.py` | Upload, delete, `get_asset_url`, `image_url` |
+| `skrift/config.py` | `StorageConfig`, `StoreConfig`, `S3Config` |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -69,6 +69,7 @@ nav:
     - SEO Metadata: guides/seo-metadata.md
     - Custom Middleware: guides/custom-middleware.md
     - Markdown Content: guides/markdown-content.md
+    - Media and Storage: guides/media-and-storage.md
     - Protecting Routes: guides/protecting-routes.md
     - Observability: guides/observability.md
     - Workers: guides/workers.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "skrift"
-version = "0.2.0a7"
+version = "0.2.0a8"
 description = "A lightweight async Python CMS for crafting modern websites"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/skrift/admin/page_type_factory.py
+++ b/skrift/admin/page_type_factory.py
@@ -29,7 +29,7 @@ from skrift.auth.guards import OwnerOrPermission, Permission, auth_guard
 from skrift.auth.roles import permissions_for_type
 from skrift.config import PageTypeConfig
 from skrift.db.services import page_service, revision_service
-from skrift.db.services.asset_service import get_asset_url
+from skrift.db.services.asset_service import get_asset_url, image_url
 from skrift.flash import flash_error, flash_success, get_flash_messages
 from skrift.hooks import PAGE_ADMIN_CAN_MUTATE, PAGE_ADMIN_PAGE_STATE, hooks
 from skrift.storage import StorageManager
@@ -214,6 +214,11 @@ def create_page_type_controller(page_type: PageTypeConfig) -> type[Controller]:
                 str(asset.id): await get_asset_url(storage, asset)
                 for asset in page.assets
             }
+            asset_image_urls = {
+                str(asset.id): await image_url(storage, asset, "thumb")
+                for asset in page.assets
+                if asset.content_type.startswith("image/")
+            }
 
             flash_messages = get_flash_messages(request)
             return TemplateResponse(
@@ -223,6 +228,7 @@ def create_page_type_controller(page_type: PageTypeConfig) -> type[Controller]:
                     "page": page,
                     "page_assets": page.assets,
                     "asset_urls": asset_urls,
+                    "asset_image_urls": asset_image_urls,
                     **page_type_ctx,
                     **ctx,
                 },

--- a/skrift/admin/settings.py
+++ b/skrift/admin/settings.py
@@ -18,6 +18,7 @@ from skrift.auth.guards import auth_guard, Permission
 from skrift.admin.helpers import get_admin_context
 from skrift.admin.navigation import ADMIN_NAV_TAG
 from skrift.db.services import setting_service
+from skrift.db.services.asset_service import internal_asset_url
 from skrift.flash import flash_success, get_flash_messages
 
 logger = logging.getLogger(__name__)
@@ -73,21 +74,14 @@ class SettingsAdminController(Controller):
                 "active": current_settings.get(setting_service.SITE_THEME_KEY, ""),
             }
 
-        # Resolve current favicon URL for preview
+        # Resolve current favicon URL for preview. Use the Skrift-internal URL so
+        # the ``sized('icon')`` request routes through the storage middleware and
+        # resolves on any backend.
         current_favicon_url = ""
         favicon_key = current_settings.get(setting_service.SITE_FAVICON_KEY, "")
         if favicon_key and not selected_site:
-            try:
-                from skrift.storage import StorageManager
-                storage: StorageManager = request.app.state.storage_manager
-                backend = await storage.get()
-                current_favicon_url = await backend.get_url(favicon_key)
-            except Exception:
-                logger.warning(
-                    "Failed to resolve favicon preview URL for key '%s'",
-                    favicon_key,
-                    exc_info=True,
-                )
+            storage = request.app.state.storage_manager
+            current_favicon_url = internal_asset_url(storage.default_store, favicon_key)
 
         flash_messages = get_flash_messages(request)
         return TemplateResponse(

--- a/skrift/asgi.py
+++ b/skrift/asgi.py
@@ -43,6 +43,7 @@ from skrift.app_factory import (
     update_template_directories,
 )
 from skrift.config import DatabaseConfig, get_config_path, get_settings, is_config_valid
+from skrift.db.services.asset_service import internal_asset_url
 from skrift.ratelimit import RateLimiter, set_limiter
 from skrift.lib.trusted_proxy import TrustedProxyManager
 from skrift.middleware.client_ip import ClientIPMiddleware
@@ -877,14 +878,16 @@ def create_app() -> ASGIApp:
         return await backend.get_url(key_or_asset)
 
     async def _resolve_favicon_url():
-        """Resolve the favicon storage key to a URL and cache it."""
+        """Resolve the favicon storage key to a URL and cache it.
+
+        Uses the Skrift-internal URL so the ``sized('icon')`` request routes
+        through the storage middleware and resolves on any backend.
+        """
         key = get_cached_site_favicon_key()
         if not key:
             set_cached_favicon_url("")
             return
-        backend = await storage_manager.get()
-        url = await backend.get_url(key)
-        set_cached_favicon_url(url)
+        set_cached_favicon_url(internal_asset_url(storage_manager.default_store, key))
 
     # Template configuration
     from jinja2 import pass_context
@@ -1189,7 +1192,7 @@ def create_app() -> ASGIApp:
             site_static_dir=site_static_dir,
             package_static_dir=package_static_dir,
         ),
-        storage_config=settings.storage,
+        storage_manager=storage_manager,
     )
 
     # Build subdomain → page_types mapping from config

--- a/skrift/claude_skill/skrift-frontend/SKILL.md
+++ b/skrift/claude_skill/skrift-frontend/SKILL.md
@@ -46,9 +46,12 @@ Without a theme, tiers 2 and 3 apply.
 | `themes_available()` | bool | Whether `themes/` has valid themes |
 | `static_url(path)` | str | Cache-busted static URL |
 | `theme_url(path)` | str | Theme-aware static URL |
+| `favicon_url()` | str | Cached site favicon URL (internal `/storage` URL) |
 | `csp_nonce()` | str | Current request's CSP nonce |
 
-Filter: `markdown` — renders markdown to HTML.
+Filters: `markdown` — renders markdown to HTML; `sized('name')` — appends
+`?size=name` for on-demand image sizing (see [Asset URLs & Image
+Sizing](#asset-urls-image-sizing)).
 
 ## Themes
 
@@ -130,6 +133,65 @@ Static files follow the same three-tier resolution as templates: theme → proje
 
 `theme_url(path)` resolves via the active theme's `static/` directory.
 
+## Asset URLs & Image Sizing
+
+Uploaded assets are served at `/storage/{store}/{key}` by `StorageFilesMiddleware`,
+which works across any storage backend (local, S3, custom). Images can be
+requested at a named size with `?size=<name>`; variants are generated lazily,
+cached back into the backend, and served from there (inline for local, `302` to
+the CDN for remote). Sizes live in `skrift.lib.imaging.IMAGE_SIZES`: `icon`
+(64×64), `thumb` (200×200), `small` (400w), `medium` (800w), `cover` (1200w),
+`og` (1200×630). Resizing never upscales and preserves the original format.
+
+### Async helpers are code-side, not template-side
+
+Templates render **synchronously**, so the async URL helpers cannot be awaited
+in a template (they return a coroutine). Resolve in the controller, pass strings
+into the context:
+
+```python
+from skrift.db.services.asset_service import get_asset_url, image_url, internal_asset_url
+
+storage = request.app.state.storage_manager
+original = await get_asset_url(storage, asset)        # backend-native (CDN/local) URL
+thumb = await image_url(storage, asset, "thumb")      # lazy, backend-aware sized URL
+internal = internal_asset_url(asset.store, asset.key) # always-internal /storage URL
+```
+
+`image_url` returns the backend's direct URL when no size is given or the variant
+already exists (warm path → straight to the CDN, no Skrift round-trip), and the
+internal `/storage/{store}/{key}?size=…` URL when the variant is missing (cold
+path → generate + redirect on first hit).
+
+### In templates: precomputed context + the `sized` filter
+
+Public page templates receive pre-resolved strings:
+
+| Context variable | Contents |
+|------------------|----------|
+| `asset_urls` | `{asset_id: original_url}` for every attached asset |
+| `asset_image_urls` | `{asset_id: medium_url}` for image assets (via `image_url`) |
+| `featured_image_url` | Internal `/storage` URL for the featured asset (sized for og:image) |
+| `featured_cover_url` | Pre-resolved `cover` URL for on-page display |
+
+```html
+<img src="{{ asset_image_urls[asset.id | string] }}" alt="{{ asset.alt_text }}">
+<img src="{{ featured_cover_url }}" alt="{{ page.title }}">
+<a href="{{ asset_urls[asset.id | string] }}">Open original</a>
+```
+
+The `sized('name')` filter is for URLs sized directly in-template (favicon,
+og:image). It only appends `?size=`, so it triggers resizing **only** on an
+internal `/storage` URL — appending to a CDN URL does nothing. Built-in
+controllers pass internal URLs for the favicon and og:image for this reason:
+
+```html
+<link rel="icon" href="{{ favicon_url() | sized('icon') }}">
+<meta property="og:image" content="{{ og_meta.image | sized('og') }}">
+```
+
+Full reference: [Media & Storage guide](../../../docs/guides/media-and-storage.md).
+
 ## CSP Nonces
 
 The `SecurityHeadersMiddleware` generates a per-request nonce and injects it into the CSP header. Use nonces for inline scripts and styles:
@@ -181,6 +243,9 @@ For form rendering and CSRF tokens, see `/skrift-forms`.
 | `skrift/lib/theme.py` | Theme discovery, `ThemeInfo` dataclass, metadata parsing |
 | `skrift/app_factory.py` | Directory builders, `create_static_hasher()`, template config |
 | `skrift/middleware/security.py` | `SecurityHeadersMiddleware`, `csp_nonce_var` |
+| `skrift/middleware/storage.py` | `StorageFilesMiddleware` — asset serving + on-demand sizing |
+| `skrift/lib/imaging.py` | `IMAGE_SIZES`, `resize_image()`, variant helpers |
+| `skrift/db/services/asset_service.py` | `get_asset_url`, `image_url`, `internal_asset_url` |
 | `skrift/db/services/setting_service.py` | `SITE_THEME_KEY`, `get_cached_site_theme()` |
 | `skrift/lib/hooks.py` | `RESOLVE_THEME` filter hook constant |
 | `skrift/controllers/web.py` | Per-request theme resolution |

--- a/skrift/controllers/page_rendering.py
+++ b/skrift/controllers/page_rendering.py
@@ -9,7 +9,7 @@ from litestar import Request
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from skrift.controllers.helpers import get_user_context, resolve_theme
-from skrift.db.services.asset_service import get_asset_url
+from skrift.db.services.asset_service import get_asset_url, image_url, internal_asset_url
 from skrift.db.services.setting_service import (
     get_cached_site_base_url,
     get_cached_site_name,
@@ -23,7 +23,9 @@ class PublicPageRenderContext:
     """Resolved data required to render a public page template."""
 
     asset_urls: dict[str, str]
+    asset_image_urls: dict[str, str]
     featured_image_url: str | None
+    featured_cover_url: str | None
     flash: Any
     og_meta: dict[str, Any]
     seo_meta: dict[str, Any]
@@ -49,7 +51,9 @@ async def build_public_page_render_context(
     theme_name = await resolve_theme(request)
 
     asset_urls: dict[str, str] = {}
+    asset_image_urls: dict[str, str] = {}
     featured_image_url = None
+    featured_cover_url = None
     storage: StorageManager | None = None
 
     if include_asset_urls and page.assets:
@@ -58,13 +62,24 @@ async def build_public_page_render_context(
             str(asset.id): await get_asset_url(storage, asset)
             for asset in page.assets
         }
+        # Pre-resolve gallery thumbnails at the ``medium`` size. ``image_url``
+        # returns the backend's direct (CDN) URL once the variant exists, so warm
+        # requests skip Skrift; cold ones fall back to the lazy ``/storage`` URL.
+        asset_image_urls = {
+            str(asset.id): await image_url(storage, asset, "medium")
+            for asset in page.assets
+            if asset.content_type.startswith("image/")
+        }
 
     if page.featured_asset:
-        featured_asset_key = str(page.featured_asset.id)
-        featured_image_url = asset_urls.get(featured_asset_key)
-        if featured_image_url is None:
-            storage = storage or request.app.state.storage_manager
-            featured_image_url = await get_asset_url(storage, page.featured_asset)
+        # The og:image tag sizes this in-template, so keep it as the
+        # Skrift-internal URL that routes through the storage middleware on any
+        # backend. The on-page cover is pre-resolved for the warm CDN path.
+        featured_image_url = internal_asset_url(
+            page.featured_asset.store, page.featured_asset.key
+        )
+        storage = storage or request.app.state.storage_manager
+        featured_cover_url = await image_url(storage, page.featured_asset, "cover")
 
     site_name = get_cached_site_name()
     base_url = get_cached_site_base_url() or str(request.base_url).rstrip("/")
@@ -78,7 +93,9 @@ async def build_public_page_render_context(
 
     return PublicPageRenderContext(
         asset_urls=asset_urls,
+        asset_image_urls=asset_image_urls,
         featured_image_url=featured_image_url,
+        featured_cover_url=featured_cover_url,
         flash=flash,
         og_meta=og_meta,
         seo_meta=seo_meta,

--- a/skrift/controllers/page_type_factory.py
+++ b/skrift/controllers/page_type_factory.py
@@ -111,7 +111,9 @@ def create_public_page_type_controller(
                     "seo_meta": render_ctx.seo_meta,
                     "og_meta": render_ctx.og_meta,
                     "featured_image_url": render_ctx.featured_image_url,
+                    "featured_cover_url": render_ctx.featured_cover_url,
                     "asset_urls": render_ctx.asset_urls,
+                    "asset_image_urls": render_ctx.asset_image_urls,
                 },
             )
             return template.render(

--- a/skrift/controllers/web.py
+++ b/skrift/controllers/web.py
@@ -70,6 +70,7 @@ class WebController(Controller):
                 "seo_meta": render_ctx.seo_meta,
                 "og_meta": render_ctx.og_meta,
                 "featured_image_url": render_ctx.featured_image_url,
+                "featured_cover_url": render_ctx.featured_cover_url,
             }
         )
         return template.render(

--- a/skrift/db/services/asset_service.py
+++ b/skrift/db/services/asset_service.py
@@ -20,6 +20,7 @@ from skrift.hooks import (
     BEFORE_ASSET_UPLOAD,
     hooks,
 )
+from skrift.lib.imaging import IMAGE_SIZES, variant_filename
 from skrift.storage.manager import StorageManager
 
 
@@ -137,6 +138,54 @@ async def get_asset_url(storage: StorageManager, asset: Asset) -> str:
     """Return the public/signed URL for an asset."""
     backend = await storage.get(asset.store)
     return await backend.get_url(asset.key)
+
+
+def internal_asset_url(store: str, key: str) -> str:
+    """Return the Skrift-internal storage URL for a key.
+
+    This always routes through ``StorageFilesMiddleware`` regardless of the
+    backend, so it is used for sized requests whose variants may not exist yet
+    and for crawler-facing tags that must resolve on any backend.
+    """
+    return f"/storage/{store}/{key}"
+
+
+async def image_url(
+    storage: StorageManager,
+    asset_or_key: Asset | str,
+    size: str | None = None,
+    store: str | None = None,
+) -> str:
+    """Resolve an asset URL, optionally at a named size.
+
+    Resolution is lazy and backend-agnostic:
+
+    * No size (or an unknown size) returns the backend's direct URL for the
+      original.
+    * When the sized variant already exists, returns the backend's direct URL
+      for that variant — for remote backends this is the CDN URL, so warm
+      requests skip Skrift entirely (no redirect).
+    * When the variant is missing, returns the internal ``/storage`` URL. The
+      first request generates and caches the variant, then redirects to the
+      backend URL, keeping generation off the hot path.
+    """
+    if isinstance(asset_or_key, Asset):
+        store_name = asset_or_key.store
+        key = asset_or_key.key
+    else:
+        store_name = store or storage.default_store
+        key = asset_or_key
+
+    backend = await storage.get(store_name)
+
+    if not size or size not in IMAGE_SIZES:
+        return await backend.get_url(key)
+
+    variant_key = variant_filename(key, size)
+    if await backend.exists(variant_key):
+        return await backend.get_url(variant_key)
+
+    return f"{internal_asset_url(store_name, key)}?size={size}"
 
 
 async def list_assets(

--- a/skrift/middleware/helpers.py
+++ b/skrift/middleware/helpers.py
@@ -11,3 +11,29 @@ async def send_not_found(send: Send) -> None:
         "headers": [(b"content-type", b"text/plain")],
     })
     await send({"type": "http.response.body", "body": b"Not Found"})
+
+
+async def send_file(send: Send, content: bytes, media_type: str) -> None:
+    """Send a 200 response carrying raw file bytes."""
+    await send({
+        "type": "http.response.start",
+        "status": 200,
+        "headers": [
+            (b"content-type", media_type.encode()),
+            (b"content-length", str(len(content)).encode()),
+        ],
+    })
+    await send({"type": "http.response.body", "body": content})
+
+
+async def send_redirect(send: Send, location: str, status: int = 302) -> None:
+    """Send a redirect response to the given location."""
+    await send({
+        "type": "http.response.start",
+        "status": status,
+        "headers": [
+            (b"location", location.encode()),
+            (b"content-length", b"0"),
+        ],
+    })
+    await send({"type": "http.response.body", "body": b""})

--- a/skrift/middleware/storage.py
+++ b/skrift/middleware/storage.py
@@ -1,37 +1,39 @@
-"""ASGI middleware for serving locally-stored assets."""
+"""ASGI middleware for serving stored assets across any storage backend."""
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import mimetypes
-from pathlib import Path
 from typing import TYPE_CHECKING
 from urllib.parse import parse_qs
 
 from litestar.types import ASGIApp, Receive, Scope, Send
 
 from skrift.lib.imaging import IMAGE_SIZES, detect_image_content_type, resize_image, variant_filename
-from skrift.middleware.helpers import send_not_found
+from skrift.middleware.helpers import send_file, send_not_found, send_redirect
 
 if TYPE_CHECKING:
-    from skrift.config import StorageConfig
+    from skrift.storage.base import StorageBackend
+    from skrift.storage.manager import StorageManager
 
 logger = logging.getLogger(__name__)
 
 
 class StorageFilesMiddleware:
-    """Serve files from local storage backends at ``/storage/{store}/{key}``.
+    """Serve stored assets at ``/storage/{store}/{key}`` through any backend.
 
-    Only handles stores configured with ``backend = "local"``.  Remote backends
-    (S3, etc.) serve via their own URLs and are not intercepted here.
-
-    Supports ``?size=name`` query parameter for on-demand image resizing.
-    Resized variants are cached alongside originals for subsequent requests.
+    Resolves the request through the configured :class:`StorageManager`, so it
+    works for local, S3, and custom backends alike. Supports ``?size=name`` for
+    on-demand image resizing: the variant is generated once, cached in the same
+    backend under a ``{key}.{size}`` key, then served inline (for backends with
+    Skrift-internal URLs) or redirected to (for backends with external/CDN URLs)
+    so subsequent warm requests bypass Skrift entirely.
     """
 
-    def __init__(self, app: ASGIApp, storage_config: StorageConfig) -> None:
+    def __init__(self, app: ASGIApp, storage_manager: StorageManager) -> None:
         self.app = app
-        self._storage_config = storage_config
+        self._storage = storage_manager
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         if scope["type"] != "http" or not scope["path"].startswith("/storage/"):
@@ -41,104 +43,77 @@ class StorageFilesMiddleware:
         # Parse /storage/{store_name}/{key...}
         rest = scope["path"][len("/storage/"):]
         slash_idx = rest.find("/")
-        if slash_idx == -1 or not rest[:slash_idx]:
+        if slash_idx <= 0:
             await send_not_found(send)
             return
 
         store_name = rest[:slash_idx]
         key = rest[slash_idx + 1:]
 
-        if not key:
+        # Security: reject empty keys, traversal, and null bytes
+        if not key or ".." in key.split("/") or "\x00" in key:
             await send_not_found(send)
             return
-
-        # Only serve local backends
-        store_cfg = self._storage_config.stores.get(store_name)
-        if store_cfg is None or store_cfg.backend != "local":
-            await send_not_found(send)
-            return
-
-        # Security: reject traversal and null bytes
-        if ".." in key.split("/") or "\x00" in key:
-            await send_not_found(send)
-            return
-
-        base_path = Path(store_cfg.local_path).resolve()
-
-        # Reconstruct the on-disk path through LocalStorageBackend's layout
-        if len(key) >= 4:
-            candidate = base_path / key[:2] / key[2:4] / key
-        else:
-            candidate = base_path / key
 
         try:
-            resolved = candidate.resolve()
-        except (OSError, ValueError):
+            backend = await self._storage.get(store_name)
+        except KeyError:
             await send_not_found(send)
             return
 
-        if not resolved.is_relative_to(base_path):
+        size_name = self._requested_size(scope)
+        serve_key = key
+        if size_name in IMAGE_SIZES:
+            variant_key = await self._ensure_variant(backend, key, size_name)
+            if variant_key is not None:
+                serve_key = variant_key
+
+        target_url = await backend.get_url(serve_key)
+        if target_url.startswith(("http://", "https://")):
+            await send_redirect(send, target_url)
+            return
+
+        if not await backend.exists(serve_key):
             await send_not_found(send)
             return
 
-        if not resolved.is_file():
-            await send_not_found(send)
-            return
-
-        # Check for ?size=name variant request
-        qs = scope.get("query_string", b"")
-        params = parse_qs(qs.decode("latin-1") if isinstance(qs, bytes) else qs)
-        size_name = params.get("size", [None])[0]
-
-        result = None
-        if size_name and size_name in IMAGE_SIZES:
-            result = self._get_or_create_variant(resolved, size_name)
-
-        if result is not None:
-            content, media_type = result
-        else:
-            content = resolved.read_bytes()
-            media_type = mimetypes.guess_type(str(resolved))[0] or "application/octet-stream"
-
-        await send({
-            "type": "http.response.start",
-            "status": 200,
-            "headers": [
-                (b"content-type", media_type.encode()),
-                (b"content-length", str(len(content)).encode()),
-            ],
-        })
-        await send({"type": "http.response.body", "body": content})
+        content = await backend.get(serve_key)
+        media_type = (
+            detect_image_content_type(content)
+            or mimetypes.guess_type(serve_key)[0]
+            or "application/octet-stream"
+        )
+        await send_file(send, content, media_type)
 
     @staticmethod
-    def _get_or_create_variant(original: Path, size_name: str) -> tuple[bytes, str] | None:
-        """Return cached variant bytes or generate and cache them.
+    def _requested_size(scope: Scope) -> str | None:
+        qs = scope.get("query_string", b"")
+        params = parse_qs(qs.decode("latin-1") if isinstance(qs, bytes) else qs)
+        return params.get("size", [None])[0]
 
-        The variant file is stored alongside the original with a ``.{size_name}``
-        suffix (e.g. ``abc123def456.thumb``).
+    @staticmethod
+    async def _ensure_variant(
+        backend: StorageBackend, key: str, size_name: str
+    ) -> str | None:
+        """Return the variant key, generating and caching it on first request.
 
-        Returns ``None`` if the original is not a recognized image format.
+        Returns ``None`` when the original is missing or is not a recognized
+        image, signalling the caller to fall back to the original key.
         """
-        variant_name = variant_filename(original.name, size_name)
-        variant_path = original.parent / variant_name
+        variant_key = variant_filename(key, size_name)
+        if await backend.exists(variant_key):
+            return variant_key
 
-        if variant_path.is_file():
-            content = variant_path.read_bytes()
-            ct = detect_image_content_type(content) or "application/octet-stream"
-            return content, ct
-
-        original_bytes = original.read_bytes()
-
-        # Skip non-image files
-        if detect_image_content_type(original_bytes) is None:
+        if not await backend.exists(key):
             return None
 
-        max_w, max_h = IMAGE_SIZES[size_name]
-        resized_bytes, content_type = resize_image(original_bytes, max_w, max_h)
+        original = await backend.get(key)
+        if detect_image_content_type(original) is None:
+            return None
 
-        try:
-            variant_path.write_bytes(resized_bytes)
-        except OSError:
-            logger.warning("Failed to cache variant %s", variant_path, exc_info=True)
-
-        return resized_bytes, content_type
+        max_width, max_height = IMAGE_SIZES[size_name]
+        resized, content_type = await asyncio.to_thread(
+            resize_image, original, max_width, max_height
+        )
+        await backend.put(variant_key, resized, content_type)
+        return variant_key

--- a/skrift/templates/admin/pages/edit.html
+++ b/skrift/templates/admin/pages/edit.html
@@ -238,7 +238,7 @@
                 {% for asset in page_assets %}
                 <div class="sk-attachment-item" data-asset-id="{{ asset.id }}">
                     {% if asset.content_type.startswith("image/") %}
-                    <img src="{{ asset_urls[asset.id | string] | sized('thumb') }}" alt="{{ asset.filename }}" class="sk-attachment-thumb" loading="lazy">
+                    <img src="{{ asset_image_urls[asset.id | string] }}" alt="{{ asset.filename }}" class="sk-attachment-thumb" loading="lazy">
                     {% endif %}
                     {% if not asset.content_type.startswith("image/") %}
                     <span class="sk-attachment-badge">{{ asset.filename.rsplit(".", 1)[-1] | upper if "." in asset.filename else "FILE" }}</span>

--- a/skrift/templates/page.html
+++ b/skrift/templates/page.html
@@ -341,7 +341,7 @@
 
     {% if featured_image_url %}
     <figure class="sk-cover-image">
-        <img src="{{ featured_image_url | sized('cover') }}" alt="{{ page.featured_asset.alt_text or page.title }}">
+        <img src="{{ featured_cover_url or featured_image_url | sized('cover') }}" alt="{{ page.featured_asset.alt_text or page.title }}">
     </figure>
     {% endif %}
 
@@ -371,7 +371,7 @@
                     <video src="{{ asset_urls[asset.id | string] }}" preload="metadata" muted loop playsinline></video>
                     <span class="sk-gallery-play"></span>
                     {% else %}
-                    <img src="{{ asset_urls[asset.id | string] | sized('medium') }}" alt="{{ asset.alt_text or asset.filename }}" loading="lazy">
+                    <img src="{{ asset_image_urls[asset.id | string] }}" alt="{{ asset.alt_text or asset.filename }}" loading="lazy">
                     {% endif %}
                     <span class="sk-gallery-overlay"><span class="sk-gallery-caption">{{ asset.alt_text or asset.filename }}</span></span>
                 </a>

--- a/tests/test_admin_controller.py
+++ b/tests/test_admin_controller.py
@@ -527,30 +527,29 @@ class TestPageMutationErrors:
 
 class TestSettingsController:
     @pytest.mark.asyncio
-    async def test_favicon_preview_failure_logs_and_renders(self):
+    async def test_favicon_preview_uses_internal_url(self):
         from skrift.admin.settings import SettingsAdminController
 
         controller = SettingsAdminController(owner=MagicMock())
         request = MagicMock()
         request.query_params = {}
         request.app.state.storage_manager = MagicMock()
+        request.app.state.storage_manager.default_store = "default"
         db_session = AsyncMock()
-
-        request.app.state.storage_manager.get = AsyncMock(side_effect=RuntimeError("boom"))
 
         with patch("skrift.admin.settings.get_admin_context", new_callable=AsyncMock, return_value={}), \
              patch("skrift.admin.settings.get_flash_messages", return_value=[]), \
              patch("skrift.admin.settings.setting_service.get_site_settings", new_callable=AsyncMock, return_value={"site_favicon_key": "favicon-key"}), \
              patch("skrift.admin.settings.importlib.metadata.version", return_value="0.1.0"), \
-             patch("skrift.config.get_settings", return_value=MagicMock(sites={}, domain="")), \
-             patch("skrift.admin.settings.logger.warning") as mock_log:
+             patch("skrift.config.get_settings", return_value=MagicMock(sites={}, domain="")):
             result = await SettingsAdminController.site_settings.fn(
                 controller, request, db_session
             )
 
         assert result.template_name == "admin/settings/site.html"
-        assert result.context["current_favicon_url"] == ""
-        mock_log.assert_called_once()
+        # Internal URL so the in-template ``sized('icon')`` request routes
+        # through the storage middleware and works on any backend.
+        assert result.context["current_favicon_url"] == "/storage/default/favicon-key"
 
 
 class TestAdminNavHelper:

--- a/tests/test_page_rendering.py
+++ b/tests/test_page_rendering.py
@@ -28,10 +28,12 @@ class TestWantsMarkdownResponse:
 
 class TestBuildPublicPageRenderContext:
     @pytest.mark.asyncio
-    async def test_reuses_asset_urls_for_featured_image(self):
+    async def test_featured_image_uses_internal_url_and_preresolved_cover(self):
         from skrift.controllers.page_rendering import build_public_page_render_context
 
-        featured_asset = SimpleNamespace(id="asset-1", store="default", key="featured")
+        featured_asset = SimpleNamespace(
+            id="asset-1", store="default", key="featured", content_type="image/jpeg"
+        )
         page = SimpleNamespace(
             assets=[featured_asset],
             featured_asset=featured_asset,
@@ -59,6 +61,11 @@ class TestBuildPublicPageRenderContext:
                 return_value="https://cdn.example.com/featured.jpg",
             ) as mock_get_asset_url,
             patch(
+                "skrift.controllers.page_rendering.image_url",
+                new_callable=AsyncMock,
+                side_effect=lambda _s, _a, size: f"https://cdn.example.com/featured.{size}",
+            ),
+            patch(
                 "skrift.controllers.page_rendering.get_page_seo_meta",
                 new_callable=AsyncMock,
                 return_value={"title": "SEO"},
@@ -84,9 +91,16 @@ class TestBuildPublicPageRenderContext:
         assert render_ctx.asset_urls == {
             "asset-1": "https://cdn.example.com/featured.jpg"
         }
-        assert render_ctx.featured_image_url == "https://cdn.example.com/featured.jpg"
+        # Gallery thumbnails and the cover are pre-resolved through ``image_url``.
+        assert render_ctx.asset_image_urls == {
+            "asset-1": "https://cdn.example.com/featured.medium"
+        }
+        assert render_ctx.featured_cover_url == "https://cdn.example.com/featured.cover"
+        # The featured image stays an internal URL so og:image sizing works on
+        # any backend, including remote/CDN-backed stores.
+        assert render_ctx.featured_image_url == "/storage/default/featured"
         assert request.session == {}
         assert mock_get_asset_url.await_count == 1
         assert mock_get_og_meta.await_args.kwargs["featured_image_url"] == (
-            "https://cdn.example.com/featured.jpg"
+            "/storage/default/featured"
         )

--- a/tests/test_storage_imaging.py
+++ b/tests/test_storage_imaging.py
@@ -1,0 +1,248 @@
+"""Backend-agnostic image scaling: helper + storage middleware."""
+
+from __future__ import annotations
+
+import io
+
+import pytest
+from PIL import Image
+
+from skrift.db.services.asset_service import image_url, internal_asset_url
+from skrift.middleware.storage import StorageFilesMiddleware
+from skrift.storage.base import StoredFile
+
+
+def _png_bytes(width: int, height: int) -> bytes:
+    buf = io.BytesIO()
+    Image.new("RGB", (width, height), (10, 120, 200)).save(buf, format="PNG")
+    return buf.getvalue()
+
+
+class FakeBackend:
+    """In-memory storage backend whose URL scheme is configurable.
+
+    When ``base_url`` is set it mimics a remote/CDN backend (absolute URLs);
+    otherwise it mimics a local backend (Skrift-internal ``/storage`` URLs).
+    """
+
+    def __init__(self, store_name: str = "default", base_url: str | None = None) -> None:
+        self._store_name = store_name
+        self._base_url = base_url
+        self.objects: dict[str, bytes] = {}
+        self.put_calls: list[str] = []
+
+    async def put(self, key: str, data: bytes, content_type: str) -> StoredFile:
+        self.objects[key] = data
+        self.put_calls.append(key)
+        return StoredFile(key, await self.get_url(key), content_type, len(data), "")
+
+    async def get(self, key: str) -> bytes:
+        return self.objects[key]
+
+    async def delete(self, key: str) -> None:
+        self.objects.pop(key, None)
+
+    async def exists(self, key: str) -> bool:
+        return key in self.objects
+
+    async def list_keys(self, prefix: str = ""):
+        for key in self.objects:
+            if key.startswith(prefix):
+                yield key
+
+    async def get_url(self, key: str) -> str:
+        if self._base_url:
+            return f"{self._base_url}/{key}"
+        return internal_asset_url(self._store_name, key)
+
+
+class FakeManager:
+    def __init__(self, backend: FakeBackend, default: str = "default") -> None:
+        self._backend = backend
+        self.default_store = default
+
+    async def get(self, name: str | None = None) -> FakeBackend:
+        if name not in (None, self.default_store):
+            raise KeyError(name)
+        return self._backend
+
+
+async def _run(middleware: StorageFilesMiddleware, path: str, query: bytes = b""):
+    """Drive the middleware and capture the ASGI response messages."""
+    scope = {"type": "http", "path": path, "query_string": query}
+    sent: list[dict] = []
+
+    async def receive():
+        return {"type": "http.request", "body": b""}
+
+    async def send(message):
+        sent.append(message)
+
+    called = {"downstream": False}
+
+    async def app(scope, receive, send):
+        called["downstream"] = True
+
+    middleware.app = app
+    await middleware(scope, receive, send)
+    return sent, called["downstream"]
+
+
+def _status(sent: list[dict]) -> int:
+    return next(m["status"] for m in sent if m["type"] == "http.response.start")
+
+
+def _headers(sent: list[dict]) -> dict[bytes, bytes]:
+    start = next(m for m in sent if m["type"] == "http.response.start")
+    return dict(start["headers"])
+
+
+def _body(sent: list[dict]) -> bytes:
+    return b"".join(m.get("body", b"") for m in sent if m["type"] == "http.response.body")
+
+
+# -- image_url helper --------------------------------------------------------
+
+
+async def test_image_url_without_size_returns_original_url():
+    backend = FakeBackend(base_url="https://cdn.example.com")
+    backend.objects["abc"] = _png_bytes(50, 50)
+    manager = FakeManager(backend)
+
+    url = await image_url(manager, "abc", store="default")
+
+    assert url == "https://cdn.example.com/abc"
+
+
+async def test_image_url_cold_path_returns_internal_size_url():
+    backend = FakeBackend(base_url="https://cdn.example.com")
+    backend.objects["abc"] = _png_bytes(50, 50)
+    manager = FakeManager(backend)
+
+    url = await image_url(manager, "abc", "thumb", store="default")
+
+    # Variant does not exist yet → lazy internal URL that triggers generation.
+    assert url == "/storage/default/abc?size=thumb"
+
+
+async def test_image_url_warm_path_returns_direct_variant_url():
+    backend = FakeBackend(base_url="https://cdn.example.com")
+    backend.objects["abc"] = _png_bytes(50, 50)
+    backend.objects["abc.thumb"] = _png_bytes(20, 20)
+    manager = FakeManager(backend)
+
+    url = await image_url(manager, "abc", "thumb", store="default")
+
+    # Variant exists → direct CDN URL, no Skrift round-trip.
+    assert url == "https://cdn.example.com/abc.thumb"
+
+
+# -- middleware: remote backend (redirect) -----------------------------------
+
+
+async def test_remote_sized_request_generates_variant_and_redirects():
+    backend = FakeBackend(base_url="https://cdn.example.com")
+    backend.objects["abc"] = _png_bytes(1000, 800)
+    middleware = StorageFilesMiddleware(app=None, storage_manager=FakeManager(backend))
+
+    sent, _ = await _run(middleware, "/storage/default/abc", b"size=thumb")
+
+    assert _status(sent) == 302
+    assert _headers(sent)[b"location"] == b"https://cdn.example.com/abc.thumb"
+    # Variant was generated and cached back into the backend.
+    assert "abc.thumb" in backend.objects
+    assert backend.put_calls == ["abc.thumb"]
+
+
+async def test_remote_warm_request_does_not_regenerate():
+    backend = FakeBackend(base_url="https://cdn.example.com")
+    backend.objects["abc"] = _png_bytes(1000, 800)
+    backend.objects["abc.thumb"] = _png_bytes(200, 160)
+    middleware = StorageFilesMiddleware(app=None, storage_manager=FakeManager(backend))
+
+    sent, _ = await _run(middleware, "/storage/default/abc", b"size=thumb")
+
+    assert _status(sent) == 302
+    assert _headers(sent)[b"location"] == b"https://cdn.example.com/abc.thumb"
+    assert backend.put_calls == []  # served the cached variant, no regeneration
+
+
+# -- middleware: local backend (inline bytes) --------------------------------
+
+
+async def test_local_sized_request_serves_resized_bytes_inline():
+    backend = FakeBackend(base_url=None)  # internal URLs → served inline
+    backend.objects["abc"] = _png_bytes(1000, 1000)
+    middleware = StorageFilesMiddleware(app=None, storage_manager=FakeManager(backend))
+
+    sent, _ = await _run(middleware, "/storage/default/abc", b"size=thumb")
+
+    assert _status(sent) == 200
+    assert _headers(sent)[b"content-type"] == b"image/png"
+    resized = Image.open(io.BytesIO(_body(sent)))
+    assert resized.size == (200, 200)
+    assert "abc.thumb" in backend.objects
+
+
+async def test_local_original_request_serves_bytes_inline():
+    backend = FakeBackend(base_url=None)
+    original = _png_bytes(40, 40)
+    backend.objects["abc"] = original
+    middleware = StorageFilesMiddleware(app=None, storage_manager=FakeManager(backend))
+
+    sent, _ = await _run(middleware, "/storage/default/abc")
+
+    assert _status(sent) == 200
+    assert _body(sent) == original
+
+
+# -- middleware: edge cases --------------------------------------------------
+
+
+async def test_non_image_with_size_falls_back_to_original():
+    backend = FakeBackend(base_url=None)
+    backend.objects["doc"] = b"%PDF-1.4 not an image"
+    middleware = StorageFilesMiddleware(app=None, storage_manager=FakeManager(backend))
+
+    sent, _ = await _run(middleware, "/storage/default/doc", b"size=thumb")
+
+    assert _status(sent) == 200
+    assert _body(sent) == b"%PDF-1.4 not an image"
+    assert backend.put_calls == []  # never tried to resize a non-image
+
+
+async def test_missing_original_returns_404():
+    backend = FakeBackend(base_url=None)
+    middleware = StorageFilesMiddleware(app=None, storage_manager=FakeManager(backend))
+
+    sent, _ = await _run(middleware, "/storage/default/missing")
+
+    assert _status(sent) == 404
+
+
+async def test_unknown_store_returns_404():
+    backend = FakeBackend(base_url=None)
+    middleware = StorageFilesMiddleware(app=None, storage_manager=FakeManager(backend))
+
+    sent, _ = await _run(middleware, "/storage/other/abc")
+
+    assert _status(sent) == 404
+
+
+async def test_path_traversal_is_rejected():
+    backend = FakeBackend(base_url=None)
+    middleware = StorageFilesMiddleware(app=None, storage_manager=FakeManager(backend))
+
+    sent, _ = await _run(middleware, "/storage/default/../secret")
+
+    assert _status(sent) == 404
+
+
+async def test_non_storage_path_passes_through():
+    backend = FakeBackend(base_url=None)
+    middleware = StorageFilesMiddleware(app=None, storage_manager=FakeManager(backend))
+
+    sent, downstream = await _run(middleware, "/about")
+
+    assert downstream is True
+    assert sent == []


### PR DESCRIPTION
## Summary
On-demand image scaling now works across **any** storage backend (local, S3, and custom), not just the local filesystem. Variants are generated lazily, cached back into the same backend, and served from there — including straight from a CDN for remote stores.

## Changes

### New Features
- Backend-agnostic on-demand image sizing: `StorageFilesMiddleware` rewritten against the `StorageBackend` protocol via `StorageManager`. Variants cache into the same backend under a `{key}.{size}` key and are served inline (local) or via `302` redirect (S3/CDN).
- New `image_url()` asset-service helper — lazy and backend-aware. Warm path returns the backend's direct (CDN) URL with no Skrift round-trip; cold path returns the internal `/storage/{store}/{key}?size=…` URL that generates and redirects on first hit. Added `internal_asset_url()`.

### Improvements
- Page and admin controllers pre-resolve gallery (`medium`), featured (`cover`), and attachment (`thumb`) image URLs via `image_url`, giving the warm CDN path on the hot paths.
- favicon and og:image now resolve through internal URLs so the `sized` filter works on any backend (previously appended `?size=` to CDN URLs, which did nothing).
- New **Media & Storage** guide (`docs/guides/media-and-storage.md`) and a frontend-skill section documenting backend configuration, the size table, and the `image_url`/`sized` helpers.

### Tests
- New `tests/test_storage_imaging.py` covering the helper (warm/cold/no-size), remote redirect + variant caching, local inline serving, non-image fallback, 404s, and traversal rejection. Full non-integration suite green (1426 passed).

## Release version
`0.2.0a7` -> `0.2.0a8`

🤖 Generated with [Claude Code](https://claude.com/claude-code)