### PR TITLE
Release v0.2.0a9 — code-declared, admin-editable content fields

### DIFF
--- a/.claude/skills/skrift-content/SKILL.md
+++ b/.claude/skills/skrift-content/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: skrift-content
+description: "Skrift content fields — code-declared, admin-editable page content: ContentArea schemas, field/group/repeater helpers, JSON storage, and the /admin/content editor."
+---
+
+# Skrift Content Fields
+
+Code declares the editable fields a template needs; a user edits them under **Admin → Content**; the template renders the saved, validated values. Built on the same Pydantic conventions as `/skrift-forms`. User-facing docs: `docs/guides/content-fields.md`.
+
+## Architecture
+
+```
+skrift/content/
+  fields.py    field helpers -> Pydantic Field(json_schema_extra={widget,label,...})
+  schema.py    ContentModel (groups/items) + ContentArea (registered by key) + registry
+  parse.py     parse_nested_form: dotted form names -> nested dict/list (sparse indices compacted)
+  render.py    hydrate(schema, data) -> model; build_nodes(schema, data) -> admin render tree
+  builtin.py   HomeContent (key="home") -> powers default landing index.html
+  __init__.py  public API; imports builtin so areas register on import
+
+skrift/db/models/content_area.py     ContentAreaRecord (table content_areas: key unique, data JSON)
+skrift/db/services/content_service.py get_content_data / save_content_data
+skrift/admin/content.py              ContentAdminController (/admin/content, guard Permission("modify-site"))
+skrift/templates/admin/content/      list.html, edit.html, _fields.html (recursive macros + repeater JS)
+```
+
+Migration: `content_areas` table = `b0c1d2e3f4a5`.
+
+## Declaring an area
+
+```python
+from skrift.content import ContentArea, ContentModel, text, textarea, url, group, repeater
+
+class CallToAction(ContentModel):
+    label: str = text("Button label", default="Get started")
+    url: str = url("Button link", default="/signup")
+
+class HomeSection(ContentModel):
+    heading: str = text("Heading", default="")
+    body: str = textarea("Body", default="", rows=4)
+
+class HomeContent(ContentArea, key="home", label="Home Page", description="..."):
+    hero_title: str = text("Hero title", default="Welcome")
+    cta: CallToAction = group(CallToAction, label="Call to action")
+    sections: list[HomeSection] = repeater(HomeSection, item_label="Section")
+```
+
+Areas register on import (like forms). `@content_area("key")` decorator works on a plain `ContentModel`.
+
+## Field helpers (`skrift.content`)
+
+`text`, `textarea`, `url`, `email`, `phone`, `number`, `select(choices=[(val,label),...])`, `boolean`, plus composites `group(Schema, label=…)` and `repeater(Schema, label=…, item_label=…, min_items=, max_items=)`. Each sets `json_schema_extra["widget"]` + label/help_text/placeholder; the annotation drives Pydantic validation.
+
+## Rendering in a controller/template
+
+```python
+from skrift.content import get_content_area, hydrate
+from skrift.db.services import content_service
+
+schema = get_content_area("home")
+content = hydrate(schema, await content_service.get_content_data(db_session, "home"))
+# template: content.hero_title, content.cta.label, {% for s in content.sections %}
+```
+
+The built-in `WebController.index` does this for `home`. `index.html` guards with `{% if content %}`.
+
+## Conventions & gotchas
+
+- **Defaults everywhere**: every field needs a default so an area constructs with no data; `group` uses `default_factory=Schema`, `repeater` uses `default_factory=list`.
+- **Schema evolution is safe**: `hydrate` fills missing fields from defaults and ignores unknown stored keys (Pydantic `extra="ignore"`).
+- **Admin form names are dotted/namespaced**: `cta.label`, `sections.0.heading`. `parse_nested_form` rebuilds nesting; repeater indices may be sparse (rows deleted client-side) and are sorted+compacted.
+- **Repeaters are single-level** (a list of groups). The edit template clones a `<template>` row, swapping `__INDEX__` for a monotonic counter; macros live in `_fields.html` (a partial, since importing macros from an `{% extends %}` template forces parent render).
+- **Registration**: `ContentAdminController` is auto-added in `skrift/asgi.py load_controllers` alongside the other `AdminController` sub-controllers and re-exported from `skrift/admin/controller.py`.
+- **Permission**: `modify-site` (same as site settings).
+
+## Demo
+
+`demo/basic-site` renders the `home` area on its landing page (`SiteController.index` passes `content`). Demo Login with *is_admin* → Admin → Content → Home Page.
+
+## Related Skills
+
+- **`/skrift-forms`** — shared Pydantic/`json_schema_extra` widget conventions
+- **`/skrift-db`** — models, services, migrations
+- **`/skrift-frontend`** — templates, themes, CSP nonces
+- **`/skrift-auth`** — guards/permissions (`modify-site`)

--- a/.claude/skills/skrift/SKILL.md
+++ b/.claude/skills/skrift/SKILL.md
@@ -23,6 +23,7 @@ Skrift is a lightweight async Python CMS built on Litestar, featuring WordPress-
 - **Config**: YAML (app.yaml) + environment variables (.env)
 - **Auth**: OAuth providers + role-based permissions (see `/skrift-auth`)
 - **Forms**: Pydantic-backed with CSRF (see `/skrift-forms`)
+- **Content Fields**: code-declared, admin-editable page content (see `/skrift-content`)
 - **Events**: Hooks/filters + SSE notifications (see `/skrift-events`)
 - **Web Push**: Browser push with SSE fallback (see `/skrift-push`)
 - **Multisite**: Multi-subdomain architecture (see `/skrift-multisite`)
@@ -133,11 +134,12 @@ from skrift import (
     notify_user, notify_session, ensure_nid,  # notifications
     get_settings, register_config_section,    # config
     Template, render_markdown,            # rendering
+    ContentArea, ContentModel, content_area,  # content fields
     handler, submit, Job,                 # workers
 )
 ```
 
-Subsystem modules live at guessable top-level paths: `skrift.hooks`, `skrift.forms`, `skrift.notifications`, `skrift.push`, `skrift.flash`, `skrift.template`, `skrift.markdown`, `skrift.seo`, `skrift.storage`. `skrift.lib` is internal — never import from it in downstream code.
+Subsystem modules live at guessable top-level paths: `skrift.hooks`, `skrift.forms`, `skrift.content`, `skrift.notifications`, `skrift.push`, `skrift.flash`, `skrift.template`, `skrift.markdown`, `skrift.seo`, `skrift.storage`. `skrift.lib` is internal — never import from it in downstream code.
 
 ## CLI Commands
 
@@ -282,5 +284,6 @@ async def test_list_items(client, db_session):
 - **`/skrift-events`** — Hooks/filters, SSE notifications, backends
 - **`/skrift-push`** — Web Push notifications, service worker
 - **`/skrift-forms`** — Form system, CSRF, field customization
+- **`/skrift-content`** — Content fields: code-declared, admin-editable page content
 - **`/skrift-frontend`** — Templates, themes, static assets, CSP nonces
 - **`/skrift-multisite`** — Multi-subdomain architecture

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ A modern Litestar-powered content management framework with multi-provider OAuth
 - **Setup Wizard**: Guided first-time configuration without manual file editing
 - **Admin Interface**: Web-based management for users, pages, and site settings
 - **WordPress-like Templates**: Hierarchical template resolution for content pages
+- **Content Fields**: Declare editable fields in code; non-developers edit them in the admin
 - **Dynamic Controllers**: Load controllers from `app.yaml` configuration
 - **SQLAlchemy Integration**: Async database support with SQLite/PostgreSQL
 - **Client-Side Sessions**: Encrypted cookie sessions for horizontal scalability

--- a/demo/basic-site/basicsite/controllers.py
+++ b/demo/basic-site/basicsite/controllers.py
@@ -10,8 +10,9 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
+from skrift.content import get_content_area, hydrate
 from skrift.db.models.user import User
-from skrift.db.services import page_service
+from skrift.db.services import content_service, page_service
 from skrift.db.services.setting_service import get_cached_site_name, get_cached_site_base_url
 from skrift.seo import get_page_seo_meta, get_page_og_meta
 from skrift.storage import StorageManager
@@ -45,9 +46,22 @@ class SiteController(Controller):
         flash = request.session.pop("flash", None)
         nav_pages = await self._get_nav_pages(db_session)
 
+        # Hydrate the admin-editable "home" content area declared in code.
+        schema = get_content_area("home")
+        saved = await content_service.get_content_data(db_session, "home")
+        try:
+            content = hydrate(schema, saved)
+        except Exception:
+            content = schema()
+
         return TemplateResponse(
             "index.html",
-            context={"user": user, "flash": flash, "nav_pages": nav_pages},
+            context={
+                "user": user,
+                "flash": flash,
+                "nav_pages": nav_pages,
+                "content": content,
+            },
         )
 
     @get("/{path:path}")

--- a/docs/admin/index.md
+++ b/docs/admin/index.md
@@ -47,6 +47,14 @@ The admin interface is available to authenticated users with the admin role.
 
     Configure site name, tagline, and other settings.
 
+-   :material-pencil-box-multiple:{ .lg .middle } **Content**
+
+    ---
+
+    Edit page content for code-declared content areas (hero, sections, etc.).
+
+    [:octicons-arrow-right-24: Content Fields](../guides/content-fields.md)
+
 -   :material-puzzle:{ .lg .middle } **Custom Admin Pages**
 
     ---
@@ -64,6 +72,7 @@ The admin interface is available to authenticated users with the admin role.
 | `/admin` | Admin dashboard |
 | `/admin/users` | User list and role management |
 | `/admin/pages` | Page management |
+| `/admin/content` | Edit code-declared content areas |
 | `/admin/settings` | Site settings |
 
 ## Roles and Permissions

--- a/docs/guides/content-fields.md
+++ b/docs/guides/content-fields.md
@@ -1,0 +1,200 @@
+# Content Fields
+
+Content fields let you **declare editable fields in code** and have them appear in the admin for non-developers to edit. A template says what content it needs (a hero title, some copy, a call-to-action, a list of sections); Skrift renders an editor for those fields under **Admin → Content** and hands the saved, validated values back to your template.
+
+It is built on the same Pydantic conventions as the [Forms](forms.md) system, stores values in a single JSON-backed table, and ships with a built-in `home` area that powers the default landing page.
+
+## Overview
+
+| Concept | What it is |
+|---------|-----------|
+| **Content area** | A named schema of editable fields, bound to a string `key` (e.g. `"home"`) |
+| **Field helpers** | `text`, `textarea`, `url`, `select`, … — declare a field and its widget |
+| **Group** | A nested set of fields (e.g. a button's label + link) |
+| **Repeater** | A repeatable list of groups (e.g. "sections"), add/remove in the admin |
+| **Storage** | Values persist per key in the `content_areas` table as JSON |
+| **Admin** | Each area gets an editor at `/admin/content/{key}/edit` |
+
+## Quick Start
+
+### 1. Declare a content area
+
+```python
+from skrift.content import ContentArea, ContentModel, text, textarea, url, group, repeater
+
+
+class CallToAction(ContentModel):
+    label: str = text("Button label", default="Get started")
+    url: str = url("Button link", default="/signup")
+
+
+class HomeSection(ContentModel):
+    heading: str = text("Heading", default="")
+    body: str = textarea("Body", default="", rows=4)
+
+
+class HomeContent(ContentArea, key="home", label="Home Page",
+                  description="Hero and sections on the landing page."):
+    hero_title: str = text("Hero title", default="Welcome")
+    hero_subtitle: str = textarea("Hero subtitle", default="")
+    cta: CallToAction = group(CallToAction, label="Call to action")
+    sections: list[HomeSection] = repeater(HomeSection, item_label="Section")
+```
+
+The schema only registers once its module is imported (same rule as forms). Import it from a controller or your app package so it is available to the admin and your renderer.
+
+### 2. Render the values in a template
+
+In your controller, load and hydrate the area, then pass the model to the template:
+
+```python
+from skrift.content import get_content_area, hydrate
+from skrift.db.services import content_service
+
+schema = get_content_area("home")
+saved = await content_service.get_content_data(db_session, "home")
+content = hydrate(schema, saved)   # validated model, defaults filled in
+
+return TemplateResponse("index.html", context={"content": content})
+```
+
+The template reads the fields as plain attributes:
+
+```html
+<section class="hero">
+    <h1>{{ content.hero_title }}</h1>
+    <p>{{ content.hero_subtitle }}</p>
+    <a href="{{ content.cta.url }}">{{ content.cta.label }}</a>
+</section>
+
+{% for section in content.sections %}
+<article>
+    <h2>{{ section.heading }}</h2>
+    <p>{{ section.body }}</p>
+</article>
+{% endfor %}
+```
+
+### 3. Edit in the admin
+
+Sign in as a user with the `modify-site` permission and open **Admin → Content**. Each registered area is listed; the editor renders an input for every field, nested fieldsets for groups, and add/remove rows for repeaters. Saving validates the values through your schema and stores them.
+
+That's the whole loop: **declare in code → edit in the admin → render in the template.**
+
+## Field Types
+
+All helpers live in `skrift.content`. Each accepts a `label` plus keyword options like `default`, `help_text`, and `placeholder`.
+
+| Helper | Widget | Notes |
+|--------|--------|-------|
+| `text(label, …)` | single-line input | |
+| `textarea(label, …, rows=6)` | multi-line input | |
+| `url(label, …)` | text input (`type=url`) | accepts absolute or site-relative links |
+| `email(label, …)` | text input (`type=email`) | |
+| `phone(label, …)` | text input (`type=tel`) | |
+| `number(label, …, default=0)` | numeric input | |
+| `select(label, choices=[…], …)` | dropdown | `choices` is a list of `(value, label)` tuples |
+| `boolean(label, …)` | checkbox | |
+| `group(Schema, label=…)` | nested fieldset | `Schema` is a `ContentModel` subclass |
+| `repeater(Schema, label=…, item_label=…)` | repeatable rows | `min_items` / `max_items` optional |
+
+```python
+from skrift.content import select, boolean, number
+
+class Pricing(ContentModel):
+    plan: str = select("Default plan",
+                       choices=[("free", "Free"), ("pro", "Pro")], default="free")
+    seats: int = number("Included seats", default=3)
+    show_banner: bool = boolean("Show announcement banner", default=False)
+```
+
+### Groups
+
+A group is a nested `ContentModel` — use it for fields that belong together, like a button:
+
+```python
+class CallToAction(ContentModel):
+    label: str = text("Button label", default="Get started")
+    url: str = url("Button link", default="/signup")
+
+class HomeContent(ContentArea, key="home"):
+    cta: CallToAction = group(CallToAction, label="Call to action")
+```
+
+In the template: `{{ content.cta.label }}`, `{{ content.cta.url }}`.
+
+### Repeaters
+
+A repeater is a list of a group schema. Editors can add and remove rows; rows preserve their order. Use `min_items` / `max_items` to bound the count.
+
+```python
+sections: list[HomeSection] = repeater(
+    HomeSection, label="Sections", item_label="Section", max_items=8
+)
+```
+
+In the template, iterate: `{% for section in content.sections %}…{% endfor %}`.
+
+!!! note "Single level"
+    Repeaters support one level of nesting (a list of groups). Deeply nested repeaters-within-repeaters are not rendered by the admin editor.
+
+## Binding and Keys
+
+A content area is identified by its `key`. Choose a stable, URL-safe key — it appears in the admin URL (`/admin/content/{key}/edit`) and is the storage key.
+
+You can register an area two ways:
+
+```python
+# Subclass form
+class HomeContent(ContentArea, key="home", label="Home Page"):
+    ...
+
+# Decorator form (for a plain ContentModel/BaseModel)
+from skrift.content import content_area
+
+@content_area("footer", label="Footer")
+class FooterContent(ContentModel):
+    blurb: str = textarea("Footer blurb", default="")
+```
+
+`label` and `description` are shown in the admin list; both default sensibly from the key.
+
+## Persistence and Hydration
+
+Values are stored in the `content_areas` table — one JSON document per key — via `skrift.db.services.content_service`:
+
+```python
+await content_service.get_content_data(db_session, "home")   # -> dict (or {} if unset)
+await content_service.save_content_data(db_session, "home", data)
+```
+
+`hydrate(schema, data)` validates a stored dict against the schema and returns a model instance:
+
+- **Missing fields** fall back to their declared defaults.
+- **Unknown stored keys are ignored**, so you can remove a field from a schema without breaking previously saved content.
+
+This makes schemas safe to evolve. When you add a field, existing content simply uses the new field's default until someone edits the area.
+
+## Public API
+
+```python
+from skrift.content import (
+    ContentArea, ContentModel, content_area,   # declare & register
+    text, textarea, url, email, phone, number, select, boolean,  # field helpers
+    group, repeater,                            # composites
+    get_content_area, list_content_areas,       # registry lookups
+    hydrate,                                     # validate stored data
+)
+```
+
+`ContentArea`, `ContentModel`, `content_area`, `get_content_area`, and `list_content_areas` are also re-exported from the top-level `skrift` package.
+
+## The built-in `home` area
+
+Skrift ships a `HomeContent` area (`skrift/content/builtin.py`) that the default landing template (`index.html`) renders — a hero title, subtitle, a CTA group, and repeatable sections. The built-in `WebController` hydrates it automatically. Override `index.html` in your theme or project to change the markup; the editable fields stay the same.
+
+See the **basic-site** demo (`demo/basic-site`) for a working example: log in with the Demo Login (check *is_admin*), edit **Admin → Content → Home Page**, and watch the landing page update.
+
+## Permissions
+
+The content admin is guarded by the `modify-site` permission — the same one used for site settings. Administrators have it by default.

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -74,6 +74,14 @@ Step-by-step guides for building and customizing your Skrift site.
 
     [:octicons-arrow-right-24: Forms](forms.md)
 
+-   :material-pencil-box-multiple:{ .lg .middle } **Content Fields**
+
+    ---
+
+    Declare editable fields in code and let non-developers edit them in the admin.
+
+    [:octicons-arrow-right-24: Content Fields](content-fields.md)
+
 -   :material-layers-triple:{ .lg .middle } **Custom Middleware**
 
     ---
@@ -167,6 +175,7 @@ Step-by-step guides for building and customizing your Skrift site.
 | [Hooks and Filters](hooks-and-filters.md) | Extensibility | Python basics |
 | [Custom Controllers](custom-controllers.md) | New routes | Python, async |
 | [Forms](forms.md) | Form handling | Python basics |
+| [Content Fields](content-fields.md) | Admin-editable page content | Python basics |
 | [Custom Middleware](custom-middleware.md) | Request processing | Python, ASGI |
 | [Protecting Routes](protecting-routes.md) | Security | Python basics |
 | [Observability](observability.md) | Tracing & logging | None |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -65,6 +65,7 @@ nav:
     - Custom Templates: guides/custom-templates.md
     - Custom Controllers: guides/custom-controllers.md
     - Forms: guides/forms.md
+    - Content Fields: guides/content-fields.md
     - Hooks and Filters: guides/hooks-and-filters.md
     - SEO Metadata: guides/seo-metadata.md
     - Custom Middleware: guides/custom-middleware.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "skrift"
-version = "0.2.0a8"
+version = "0.2.0a9"
 description = "A lightweight async Python CMS for crafting modern websites"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/skrift/__init__.py
+++ b/skrift/__init__.py
@@ -15,6 +15,13 @@ import importlib
 
 from skrift.auth.guards import Permission, Role, auth_guard
 from skrift.config import get_settings, register_config_section
+from skrift.content import (
+    ContentArea,
+    ContentModel,
+    content_area,
+    get_content_area,
+    list_content_areas,
+)
 from skrift.flash import (
     flash_error,
     flash_info,
@@ -104,6 +111,8 @@ __all__ = [
     "ApprovalRejection",
     "BlobRef",
     "Chat",
+    "ContentArea",
+    "ContentModel",
     "Form",
     "FormModel",
     "Job",
@@ -129,6 +138,7 @@ __all__ = [
     "auth_guard",
     "configure_webhooks",
     "configure_workers",
+    "content_area",
     "do_action",
     "enqueue_webhook",
     "enqueue_webhook_standalone",
@@ -138,10 +148,12 @@ __all__ = [
     "flash_success",
     "flash_warning",
     "form",
+    "get_content_area",
     "get_flash_messages",
     "get_handle",
     "get_runtime",
     "get_settings",
+    "list_content_areas",
     "handler",
     "hooks",
     "local_executor",

--- a/skrift/admin/content.py
+++ b/skrift/admin/content.py
@@ -1,0 +1,129 @@
+"""Admin controller for editing code-declared content areas."""
+
+from __future__ import annotations
+
+import logging
+from typing import Annotated
+
+from litestar import Controller, Request, get, post
+from litestar.enums import RequestEncodingType
+from litestar.params import Body
+from litestar.response import Redirect, Template as TemplateResponse
+from pydantic import ValidationError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from skrift.admin.helpers import get_admin_context
+from skrift.admin.navigation import ADMIN_NAV_TAG
+from skrift.auth.guards import Permission, auth_guard
+from skrift.content import (
+    build_nodes,
+    get_content_area,
+    hydrate,
+    list_content_areas,
+    parse_nested_form,
+)
+from skrift.db.services import content_service
+from skrift.flash import flash_error, flash_success, get_flash_messages
+
+logger = logging.getLogger(__name__)
+
+CONTENT_BASE = "/admin/content"
+
+
+class ContentAdminController(Controller):
+    """List content areas and edit their values."""
+
+    path = "/admin"
+    guards = [auth_guard]
+
+    @get(
+        "/content",
+        tags=[ADMIN_NAV_TAG],
+        guards=[auth_guard, Permission("modify-site")],
+        opt={"label": "Content", "icon": "layout", "order": 30},
+    )
+    async def list_content(
+        self, request: Request, db_session: AsyncSession
+    ) -> TemplateResponse:
+        ctx = await get_admin_context(request, db_session)
+        areas = [
+            {
+                "key": key,
+                "label": schema._content_label,
+                "description": schema._content_description,
+            }
+            for key, schema in sorted(
+                list_content_areas().items(),
+                key=lambda item: item[1]._content_label,
+            )
+        ]
+        flash_messages = get_flash_messages(request)
+        return TemplateResponse(
+            "admin/content/list.html",
+            context={"flash_messages": flash_messages, "areas": areas, **ctx},
+        )
+
+    @get(
+        "/content/{key:str}/edit",
+        guards=[auth_guard, Permission("modify-site")],
+    )
+    async def edit_content(
+        self, request: Request, db_session: AsyncSession, key: str
+    ) -> TemplateResponse | Redirect:
+        ctx = await get_admin_context(request, db_session)
+
+        try:
+            schema = get_content_area(key)
+        except LookupError:
+            flash_error(request, f"Unknown content area '{key}'")
+            return Redirect(path=CONTENT_BASE)
+
+        saved = await content_service.get_content_data(db_session, key)
+        try:
+            model = hydrate(schema, saved)
+        except ValidationError:
+            # Stored data predates a schema change; start from defaults.
+            model = schema()
+        nodes = build_nodes(schema, model.model_dump())
+
+        flash_messages = get_flash_messages(request)
+        return TemplateResponse(
+            "admin/content/edit.html",
+            context={
+                "flash_messages": flash_messages,
+                "content_key": key,
+                "content_label": schema._content_label,
+                "content_description": schema._content_description,
+                "nodes": nodes,
+                **ctx,
+            },
+        )
+
+    @post(
+        "/content/{key:str}/edit",
+        guards=[auth_guard, Permission("modify-site")],
+    )
+    async def save_content(
+        self,
+        request: Request,
+        db_session: AsyncSession,
+        key: str,
+        data: Annotated[dict, Body(media_type=RequestEncodingType.URL_ENCODED)],
+    ) -> Redirect:
+        try:
+            schema = get_content_area(key)
+        except LookupError:
+            flash_error(request, f"Unknown content area '{key}'")
+            return Redirect(path=CONTENT_BASE)
+
+        parsed = parse_nested_form(data)
+        try:
+            model = schema(**parsed)
+        except ValidationError as error:
+            logger.info("Content validation failed for %s: %s", key, error)
+            flash_error(request, "Some fields were invalid. Please review and try again.")
+            return Redirect(path=f"{CONTENT_BASE}/{key}/edit")
+
+        await content_service.save_content_data(db_session, key, model.model_dump(mode="json"))
+        flash_success(request, f"{schema._content_label} updated successfully")
+        return Redirect(path=CONTENT_BASE)

--- a/skrift/admin/controller.py
+++ b/skrift/admin/controller.py
@@ -14,6 +14,7 @@ from skrift.flash import get_flash_messages
 # Re-export split controllers for convenient registration
 from skrift.admin.users import UserAdminController  # noqa: F401
 from skrift.admin.settings import SettingsAdminController  # noqa: F401
+from skrift.admin.content import ContentAdminController  # noqa: F401
 from skrift.admin.media import MediaAdminController  # noqa: F401
 from skrift.admin.oauth2_clients import OAuth2ClientAdminController  # noqa: F401
 from skrift.admin.api_keys import APIKeyAdminController  # noqa: F401

--- a/skrift/alembic/versions/20260626_add_content_areas.py
+++ b/skrift/alembic/versions/20260626_add_content_areas.py
@@ -1,0 +1,35 @@
+"""Add content_areas table for code-declared editable content.
+
+Revision ID: b0c1d2e3f4a5
+Revises: f2a3b4c5d6e7
+Create Date: 2026-06-26
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from advanced_alchemy.types import DateTimeUTC, GUID
+
+
+revision = "b0c1d2e3f4a5"
+down_revision = "f2a3b4c5d6e7"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "content_areas",
+        sa.Column("id", GUID(length=16), nullable=False),
+        sa.Column("key", sa.String(length=255), nullable=False),
+        sa.Column("data", sa.JSON(), nullable=False),
+        sa.Column("created_at", DateTimeUTC(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.Column("updated_at", DateTimeUTC(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.Column("sa_orm_sentinel", sa.Integer(), nullable=True),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("ix_content_areas_key", "content_areas", ["key"], unique=True)
+
+
+def downgrade() -> None:
+    op.drop_index("ix_content_areas_key", table_name="content_areas")
+    op.drop_table("content_areas")

--- a/skrift/asgi.py
+++ b/skrift/asgi.py
@@ -167,6 +167,7 @@ def load_controllers() -> list:
             for sub_name in (
                 "UserAdminController",
                 "SettingsAdminController",
+                "ContentAdminController",
                 "MediaAdminController",
                 "OAuth2ClientAdminController",
                 "APIKeyAdminController",

--- a/skrift/content/__init__.py
+++ b/skrift/content/__init__.py
@@ -1,0 +1,59 @@
+"""Skrift content system — code-declared, admin-editable page fields.
+
+Declare a content schema with the field helpers and bind it to a key::
+
+    from skrift.content import ContentArea, text, textarea, group, repeater
+
+    class HomeContent(ContentArea, key="home"):
+        hero_title: str = text("Hero title", default="Welcome")
+        hero_copy: str = textarea("Hero copy")
+
+The values are edited under ``/admin/content`` and persisted per key, then
+hydrated back into templates as a validated model instance.
+"""
+
+from skrift.content.fields import (
+    boolean,
+    email,
+    group,
+    number,
+    phone,
+    repeater,
+    select,
+    text,
+    textarea,
+    url,
+)
+from skrift.content.parse import parse_nested_form
+from skrift.content.render import build_nodes, hydrate
+from skrift.content.schema import (
+    ContentArea,
+    ContentModel,
+    content_area,
+    get_content_area,
+    list_content_areas,
+)
+
+# Importing registers the built-in areas (e.g. the "home" landing page).
+from skrift.content import builtin  # noqa: E402,F401
+
+__all__ = [
+    "ContentArea",
+    "ContentModel",
+    "content_area",
+    "get_content_area",
+    "list_content_areas",
+    "build_nodes",
+    "hydrate",
+    "parse_nested_form",
+    "boolean",
+    "email",
+    "group",
+    "number",
+    "phone",
+    "repeater",
+    "select",
+    "text",
+    "textarea",
+    "url",
+]

--- a/skrift/content/builtin.py
+++ b/skrift/content/builtin.py
@@ -1,0 +1,46 @@
+"""Built-in content areas shipped with Skrift.
+
+``HomeContent`` powers the default landing page template (``index.html``).
+Importing this module registers the areas, so it is imported from
+:mod:`skrift.content` to guarantee they are always available to the admin and
+the public renderer.
+"""
+
+from __future__ import annotations
+
+from skrift.content.fields import group, repeater, text, textarea, url
+from skrift.content.schema import ContentArea, ContentModel
+
+
+class CallToAction(ContentModel):
+    """A button label paired with its destination link."""
+
+    label: str = text("Button label", default="Get started")
+    url: str = url("Button link", default="/auth/login", placeholder="/signup or https://…")
+
+
+class HomeSection(ContentModel):
+    """A heading-and-body block stacked below the hero."""
+
+    heading: str = text("Heading", default="")
+    body: str = textarea("Body", default="", rows=4)
+
+
+class HomeContent(
+    ContentArea,
+    key="home",
+    label="Home Page",
+    description="Hero and content sections shown on the site landing page.",
+):
+    """The editable content of the default landing page."""
+
+    hero_title: str = text("Hero title", default="Welcome to your new site")
+    hero_subtitle: str = textarea(
+        "Hero subtitle",
+        default="Publish content, manage pages, and make it your own.",
+        rows=3,
+    )
+    cta: CallToAction = group(CallToAction, label="Call to action")
+    sections: list[HomeSection] = repeater(
+        HomeSection, label="Sections", item_label="Section"
+    )

--- a/skrift/content/fields.py
+++ b/skrift/content/fields.py
@@ -1,0 +1,175 @@
+"""Field helpers for declaring editable content fields in code.
+
+Each helper returns a Pydantic field carrying widget metadata in
+``json_schema_extra``. The admin renderer reads that metadata to choose an
+input type, label, and validation hints, while Pydantic itself handles
+coercion and defaults. A page author declares a content schema like::
+
+    class HomeContent(ContentArea, key="home"):
+        hero_title: str = text("Hero title", default="Welcome")
+        hero_copy: str = textarea("Hero copy")
+        cta: CallToAction = group(CallToAction, label="Call to action")
+        sections: list[Section] = repeater(Section, label="Sections")
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+def _content_field(
+    widget: str,
+    label: str | None,
+    default: Any,
+    help_text: str | None,
+    placeholder: str | None,
+    extra: dict[str, Any] | None = None,
+) -> Any:
+    """Build a Pydantic field annotated with content widget metadata."""
+    schema_extra: dict[str, Any] = {"widget": widget}
+    if label is not None:
+        schema_extra["label"] = label
+    if help_text is not None:
+        schema_extra["help_text"] = help_text
+    if placeholder is not None:
+        schema_extra["placeholder"] = placeholder
+    if extra:
+        schema_extra.update(extra)
+    return Field(default=default, json_schema_extra=schema_extra)
+
+
+def text(
+    label: str | None = None,
+    *,
+    default: str = "",
+    help_text: str | None = None,
+    placeholder: str | None = None,
+) -> Any:
+    """A single-line text input."""
+    return _content_field("text", label, default, help_text, placeholder)
+
+
+def textarea(
+    label: str | None = None,
+    *,
+    default: str = "",
+    help_text: str | None = None,
+    placeholder: str | None = None,
+    rows: int = 6,
+) -> Any:
+    """A multi-line text area."""
+    return _content_field("textarea", label, default, help_text, placeholder, {"rows": rows})
+
+
+def url(
+    label: str | None = None,
+    *,
+    default: str = "",
+    help_text: str | None = None,
+    placeholder: str | None = None,
+) -> Any:
+    """A URL input. Accepts absolute or site-relative links."""
+    return _content_field("text", label, default, help_text, placeholder, {"input_type": "url"})
+
+
+def email(
+    label: str | None = None,
+    *,
+    default: str = "",
+    help_text: str | None = None,
+    placeholder: str | None = None,
+) -> Any:
+    """An email address input."""
+    return _content_field("text", label, default, help_text, placeholder, {"input_type": "email"})
+
+
+def phone(
+    label: str | None = None,
+    *,
+    default: str = "",
+    help_text: str | None = None,
+    placeholder: str | None = None,
+) -> Any:
+    """A telephone number input."""
+    return _content_field("text", label, default, help_text, placeholder, {"input_type": "tel"})
+
+
+def number(
+    label: str | None = None,
+    *,
+    default: int = 0,
+    help_text: str | None = None,
+    placeholder: str | None = None,
+) -> Any:
+    """A numeric input."""
+    return _content_field("number", label, default, help_text, placeholder, {"input_type": "number"})
+
+
+def select(
+    label: str | None = None,
+    *,
+    choices: list[tuple[str, str]],
+    default: str = "",
+    help_text: str | None = None,
+) -> Any:
+    """A dropdown of ``(value, label)`` choices."""
+    return _content_field("select", label, default, help_text, None, {"choices": choices})
+
+
+def boolean(
+    label: str | None = None,
+    *,
+    default: bool = False,
+    help_text: str | None = None,
+) -> Any:
+    """A checkbox toggle."""
+    return _content_field("checkbox", label, default, help_text, None)
+
+
+def group(
+    schema: type[BaseModel],
+    *,
+    label: str | None = None,
+    help_text: str | None = None,
+) -> Any:
+    """A nested group of fields, validated by ``schema``.
+
+    The field annotation supplies the type for Pydantic; ``schema`` is also
+    stored in the field metadata so the renderer can walk the nested fields
+    without re-deriving the type from the annotation.
+    """
+    return Field(
+        default_factory=schema,
+        json_schema_extra={
+            "widget": "group",
+            "label": label,
+            "help_text": help_text,
+            "schema": schema,
+        },
+    )
+
+
+def repeater(
+    schema: type[BaseModel],
+    *,
+    label: str | None = None,
+    help_text: str | None = None,
+    item_label: str = "Item",
+    min_items: int = 0,
+    max_items: int | None = None,
+) -> Any:
+    """A repeatable list of ``schema`` groups (add/remove rows in the admin)."""
+    return Field(
+        default_factory=list,
+        json_schema_extra={
+            "widget": "repeater",
+            "label": label,
+            "help_text": help_text,
+            "schema": schema,
+            "item_label": item_label,
+            "min_items": min_items,
+            "max_items": max_items,
+        },
+    )

--- a/skrift/content/parse.py
+++ b/skrift/content/parse.py
@@ -1,0 +1,52 @@
+"""Parse dotted form field names into nested data for content validation.
+
+The admin content form names inputs with dotted paths so nested groups and
+repeater rows round-trip through a flat URL-encoded body::
+
+    hero_title          -> {"hero_title": ...}
+    cta.label           -> {"cta": {"label": ...}}
+    sections.0.heading  -> {"sections": [{"heading": ...}]}
+
+Numeric path segments become list positions. Indices may be sparse (the admin
+deletes repeater rows without renumbering the survivors); they are sorted and
+compacted into a dense list, so order is preserved and gaps are dropped.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+
+def parse_nested_form(data: Mapping[str, Any]) -> dict[str, Any]:
+    """Build a nested dict/list structure from dotted form keys.
+
+    Keys beginning with ``_`` (e.g. the CSRF token) are ignored.
+    """
+    root: dict[str, Any] = {}
+    for raw_key, value in data.items():
+        if raw_key.startswith("_"):
+            continue
+        _assign(root, raw_key.split("."), value)
+    return _compact(root)
+
+
+def _assign(root: dict[str, Any], segments: list[str], value: Any) -> None:
+    """Place ``value`` into ``root`` following ``segments``, creating dicts."""
+    node = root
+    for segment in segments[:-1]:
+        child = node.get(segment)
+        if not isinstance(child, dict):
+            child = {}
+            node[segment] = child
+        node = child
+    node[segments[-1]] = value
+
+
+def _compact(node: Any) -> Any:
+    """Convert all-numeric-keyed dicts into index-ordered lists, recursively."""
+    if not isinstance(node, dict):
+        return node
+    if node and all(key.isdigit() for key in node):
+        return [_compact(node[key]) for key in sorted(node, key=int)]
+    return {key: _compact(value) for key, value in node.items()}

--- a/skrift/content/render.py
+++ b/skrift/content/render.py
@@ -1,0 +1,102 @@
+"""Turn a content schema plus saved values into a render tree for the admin.
+
+``build_nodes`` walks a schema's fields and emits plain dicts the admin edit
+template iterates over to render widgets. Repeater rows carry a blank
+``template_nodes`` row (named with an ``__INDEX__`` placeholder) that the
+client clones to add new entries.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel
+from pydantic_core import PydanticUndefined
+
+# Sentinel used in repeater item names; the admin's JS swaps it for a real
+# index when cloning a blank row.
+INDEX_PLACEHOLDER = "__INDEX__"
+
+
+def hydrate(schema: type[BaseModel], data: dict[str, Any] | None) -> BaseModel:
+    """Validate stored ``data`` against ``schema``, filling defaults.
+
+    Missing fields fall back to their declared defaults and unknown stored
+    keys are ignored, so a schema can evolve without invalidating old content.
+    """
+    return schema(**(data or {}))
+
+
+def build_nodes(
+    schema: type[BaseModel], data: dict[str, Any] | None, prefix: str = ""
+) -> list[dict[str, Any]]:
+    """Build render nodes for ``schema`` populated from ``data``.
+
+    ``data`` is expected to be a fully-defaulted dict (e.g. from
+    ``hydrate(...).model_dump()``); any missing scalar falls back to its
+    field default so blank repeater templates render cleanly.
+    """
+    values = data or {}
+    nodes: list[dict[str, Any]] = []
+
+    for name, info in schema.model_fields.items():
+        extra = info.json_schema_extra if isinstance(info.json_schema_extra, dict) else {}
+        widget = extra.get("widget", "text")
+        label = extra.get("label") or name.replace("_", " ").title()
+        help_text = extra.get("help_text")
+        full_name = f"{prefix}{name}"
+
+        if widget == "group":
+            nodes.append({
+                "kind": "group",
+                "label": label,
+                "help_text": help_text,
+                "children": build_nodes(
+                    extra["schema"], values.get(name) or {}, f"{full_name}."
+                ),
+            })
+            continue
+
+        if widget == "repeater":
+            item_schema = extra["schema"]
+            rows = [
+                build_nodes(item_schema, row or {}, f"{full_name}.{index}.")
+                for index, row in enumerate(values.get(name) or [])
+            ]
+            nodes.append({
+                "kind": "repeater",
+                "label": label,
+                "help_text": help_text,
+                "name": full_name,
+                "item_label": extra.get("item_label", "Item"),
+                "min_items": extra.get("min_items", 0),
+                "max_items": extra.get("max_items"),
+                "rows": rows,
+                "template_nodes": build_nodes(
+                    item_schema, {}, f"{full_name}.{INDEX_PLACEHOLDER}."
+                ),
+            })
+            continue
+
+        nodes.append({
+            "kind": "field",
+            "name": full_name,
+            "widget": widget,
+            "label": label,
+            "help_text": help_text,
+            "value": values.get(name, _default_value(info)),
+            "input_type": extra.get("input_type", "text"),
+            "placeholder": extra.get("placeholder", ""),
+            "rows": extra.get("rows", 6),
+            "choices": extra.get("choices", []),
+        })
+
+    return nodes
+
+
+def _default_value(info: Any) -> Any:
+    """Resolve a scalar field's default, or empty string if it has none."""
+    default = info.get_default(call_default_factory=True)
+    if default is PydanticUndefined or default is None:
+        return ""
+    return default

--- a/skrift/content/schema.py
+++ b/skrift/content/schema.py
@@ -1,0 +1,100 @@
+"""Content schema base classes and the content-area registry.
+
+A ``ContentArea`` is a Pydantic model whose fields are declared with the
+helpers in :mod:`skrift.content.fields`. Each registered area has a stable
+string ``key`` used to persist its values and to expose an edit screen in the
+admin. Groups and repeater items subclass :class:`ContentModel` (the same base
+without registration).
+"""
+
+from __future__ import annotations
+
+from typing import ClassVar
+
+from pydantic import BaseModel, ConfigDict
+
+_content_registry: dict[str, type["ContentArea"]] = {}
+
+
+def _humanize(key: str) -> str:
+    """Turn a key like ``home-page`` into a label like ``Home Page``."""
+    return key.replace("-", " ").replace("_", " ").title()
+
+
+class ContentModel(BaseModel):
+    """Base for content groups and repeater items.
+
+    Unknown stored keys are ignored so a schema can drop a field without
+    breaking previously saved content.
+    """
+
+    model_config = ConfigDict(extra="ignore")
+
+
+class ContentArea(ContentModel):
+    """A top-level, admin-editable content schema bound to a ``key``.
+
+    Usage::
+
+        class HomeContent(ContentArea, key="home", label="Home Page"):
+            hero_title: str = text("Hero title", default="Welcome")
+
+    Subclasses that omit ``key`` are treated as intermediate bases and are not
+    registered (useful for sharing fields between areas).
+    """
+
+    _content_key: ClassVar[str]
+    _content_label: ClassVar[str]
+    _content_description: ClassVar[str]
+
+    def __init_subclass__(
+        cls,
+        key: str | None = None,
+        label: str | None = None,
+        description: str = "",
+        **kwargs,
+    ):
+        super().__init_subclass__(**kwargs)
+
+        if key is None:
+            return
+
+        cls._content_key = key
+        cls._content_label = label or _humanize(key)
+        cls._content_description = description
+        _content_registry[key] = cls
+
+
+def content_area(
+    key: str, *, label: str | None = None, description: str = ""
+):
+    """Register a plain :class:`ContentModel`/``BaseModel`` as a content area.
+
+    Decorator alternative to subclassing ``ContentArea`` with ``key=``.
+    """
+
+    def decorator(cls: type[ContentModel]) -> type[ContentModel]:
+        cls._content_key = key
+        cls._content_label = label or _humanize(key)
+        cls._content_description = description
+        _content_registry[key] = cls
+        return cls
+
+    return decorator
+
+
+def get_content_area(key: str) -> type[ContentArea]:
+    """Look up a registered content area by key. Raises ``LookupError`` if absent."""
+    try:
+        return _content_registry[key]
+    except KeyError:
+        available = ", ".join(sorted(_content_registry)) or "(none)"
+        raise LookupError(f"No content area named '{key}'. Registered: {available}")
+
+
+def list_content_areas() -> dict[str, type[ContentArea]]:
+    """All registered content areas by key.
+
+    An area only appears once the module that declares it has been imported.
+    """
+    return dict(_content_registry)

--- a/skrift/controllers/web.py
+++ b/skrift/controllers/web.py
@@ -6,12 +6,13 @@ from litestar.response import Response, Template as TemplateResponse
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from skrift.auth.session_keys import SESSION_USER_ID
+from skrift.content import get_content_area, hydrate
 from skrift.controllers.helpers import get_user_context
 from skrift.controllers.page_rendering import (
     build_public_page_render_context,
     wants_markdown_response,
 )
-from skrift.db.services import page_service
+from skrift.db.services import content_service, page_service
 from skrift.template import Template
 
 TEMPLATE_DIR = Path(__file__).parent.parent.parent / "templates"
@@ -24,13 +25,21 @@ class WebController(Controller):
     async def index(
         self, request: "Request", db_session: AsyncSession
     ) -> TemplateResponse:
-        """Home page."""
+        """Home page rendered from the admin-editable ``home`` content area."""
         user_ctx = await get_user_context(request, db_session)
         flash = request.session.pop("flash", None)
 
+        schema = get_content_area("home")
+        saved = await content_service.get_content_data(db_session, "home")
+        try:
+            content = hydrate(schema, saved)
+        except Exception:
+            # Never let stale content break the landing page; fall back to defaults.
+            content = schema()
+
         return TemplateResponse(
             "index.html",
-            context={"flash": flash, **user_ctx},
+            context={"flash": flash, "content": content, **user_ctx},
         )
 
     @get("/{path:path}")

--- a/skrift/db/models/__init__.py
+++ b/skrift/db/models/__init__.py
@@ -1,5 +1,6 @@
 from skrift.db.models.api_key import APIKey
 from skrift.db.models.asset import Asset
+from skrift.db.models.content_area import ContentAreaRecord
 from skrift.db.models.notification import DismissedNotification, StoredNotification
 from skrift.db.models.oauth2_client import OAuth2Client
 from skrift.db.models.oauth_account import OAuthAccount
@@ -28,6 +29,7 @@ from skrift.db.models.worker import (
 __all__ = [
     "APIKey",
     "Asset",
+    "ContentAreaRecord",
     "DismissedNotification",
     "OAuth2Client",
     "OAuthAccount",

--- a/skrift/db/models/content_area.py
+++ b/skrift/db/models/content_area.py
@@ -1,0 +1,17 @@
+from sqlalchemy import JSON, String
+from sqlalchemy.orm import Mapped, mapped_column
+
+from skrift.db.base import Base
+
+
+class ContentAreaRecord(Base):
+    """Stored values for a code-declared content area, keyed by its schema key.
+
+    The schema (fields, labels, widgets) lives in code; this table holds only
+    the editor-supplied values as a JSON document validated on save.
+    """
+
+    __tablename__ = "content_areas"
+
+    key: Mapped[str] = mapped_column(String(255), nullable=False, unique=True, index=True)
+    data: Mapped[dict] = mapped_column(JSON, nullable=False, default=dict)

--- a/skrift/db/services/content_service.py
+++ b/skrift/db/services/content_service.py
@@ -1,0 +1,39 @@
+"""Service for persisting code-declared content area values."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from skrift.db.models import ContentAreaRecord
+
+
+async def get_content_data(db_session: AsyncSession, key: str) -> dict[str, Any]:
+    """Return the stored values for a content area, or an empty dict if unset."""
+    result = await db_session.execute(
+        select(ContentAreaRecord).where(ContentAreaRecord.key == key)
+    )
+    record = result.scalar_one_or_none()
+    return record.data if record and record.data else {}
+
+
+async def save_content_data(
+    db_session: AsyncSession, key: str, data: dict[str, Any]
+) -> ContentAreaRecord:
+    """Create or update the stored values for a content area."""
+    result = await db_session.execute(
+        select(ContentAreaRecord).where(ContentAreaRecord.key == key)
+    )
+    record = result.scalar_one_or_none()
+
+    if record is None:
+        record = ContentAreaRecord(key=key, data=data)
+        db_session.add(record)
+    else:
+        record.data = data
+
+    await db_session.commit()
+    await db_session.refresh(record)
+    return record

--- a/skrift/templates/admin/content/_fields.html
+++ b/skrift/templates/admin/content/_fields.html
@@ -1,0 +1,65 @@
+{# Recursive renderers for content-area field nodes. Imported by edit.html. #}
+
+{% macro render_field(node) %}
+<label>
+    {{ node.label }}
+    {% if node.widget == "textarea" %}
+    <textarea name="{{ node.name }}" rows="{{ node.rows }}"{% if node.placeholder %} placeholder="{{ node.placeholder }}"{% endif %}>{{ node.value }}</textarea>
+    {% elif node.widget == "select" %}
+    <select name="{{ node.name }}">
+        {% for value, display in node.choices %}
+        <option value="{{ value }}"{% if value == node.value %} selected{% endif %}>{{ display }}</option>
+        {% endfor %}
+    </select>
+    {% elif node.widget == "checkbox" %}
+    <input type="checkbox" name="{{ node.name }}" value="true"{% if node.value %} checked{% endif %}>
+    {% else %}
+    <input type="{{ node.input_type }}" name="{{ node.name }}" value="{{ node.value }}"{% if node.placeholder %} placeholder="{{ node.placeholder }}"{% endif %}>
+    {% endif %}
+</label>
+{% if node.help_text %}<small class="sk-text-muted sk-field-help">{{ node.help_text }}</small>{% endif %}
+{% endmacro %}
+
+{% macro render_nodes(nodes) %}
+{% for node in nodes %}
+    {% if node.kind == "field" %}
+    {{ render_field(node) }}
+    {% elif node.kind == "group" %}
+    <fieldset class="sk-content-group">
+        <legend>{{ node.label }}</legend>
+        {% if node.help_text %}<small class="sk-text-muted sk-field-help">{{ node.help_text }}</small>{% endif %}
+        {{ render_nodes(node.children) }}
+    </fieldset>
+    {% elif node.kind == "repeater" %}
+    {{ render_repeater(node) }}
+    {% endif %}
+{% endfor %}
+{% endmacro %}
+
+{% macro render_repeater(node) %}
+<fieldset class="sk-repeater" data-repeater="{{ node.name }}"{% if node.max_items is not none %} data-max="{{ node.max_items }}"{% endif %}>
+    <legend>{{ node.label }}</legend>
+    {% if node.help_text %}<small class="sk-text-muted sk-field-help">{{ node.help_text }}</small>{% endif %}
+    <div class="sk-repeater-rows" data-rows>
+        {% for row in node.rows %}
+        <div class="sk-repeater-row" data-row>
+            <div class="sk-repeater-row-header">
+                <span class="sk-repeater-row-label">{{ node.item_label }}</span>
+                <button type="button" class="sk-btn-outline sk-btn-small sk-btn-danger" data-remove>Remove</button>
+            </div>
+            {{ render_nodes(row) }}
+        </div>
+        {% endfor %}
+    </div>
+    <template data-template>
+        <div class="sk-repeater-row" data-row>
+            <div class="sk-repeater-row-header">
+                <span class="sk-repeater-row-label">{{ node.item_label }}</span>
+                <button type="button" class="sk-btn-outline sk-btn-small sk-btn-danger" data-remove>Remove</button>
+            </div>
+            {{ render_nodes(node.template_nodes) }}
+        </div>
+    </template>
+    <button type="button" class="sk-btn-outline sk-btn-small" data-add>Add {{ node.item_label }}</button>
+</fieldset>
+{% endmacro %}

--- a/skrift/templates/admin/content/edit.html
+++ b/skrift/templates/admin/content/edit.html
@@ -1,0 +1,95 @@
+{% extends "admin/base.html" %}
+
+{% block title %}Edit {{ content_label }} - Admin - {{ site_name() }}{% endblock %}
+
+{% block head %}
+<style nonce="{{ csp_nonce() }}">
+    .sk-content-group, .sk-repeater {
+        border: 1px solid var(--sk-color-border);
+        border-radius: var(--sk-radius-lg);
+        padding: var(--sk-space-md);
+        margin: var(--sk-space-md) 0;
+    }
+    .sk-content-group > legend, .sk-repeater > legend {
+        font-weight: 600;
+        padding: 0 var(--sk-space-xs);
+    }
+    .sk-repeater-row {
+        border: 1px solid var(--sk-color-border);
+        border-radius: var(--sk-radius-md);
+        padding: var(--sk-space-md);
+        margin: var(--sk-space-sm) 0;
+        background: var(--sk-color-surface);
+    }
+    .sk-repeater-row-header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        margin-bottom: var(--sk-space-sm);
+    }
+    .sk-repeater-row-label {
+        font-size: .8rem;
+        font-weight: 600;
+        color: var(--sk-color-muted);
+        text-transform: uppercase;
+        letter-spacing: .04em;
+    }
+    .sk-field-help { display: block; margin-top: -0.25rem; }
+</style>
+{% endblock %}
+
+{% import "admin/content/_fields.html" as fields %}
+
+{% block admin_content %}
+<hgroup>
+    <h1>{{ content_label }}</h1>
+    {% if content_description %}<p>{{ content_description }}</p>{% endif %}
+</hgroup>
+
+<form method="post" action="/admin/content/{{ content_key }}/edit">
+    {{ csrf_field() }}
+    {{ fields.render_nodes(nodes) }}
+
+    <div class="sk-form-actions">
+        <button type="submit">Save</button>
+        <a href="/admin/content" role="button" class="sk-btn-outline">Cancel</a>
+    </div>
+</form>
+{% endblock %}
+
+{% block scripts %}
+<script nonce="{{ csp_nonce() }}">
+(function() {
+    document.querySelectorAll("[data-repeater]").forEach(function(rep) {
+        const rows = rep.querySelector("[data-rows]");
+        const tmpl = rep.querySelector("[data-template]");
+        const addBtn = rep.querySelector("[data-add]");
+        const max = rep.dataset.max ? parseInt(rep.dataset.max, 10) : null;
+        let nextIndex = rows.querySelectorAll("[data-row]").length;
+
+        function refreshAdd() {
+            if (max === null) return;
+            const count = rows.querySelectorAll("[data-row]").length;
+            addBtn.style.display = count >= max ? "none" : "";
+        }
+
+        addBtn.addEventListener("click", function() {
+            const html = tmpl.innerHTML.replaceAll("__INDEX__", String(nextIndex++));
+            const holder = document.createElement("div");
+            holder.innerHTML = html.trim();
+            rows.appendChild(holder.firstElementChild);
+            refreshAdd();
+        });
+
+        rows.addEventListener("click", function(event) {
+            const btn = event.target.closest("[data-remove]");
+            if (!btn) return;
+            btn.closest("[data-row]").remove();
+            refreshAdd();
+        });
+
+        refreshAdd();
+    });
+})();
+</script>
+{% endblock %}

--- a/skrift/templates/admin/content/list.html
+++ b/skrift/templates/admin/content/list.html
@@ -1,0 +1,37 @@
+{% extends "admin/base.html" %}
+
+{% block title %}Content - Admin - {{ site_name() }}{% endblock %}
+
+{% block admin_content %}
+<div class="sk-admin-header">
+    <hgroup>
+        <h1>Content</h1>
+        <p>Edit the content areas declared by your templates</p>
+    </hgroup>
+</div>
+
+<table class="sk-admin-table">
+    <thead>
+        <tr>
+            <th>Area</th>
+            <th>Description</th>
+            <th>Actions</th>
+        </tr>
+    </thead>
+    <tbody>
+        {% for area in areas %}
+        <tr>
+            <td><a href="/admin/content/{{ area.key }}/edit">{{ area.label }}</a></td>
+            <td class="sk-text-muted">{{ area.description }}</td>
+            <td class="sk-actions-cell">
+                <a href="/admin/content/{{ area.key }}/edit" role="button" class="sk-btn-outline sk-btn-small">Edit</a>
+            </td>
+        </tr>
+        {% endfor %}
+    </tbody>
+</table>
+
+{% if not areas %}
+<p class="sk-no-items">No content areas are registered.</p>
+{% endif %}
+{% endblock %}

--- a/skrift/templates/index.html
+++ b/skrift/templates/index.html
@@ -1,113 +1,83 @@
 {% extends "base.html" %}
 
-{% block title %}Home - {{ site_name() }}{% endblock %}
+{% block title %}{{ site_name() }}{% endblock %}
 
 {% block head %}
 <style>
-    .user-card {
-        max-width: 640px;
-        margin: 2rem auto;
-        padding: 1.75rem 2rem;
+    .sk-hero {
+        max-width: 760px;
+        margin: 4rem auto 2rem;
+        text-align: center;
+    }
+    .sk-hero h1 {
+        font-size: clamp(2rem, 5vw, 3.25rem);
+        line-height: 1.1;
+        margin: 0 0 1rem;
+    }
+    .sk-hero p {
+        font-size: 1.15rem;
+        color: var(--sk-color-text-secondary, rgba(255, 255, 255, 0.7));
+        margin: 0 auto 1.75rem;
+        max-width: 38rem;
+    }
+    .sk-hero .sk-cta {
+        display: inline-block;
+        padding: 0.75rem 1.75rem;
+        border-radius: 999px;
+        background: var(--sk-color-accent, #34D399);
+        color: #06251a;
+        font-weight: 600;
+        text-decoration: none;
+    }
+    .sk-sections {
+        max-width: 960px;
+        margin: 2rem auto 4rem;
+        display: grid;
+        gap: 1.5rem;
+        grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+        padding: 0 1rem;
+    }
+    .sk-section-card {
+        padding: 1.5rem 1.75rem;
         border-radius: 1rem;
         border: 1px solid var(--sk-color-border, rgba(255, 255, 255, 0.08));
         background: var(--sk-color-surface, rgba(255, 255, 255, 0.04));
-        box-shadow: 0 20px 48px rgba(0, 0, 0, 0.35);
     }
-
-    .user-card h2 {
-        margin: 0 0 1rem;
+    .sk-section-card h2 {
+        margin: 0 0 0.5rem;
+        font-size: 1.25rem;
     }
-
-    .user-card dl {
-        display: grid;
-        grid-template-columns: max-content 1fr;
-        gap: 0.5rem 1.25rem;
+    .sk-section-card p {
         margin: 0;
-    }
-
-    .user-card dt {
-        color: var(--sk-color-text-secondary, rgba(255, 255, 255, 0.6));
-        font-weight: 600;
-    }
-
-    .user-card dd {
-        margin: 0;
-        font-family: var(--sk-font-mono, ui-monospace, monospace);
-        word-break: break-all;
-    }
-
-    .user-card dd.placeholder {
-        font-family: inherit;
-        color: var(--sk-color-muted, rgba(255, 255, 255, 0.4));
-        font-style: italic;
-    }
-
-    .user-card .user-avatar {
-        width: 56px;
-        height: 56px;
-        border-radius: 999px;
-        object-fit: cover;
-        margin-bottom: 1rem;
-    }
-
-    .user-card .tag {
-        display: inline-block;
-        padding: 0.15rem 0.55rem;
-        margin: 0 0.35rem 0.35rem 0;
-        border-radius: 999px;
-        background: var(--sk-color-accent-soft, rgba(52, 211, 153, 0.12));
-        color: var(--sk-color-accent, #34D399);
-        font-size: 0.82rem;
-        font-family: inherit;
+        color: var(--sk-color-text-secondary, rgba(255, 255, 255, 0.7));
+        white-space: pre-line;
     }
 </style>
 {% endblock %}
 
 {% block content %}
+{% if content %}
+<section class="sk-hero">
+    <h1>{{ content.hero_title }}</h1>
+    {% if content.hero_subtitle %}<p>{{ content.hero_subtitle }}</p>{% endif %}
+    {% if content.cta.label %}
+    <a class="sk-cta" href="{{ content.cta.url }}">{{ content.cta.label }}</a>
+    {% endif %}
+</section>
+
+{% if content.sections %}
+<div class="sk-sections">
+    {% for section in content.sections %}
+    <article class="sk-section-card">
+        {% if section.heading %}<h2>{{ section.heading }}</h2>{% endif %}
+        {% if section.body %}<p>{{ section.body }}</p>{% endif %}
+    </article>
+    {% endfor %}
+</div>
+{% endif %}
+{% else %}
 <hgroup>
     <h1>{{ site_tagline() }}</h1>
 </hgroup>
-
-{% if user %}
-<section class="user-card" aria-labelledby="user-heading">
-    <h2 id="user-heading">Signed in</h2>
-    {% if user.picture_url %}
-    <img src="{{ user.picture_url }}" alt="" class="user-avatar">
-    {% endif %}
-    <dl>
-        <dt>User ID</dt>
-        <dd>{{ user.id }}</dd>
-
-        <dt>Email</dt>
-        {% if user.email %}<dd>{{ user.email }}</dd>{% else %}<dd class="placeholder">not set</dd>{% endif %}
-
-        <dt>Name</dt>
-        {% if user.name %}<dd>{{ user.name }}</dd>{% else %}<dd class="placeholder">not set</dd>{% endif %}
-
-        <dt>Active</dt>
-        <dd>{{ "yes" if user.is_active else "no" }}</dd>
-
-        <dt>Last login</dt>
-        {% if user.last_login_at %}<dd>{{ user.last_login_at.strftime("%Y-%m-%d %H:%M:%S %Z") }}</dd>{% else %}<dd class="placeholder">never</dd>{% endif %}
-
-        <dt>Roles</dt>
-        <dd>
-            {% if user.roles %}
-                {% for role in user.roles %}<span class="tag">{{ role.name }}</span>{% endfor %}
-            {% else %}
-                <span class="placeholder">none</span>
-            {% endif %}
-        </dd>
-
-        <dt>Passkeys</dt>
-        <dd>
-            {% if user.second_factor_enrollments %}
-                {% for enrollment in user.second_factor_enrollments %}<span class="tag">{{ (enrollment.display_name or enrollment.factor_key) | e }}</span>{% endfor %}
-            {% else %}
-                <span class="placeholder">none enrolled</span>
-            {% endif %}
-        </dd>
-    </dl>
-</section>
 {% endif %}
 {% endblock %}

--- a/tests/test_content_admin.py
+++ b/tests/test_content_admin.py
@@ -1,0 +1,107 @@
+"""Tests for the content admin controller: registration and the save path."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+import pytest_asyncio
+from litestar.response import Redirect
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+from skrift.admin.content import ContentAdminController
+from skrift.db.base import Base
+from skrift.db.models import ContentAreaRecord  # noqa: F401  (registers table)
+from skrift.db.services import content_service
+
+
+def _raw_fn(handler):
+    """Return the underlying async function behind a Litestar route handler."""
+    return getattr(handler, "fn", handler)
+
+
+@pytest_asyncio.fixture
+async def db_session():
+    engine = create_async_engine("sqlite+aiosqlite://")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    maker = async_sessionmaker(engine, expire_on_commit=False)
+    async with maker() as session:
+        yield session
+    await engine.dispose()
+
+
+class TestRegistration:
+    def test_admin_config_expands_to_include_content_controller(self, mock_config_path):
+        from skrift.asgi import load_controllers
+
+        _patched, patcher = mock_config_path(
+            {"controllers": ["skrift.admin.controller:AdminController"]}
+        )
+        try:
+            controllers = load_controllers()
+        finally:
+            patcher.stop()
+
+        assert ContentAdminController in controllers
+
+    def test_content_routes_are_registered(self):
+        # The handler decorators register the list, edit, and save routes.
+        all_paths = set()
+        for handler in (
+            ContentAdminController.list_content,
+            ContentAdminController.edit_content,
+            ContentAdminController.save_content,
+        ):
+            all_paths.update(handler.paths)
+        assert "/content" in all_paths
+        assert "/content/{key:str}/edit" in all_paths
+
+
+class TestSaveHandler:
+    @pytest.mark.asyncio
+    async def test_save_persists_nested_form_and_redirects(self, db_session):
+        request = SimpleNamespace(session={})
+        form = {
+            "_csrf": "token",
+            "hero_title": "Launch day",
+            "hero_subtitle": "Async to the core.",
+            "cta.label": "Sign up",
+            "cta.url": "/signup",
+            "sections.0.heading": "Fast",
+            "sections.0.body": "Very",
+            "sections.1.heading": "Open",
+            "sections.1.body": "Yes",
+        }
+
+        result = await _raw_fn(ContentAdminController.save_content)(
+            ContentAdminController(owner=None),
+            request=request,
+            db_session=db_session,
+            key="home",
+            data=form,
+        )
+
+        assert isinstance(result, Redirect)
+        assert result.url == "/admin/content"
+
+        stored = await content_service.get_content_data(db_session, "home")
+        assert stored["hero_title"] == "Launch day"
+        assert stored["cta"] == {"label": "Sign up", "url": "/signup"}
+        assert [s["heading"] for s in stored["sections"]] == ["Fast", "Open"]
+
+    @pytest.mark.asyncio
+    async def test_save_unknown_key_redirects_without_persisting(self, db_session):
+        request = SimpleNamespace(session={})
+
+        result = await _raw_fn(ContentAdminController.save_content)(
+            ContentAdminController(owner=None),
+            request=request,
+            db_session=db_session,
+            key="not-a-real-area",
+            data={"x": "1"},
+        )
+
+        assert isinstance(result, Redirect)
+        assert result.url == "/admin/content"
+        assert request.session.get("flash_messages")

--- a/tests/test_content_service.py
+++ b/tests/test_content_service.py
@@ -1,0 +1,62 @@
+"""Integration tests for content persistence against a real SQLite database."""
+
+from __future__ import annotations
+
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+from skrift.content import hydrate
+from skrift.content.builtin import HomeContent
+from skrift.db.base import Base
+from skrift.db.models import ContentAreaRecord  # noqa: F401  (registers table)
+from skrift.db.services import content_service
+
+
+@pytest_asyncio.fixture
+async def db_session():
+    engine = create_async_engine("sqlite+aiosqlite://")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    maker = async_sessionmaker(engine, expire_on_commit=False)
+    async with maker() as session:
+        yield session
+    await engine.dispose()
+
+
+class TestContentService:
+    @pytest.mark.asyncio
+    async def test_missing_key_returns_empty_dict(self, db_session):
+        assert await content_service.get_content_data(db_session, "home") == {}
+
+    @pytest.mark.asyncio
+    async def test_save_then_get_roundtrip(self, db_session):
+        await content_service.save_content_data(
+            db_session, "home", {"hero_title": "Hello"}
+        )
+        stored = await content_service.get_content_data(db_session, "home")
+        assert stored == {"hero_title": "Hello"}
+
+    @pytest.mark.asyncio
+    async def test_save_updates_existing_record(self, db_session):
+        await content_service.save_content_data(db_session, "home", {"hero_title": "One"})
+        await content_service.save_content_data(db_session, "home", {"hero_title": "Two"})
+        stored = await content_service.get_content_data(db_session, "home")
+        assert stored == {"hero_title": "Two"}
+
+    @pytest.mark.asyncio
+    async def test_full_home_content_roundtrips_through_schema(self, db_session):
+        model = HomeContent(
+            hero_title="Launch day",
+            cta={"label": "Sign up", "url": "/signup"},
+            sections=[{"heading": "Fast", "body": "Async to the core."}],
+        )
+        await content_service.save_content_data(
+            db_session, "home", model.model_dump(mode="json")
+        )
+
+        stored = await content_service.get_content_data(db_session, "home")
+        restored = hydrate(HomeContent, stored)
+        assert restored.hero_title == "Launch day"
+        assert restored.cta.label == "Sign up"
+        assert restored.sections[0].heading == "Fast"

--- a/tests/test_content_system.py
+++ b/tests/test_content_system.py
@@ -1,0 +1,163 @@
+"""Tests for the code-declared content field system."""
+
+from __future__ import annotations
+
+import pytest
+
+from skrift.content import (
+    ContentArea,
+    ContentModel,
+    build_nodes,
+    get_content_area,
+    group,
+    hydrate,
+    list_content_areas,
+    parse_nested_form,
+    repeater,
+    select,
+    text,
+    textarea,
+)
+
+
+class CTA(ContentModel):
+    label: str = text("Button label", default="Go")
+    url: str = text("Button link", default="/")
+
+
+class Section(ContentModel):
+    heading: str = text("Heading", default="")
+    body: str = textarea("Body", default="")
+
+
+class SampleHome(ContentArea, key="test-home", label="Test Home"):
+    hero_title: str = text("Hero title", default="Welcome")
+    plan: str = select(
+        "Plan", choices=[("free", "Free"), ("pro", "Pro")], default="free"
+    )
+    cta: CTA = group(CTA, label="Call to action")
+    sections: list[Section] = repeater(Section, label="Sections")
+
+
+class TestRegistry:
+    def test_area_is_registered_by_key(self):
+        assert get_content_area("test-home") is SampleHome
+        assert "test-home" in list_content_areas()
+
+    def test_label_and_description_metadata(self):
+        assert SampleHome._content_label == "Test Home"
+        assert get_content_area("test-home")._content_key == "test-home"
+
+    def test_unknown_key_raises(self):
+        with pytest.raises(LookupError):
+            get_content_area("does-not-exist")
+
+
+class TestHydrate:
+    def test_empty_data_fills_defaults(self):
+        model = hydrate(SampleHome, {})
+        assert model.hero_title == "Welcome"
+        assert model.cta.label == "Go"
+        assert model.sections == []
+
+    def test_partial_data_merges_with_defaults(self):
+        model = hydrate(SampleHome, {"hero_title": "Hi", "cta": {"label": "Join"}})
+        assert model.hero_title == "Hi"
+        assert model.cta.label == "Join"
+        assert model.cta.url == "/"
+
+    def test_unknown_keys_are_ignored(self):
+        model = hydrate(SampleHome, {"removed_field": "x", "hero_title": "Kept"})
+        assert model.hero_title == "Kept"
+        assert not hasattr(model, "removed_field")
+
+    def test_repeater_rows_validate(self):
+        model = hydrate(
+            SampleHome,
+            {"sections": [{"heading": "A", "body": "b"}, {"heading": "C"}]},
+        )
+        assert [s.heading for s in model.sections] == ["A", "C"]
+        assert model.sections[1].body == ""
+
+
+class TestParseNestedForm:
+    def test_flat_fields(self):
+        assert parse_nested_form({"hero_title": "Hi"}) == {"hero_title": "Hi"}
+
+    def test_skips_underscore_keys(self):
+        assert parse_nested_form({"_csrf": "tok", "a": "1"}) == {"a": "1"}
+
+    def test_nested_group(self):
+        parsed = parse_nested_form({"cta.label": "Join", "cta.url": "/x"})
+        assert parsed == {"cta": {"label": "Join", "url": "/x"}}
+
+    def test_repeater_indices_become_list(self):
+        parsed = parse_nested_form({
+            "sections.0.heading": "A",
+            "sections.0.body": "a",
+            "sections.1.heading": "B",
+            "sections.1.body": "b",
+        })
+        assert parsed == {
+            "sections": [
+                {"heading": "A", "body": "a"},
+                {"heading": "B", "body": "b"},
+            ]
+        }
+
+    def test_sparse_indices_are_compacted_in_order(self):
+        # Rows 0 and 1 deleted in the admin; survivors keep their order.
+        parsed = parse_nested_form({
+            "sections.2.heading": "Third",
+            "sections.5.heading": "Sixth",
+        })
+        assert parsed == {"sections": [{"heading": "Third"}, {"heading": "Sixth"}]}
+
+    def test_roundtrip_through_schema(self):
+        form = {
+            "_csrf": "tok",
+            "hero_title": "Launch",
+            "plan": "pro",
+            "cta.label": "Buy",
+            "cta.url": "/buy",
+            "sections.0.heading": "Why",
+            "sections.0.body": "Because",
+        }
+        model = hydrate(SampleHome, parse_nested_form(form))
+        assert model.hero_title == "Launch"
+        assert model.plan == "pro"
+        assert model.cta.label == "Buy"
+        assert model.sections[0].heading == "Why"
+
+
+class TestBuildNodes:
+    def test_scalar_node_carries_widget_and_value(self):
+        nodes = build_nodes(SampleHome, hydrate(SampleHome, {}).model_dump())
+        title = next(n for n in nodes if n.get("name") == "hero_title")
+        assert title["kind"] == "field"
+        assert title["widget"] == "text"
+        assert title["value"] == "Welcome"
+        assert title["label"] == "Hero title"
+
+    def test_select_node_includes_choices(self):
+        nodes = build_nodes(SampleHome, hydrate(SampleHome, {}).model_dump())
+        plan = next(n for n in nodes if n.get("name") == "plan")
+        assert plan["widget"] == "select"
+        assert ("pro", "Pro") in plan["choices"]
+
+    def test_group_children_are_namespaced(self):
+        nodes = build_nodes(SampleHome, hydrate(SampleHome, {}).model_dump())
+        cta = next(n for n in nodes if n["kind"] == "group")
+        child_names = [c["name"] for c in cta["children"]]
+        assert "cta.label" in child_names
+        assert "cta.url" in child_names
+
+    def test_repeater_rows_and_template(self):
+        data = hydrate(SampleHome, {"sections": [{"heading": "A"}]}).model_dump()
+        nodes = build_nodes(SampleHome, data)
+        rep = next(n for n in nodes if n["kind"] == "repeater")
+        assert rep["name"] == "sections"
+        # one populated row, namespaced by index
+        assert rep["rows"][0][0]["name"] == "sections.0.heading"
+        # blank template row carries the index placeholder for client cloning
+        assert rep["template_nodes"][0]["name"] == "sections.__INDEX__.heading"

--- a/tests/test_content_templates.py
+++ b/tests/test_content_templates.py
@@ -1,0 +1,58 @@
+"""Render the real content templates to catch macro and markup regressions."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from jinja2 import Environment, FileSystemLoader
+
+from skrift.content import build_nodes, hydrate
+from skrift.content.builtin import HomeContent
+
+TEMPLATES = Path(__file__).resolve().parent.parent / "skrift" / "templates"
+
+
+@pytest.fixture
+def env():
+    return Environment(loader=FileSystemLoader([str(TEMPLATES)]), autoescape=True)
+
+
+def test_templates_compile(env):
+    # Parsing exercises all Jinja syntax in the templates.
+    env.get_template("admin/content/edit.html")
+    env.get_template("index.html")
+
+
+def test_render_nodes_emits_namespaced_widgets(env):
+    data = hydrate(HomeContent, {"sections": [{"heading": "Why us"}]}).model_dump()
+    nodes = build_nodes(HomeContent, data)
+
+    rendered = env.from_string(
+        "{% from 'admin/content/_fields.html' import render_nodes %}{{ render_nodes(nodes) }}"
+    ).render(nodes=nodes)
+
+    # Scalar + group fields are namespaced with dotted paths.
+    assert 'name="hero_title"' in rendered
+    assert "<textarea" in rendered  # hero_subtitle
+    assert 'name="cta.label"' in rendered
+    assert 'name="cta.url"' in rendered
+
+    # Existing repeater row is namespaced by index.
+    assert 'name="sections.0.heading"' in rendered
+    assert "Why us" in rendered
+
+    # The blank repeater template carries the placeholder for client cloning.
+    assert 'name="sections.__INDEX__.heading"' in rendered
+    assert "data-repeater" in rendered
+    assert "data-add" in rendered
+
+
+def test_render_escapes_values(env):
+    data = hydrate(HomeContent, {"hero_title": '<script>"x"'}).model_dump()
+    nodes = build_nodes(HomeContent, data)
+    rendered = env.from_string(
+        "{% from 'admin/content/_fields.html' import render_nodes %}{{ render_nodes(nodes) }}"
+    ).render(nodes=nodes)
+    assert "<script>" not in rendered
+    assert "&lt;script&gt;" in rendered

--- a/uv.lock
+++ b/uv.lock
@@ -2137,7 +2137,7 @@ wheels = [
 
 [[package]]
 name = "skrift"
-version = "0.2.0a7"
+version = "0.2.0a9"
 source = { editable = "." }
 dependencies = [
     { name = "advanced-alchemy" },


### PR DESCRIPTION
## Summary

Adds a content-fields subsystem that lets code declare the editable fields a template needs and have a user configure them from the site admin. The default landing page now renders from a built-in, admin-editable content area.

## Changes

### New Features
- **Content fields system** (`skrift/content`): declare editable fields in code with a Pydantic-backed helper DSL (`text`, `textarea`, `url`, `email`, `phone`, `number`, `select`, `boolean`, plus `group` and `repeater` composites).
- **`ContentArea` schemas** bound to a string key, with nested-form parsing, an admin render tree, and `hydrate()` that validates stored data and fills defaults (schemas can evolve safely).
- **Admin editor** at `/admin/content` (`ContentAdminController`, guarded by `modify-site`), with recursive field rendering and add/remove repeater rows.
- **Built-in `home` content area** drives the default landing page (`index.html`); `WebController` hydrates it automatically.

### Improvements
- New user guide (`docs/guides/content-fields.md`) wired into the docs nav, plus `skrift-content` skill, README/admin/guide cross-links.
- `basic-site` demo renders the `home` area on its landing page.

### Database
- New `content_areas` table (key → JSON) with Alembic migration `b0c1d2e3f4a5` (additive; reversible).

## Release version
`0.2.0a8` -> `0.2.0a9`