### PR TITLE
fix(setup): register csrf_field, favicon_url, and sized on the setup app engine

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "skrift"
-version = "0.2.0a9"
+version = "0.2.0a10"
 description = "A lightweight async Python CMS for crafting modern websites"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/skrift/asgi.py
+++ b/skrift/asgi.py
@@ -1311,6 +1311,20 @@ def create_setup_app() -> Litestar:
     # Template configuration (setup app never uses themes)
     from skrift.app_factory import get_template_directories_for_theme
     setup_template_dirs = get_template_directories_for_theme("")
+    from jinja2 import pass_context
+    from skrift.forms import csrf_field as _csrf_field
+
+    @pass_context
+    def _csrf_field_ctx(context):
+        return _csrf_field(context["request"])
+
+    def _sized_url(url: str, size: str) -> str:
+        sep = "&" if "?" in url else "?"
+        return f"{url}{sep}size={size}"
+
+    # The setup app renders setup/* templates (passkey_login uses csrf_field)
+    # and, via its error handlers, the shared error templates, which extend
+    # base.html (favicon_url + the sized filter). All of them must exist here.
     engine_callback = build_template_engine_callback(
         extra_globals={
             "site_name": lambda: "Skrift",
@@ -1318,7 +1332,10 @@ def create_setup_app() -> Litestar:
             "site_copyright_holder": lambda: "",
             "site_copyright_start_year": lambda: None,
             "static_url": static_url,
+            "csrf_field": _csrf_field_ctx,
+            "favicon_url": get_cached_favicon_url,
         },
+        extra_filters={"sized": _sized_url},
     )
     template_config = create_template_config(setup_template_dirs, engine_callback)
 

--- a/tests/test_setup_controller.py
+++ b/tests/test_setup_controller.py
@@ -562,3 +562,40 @@ class TestResolveEnvVar:
         from skrift.setup.controller import _resolve_env_var
 
         assert _resolve_env_var("$NONEXISTENT_SKRIFT_VAR_12345") == ""
+
+
+class TestSetupAppTemplateEnvironment:
+    """The setup app renders setup/* templates and, through its error handlers,
+    the shared error templates (which extend base.html). Every global and filter
+    those templates reference must be registered on the setup app's engine."""
+
+    def _setup_engine(self):
+        from skrift.asgi import create_setup_app
+
+        app = create_setup_app()
+        litestar_app = app.app  # unwrap StaticFilesMiddleware
+        return litestar_app.template_engine.engine
+
+    def test_globals_used_by_setup_and_error_templates_are_registered(self):
+        env = self._setup_engine()
+        required = (
+            "csp_nonce",
+            "csrf_field",
+            "favicon_url",
+            "now",
+            "site_copyright_holder",
+            "site_copyright_start_year",
+            "site_name",
+            "static_url",
+        )
+        missing = [name for name in required if name not in env.globals]
+        assert not missing, f"setup app engine is missing template globals: {missing}"
+
+    def test_filters_used_by_base_template_are_registered(self):
+        env = self._setup_engine()
+        assert "sized" in env.filters, "setup app engine is missing the 'sized' filter"
+
+    def test_setup_and_error_templates_compile_in_the_setup_environment(self):
+        env = self._setup_engine()
+        for template_name in ("setup/passkey_login.html", "error-500.html", "error-404.html", "error.html"):
+            env.get_template(template_name)


### PR DESCRIPTION
## Summary

The setup app's Jinja environment was missing template globals/filters that its own templates rely on:

- `passkey_login.html` calls `csrf_field()`
- the setup error handlers render `error-500/404.html`, which extend `base.html` and use `favicon_url()` + the `sized` filter

As a result a passkey-auth setup flow 500'd, and the error page itself crashed while rendering. This registers those globals/filter on the setup app engine and adds coverage.

Bumps to `0.2.0a10` (will ship with a future release).

## Tests
`tests/test_setup_controller.py` — 29 passed.