### PR TITLE
Release v0.2.0a11 — Editorial theme, admin feature gating, UI fixes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "skrift"
-version = "0.2.0a10"
+version = "0.2.0a11"
 description = "A lightweight async Python CMS for crafting modern websites"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/skrift/asgi.py
+++ b/skrift/asgi.py
@@ -162,19 +162,32 @@ def load_controllers() -> list:
             from skrift.controllers.push import service_worker
             controllers.append(service_worker)
 
-        # Auto-expand AdminController to include split sub-controllers
+        # Auto-expand AdminController to include split sub-controllers.
+        # Sub-controllers tied to a config-gated feature are only registered
+        # when that feature is enabled; when it's off their routes are never
+        # added, so the pages 404 and drop out of the admin nav automatically.
         if class_name == "AdminController" and module_path == "skrift.admin.controller":
-            for sub_name in (
-                "UserAdminController",
-                "SettingsAdminController",
-                "ContentAdminController",
-                "MediaAdminController",
-                "OAuth2ClientAdminController",
-                "APIKeyAdminController",
-                "WorkersAdminController",
-                "AgentUsageAdminController",
-                "WebhooksAdminController",
-            ):
+            # Read feature flags straight from the raw config (defaults mirror
+            # the config models). Avoids building the full Settings — which
+            # requires secret_key — just to gate admin registration.
+            workers_cfg = config.get("workers") or {}
+            webhooks_cfg = config.get("webhooks") or {}
+            api_keys_cfg = config.get("api_keys") or {}
+            workers_enabled = bool(workers_cfg.get("enabled", False))
+            admin_subcontrollers = (
+                ("UserAdminController", True),
+                ("SettingsAdminController", True),
+                ("ContentAdminController", True),
+                ("MediaAdminController", True),
+                ("OAuth2ClientAdminController", bool(config.get("oauth2_enabled", False))),
+                ("APIKeyAdminController", bool(api_keys_cfg.get("enabled", True))),
+                ("WorkersAdminController", workers_enabled),
+                ("AgentUsageAdminController", workers_enabled),
+                ("WebhooksAdminController", bool(webhooks_cfg.get("enabled", False))),
+            )
+            for sub_name, feature_enabled in admin_subcontrollers:
+                if not feature_enabled:
+                    continue
                 sub_class = getattr(module, sub_name, None)
                 if sub_class and sub_class not in controllers:
                     controllers.append(sub_class)

--- a/skrift/static/css/admin.css
+++ b/skrift/static/css/admin.css
@@ -6,15 +6,15 @@
    ======================================== */
 
 :root {
-    --sk-admin-sidebar-bg: #080D18;
+    --sk-admin-sidebar-bg: var(--sk-color-surface-sunken);
     --sk-admin-sidebar-width: 15.5rem;
-    --sk-admin-sidebar-text: #fff;
-    --sk-admin-sidebar-muted: rgba(255, 255, 255, 0.3);
-    --sk-admin-sidebar-border: rgba(255, 255, 255, 0.08);
-    --sk-admin-sidebar-link: rgba(255, 255, 255, 0.45);
-    --sk-admin-sidebar-link-hover: rgba(255, 255, 255, 0.8);
-    --sk-admin-sidebar-link-hover-bg: var(--sk-color-surface, rgba(255, 255, 255, 0.03));
-    --sk-admin-sidebar-active-bg: rgba(52, 211, 153, 0.06);
+    --sk-admin-sidebar-text: var(--sk-color-text);
+    --sk-admin-sidebar-muted: var(--sk-color-faint);
+    --sk-admin-sidebar-border: var(--sk-color-border);
+    --sk-admin-sidebar-link: var(--sk-color-text-secondary);
+    --sk-admin-sidebar-link-hover: var(--sk-color-text);
+    --sk-admin-sidebar-link-hover-bg: var(--sk-color-surface-hover);
+    --sk-admin-sidebar-active-bg: var(--sk-color-surface);
 }
 
 /* ========================================
@@ -73,14 +73,11 @@
 
 .sk-sidebar-brand h1 {
     font-family: var(--sk-font-display);
-    font-size: 1.25rem;
-    font-weight: 700;
-    letter-spacing: -0.02em;
+    font-size: 1.4rem;
+    font-weight: 600;
+    letter-spacing: -0.01em;
     margin-bottom: 0;
-    background: var(--sk-gradient-brand);
-    -webkit-background-clip: text;
-    -webkit-text-fill-color: transparent;
-    background-clip: text;
+    color: var(--sk-color-text);
 }
 
 .sk-sidebar-brand .sk-sidebar-sub {
@@ -91,12 +88,13 @@
 
 /* Sidebar Section Labels */
 .sk-sidebar-section {
-    font-size: 0.62rem;
-    font-weight: 600;
+    font-family: var(--sk-font-mono);
+    font-size: 0.64rem;
+    font-weight: 500;
     text-transform: uppercase;
-    letter-spacing: 0.1em;
+    letter-spacing: 0.12em;
     color: var(--sk-admin-sidebar-muted);
-    padding: 0.75rem 1.5rem 0.5rem;
+    padding: 0.9rem 1.5rem 0.5rem;
 }
 
 /* Sidebar Nav */
@@ -120,9 +118,10 @@
 }
 
 .sk-sidebar-link.active {
-    color: #fff;
+    color: var(--sk-color-text);
+    font-weight: 600;
     background: var(--sk-admin-sidebar-active-bg);
-    border-left-color: var(--sk-color-accent, var(--sk-emerald));
+    border-left-color: var(--sk-color-accent);
 }
 
 /* Sidebar Footer */
@@ -138,9 +137,9 @@
 .sk-sidebar-avatar {
     width: 2rem;
     height: 2rem;
-    border-radius: 0.625rem;
-    background: var(--sk-gradient-brand);
-    color: #fff;
+    border-radius: 0.5rem;
+    background: var(--sk-color-accent);
+    color: var(--sk-color-on-accent);
     display: flex;
     align-items: center;
     justify-content: center;
@@ -158,7 +157,7 @@
 
 .sk-sidebar-user .sk-sidebar-name {
     font-size: 1rem;
-    color: rgba(255, 255, 255, 0.8);
+    color: var(--sk-color-text);
     font-weight: 600;
 }
 
@@ -254,7 +253,7 @@
     left: 0;
     right: 0;
     height: 3px;
-    background: var(--sk-gradient-brand);
+    background: var(--sk-color-accent);
     opacity: 0.8;
     transition: height 0.3s, opacity 0.3s;
 }
@@ -378,7 +377,7 @@
 }
 
 .sk-pill-published {
-    background: rgba(52, 211, 153, 0.1);
+    background: var(--sk-color-success-soft);
     color: var(--sk-color-success);
 }
 
@@ -388,7 +387,7 @@
 }
 
 .sk-pill-review {
-    background: rgba(139, 92, 246, 0.1);
+    background: var(--sk-color-warm);
     color: var(--sk-violet);
 }
 
@@ -673,7 +672,7 @@
 
 .sk-worker-dot-claimed,
 .sk-worker-bar-claimed {
-    background: #2563eb;
+    background: var(--sk-color-accent);
 }
 
 .sk-worker-dot-dead,
@@ -796,7 +795,7 @@
 }
 
 .sk-worker-chart-claimed {
-    stroke: #2563eb;
+    stroke: var(--sk-color-accent);
 }
 
 .sk-worker-chart-dead {
@@ -1015,8 +1014,8 @@
 }
 
 .sk-webhook-live {
-    background: rgba(52, 211, 153, 0.12);
-    border: 1px solid rgba(52, 211, 153, 0.32);
+    background: var(--sk-color-success-soft);
+    border: 1px solid var(--sk-color-success-soft);
     border-radius: 999px;
     color: var(--sk-color-success);
     display: inline-flex;
@@ -1028,8 +1027,8 @@
 }
 
 .sk-webhook-live-stale {
-    background: rgba(245, 158, 11, 0.14);
-    border-color: rgba(245, 158, 11, 0.32);
+    background: var(--sk-color-warning-soft);
+    border-color: var(--sk-color-warning-soft);
     color: var(--sk-color-warning);
 }
 
@@ -1102,7 +1101,7 @@
 
 .sk-webhook-status-succeeded,
 .sk-webhook-status-success {
-    background: rgba(52, 211, 153, 0.12);
+    background: var(--sk-color-success-soft);
     color: var(--sk-color-success);
 }
 
@@ -1110,13 +1109,13 @@
 .sk-webhook-status-queued,
 .sk-webhook-status-sending,
 .sk-webhook-status-retry {
-    background: rgba(245, 158, 11, 0.14);
+    background: var(--sk-color-warning-soft);
     color: var(--sk-color-warning);
 }
 
 .sk-webhook-status-dead,
 .sk-webhook-status-cancelled {
-    background: rgba(239, 68, 68, 0.14);
+    background: var(--sk-color-error-soft);
     color: var(--sk-color-error);
 }
 
@@ -1137,9 +1136,4 @@
    Light Theme Overrides
    ======================================== */
 
-@media (prefers-color-scheme: light) {
-    :root {
-        --sk-admin-sidebar-bg: #0f172a;
-        --sk-admin-sidebar-active-bg: rgba(5, 150, 105, 0.1);
-    }
-}
+/* Sidebar adapts to light/dark via the shared theme tokens. */

--- a/skrift/static/css/site.css
+++ b/skrift/static/css/site.css
@@ -9,7 +9,7 @@
     position: sticky;
     top: 0;
     z-index: 100;
-    background: rgba(7, 11, 20, 0.75);
+    background: var(--sk-color-nav-bg);
     backdrop-filter: blur(20px);
     -webkit-backdrop-filter: blur(20px);
     border-bottom: 1px solid var(--sk-color-border);
@@ -28,13 +28,10 @@
 
 .sk-nav-logo {
     font-family: var(--sk-font-display);
-    font-size: 1.35rem;
-    font-weight: 700;
-    background: var(--sk-gradient-brand);
-    -webkit-background-clip: text;
-    -webkit-text-fill-color: transparent;
-    background-clip: text;
-    letter-spacing: -0.02em;
+    font-size: 1.5rem;
+    font-weight: 600;
+    color: var(--sk-color-text);
+    letter-spacing: -0.01em;
     text-decoration: none;
 }
 
@@ -67,8 +64,8 @@
 .sk-nav-cta {
     font-size: 0.8rem;
     font-weight: 500;
-    color: var(--sk-color-bg);
-    background: var(--sk-gradient-accent);
+    color: var(--sk-color-on-accent);
+    background: var(--sk-color-accent);
     padding: 0.5rem 1.1rem;
     border-radius: var(--sk-radius-md);
     transition: all 0.25s;
@@ -79,10 +76,9 @@
 }
 
 .sk-nav-cta:hover {
-    opacity: 0.9;
+    background: var(--sk-color-accent-hover);
     transform: translateY(-1px);
-    box-shadow: 0 4px 20px rgba(52, 211, 153, 0.3);
-    color: var(--sk-color-bg);
+    color: var(--sk-color-on-accent);
 }
 
 /* ========================================
@@ -129,7 +125,7 @@
     font-weight: 500;
     color: var(--sk-color-accent);
     background: var(--sk-color-accent-soft);
-    border: 1px solid rgba(52, 211, 153, 0.15);
+    border: 1px solid var(--sk-color-accent-soft);
     padding: 0.4rem 1rem;
     border-radius: var(--sk-radius-pill);
     margin-bottom: 1.5rem;
@@ -137,10 +133,10 @@
 
 .sk-hero h1 {
     font-family: var(--sk-font-display);
-    font-size: clamp(2.5rem, 5vw, 3.8rem);
-    font-weight: 700;
-    line-height: 1.1;
-    letter-spacing: -0.03em;
+    font-size: clamp(2.5rem, 5vw, 3.6rem);
+    font-weight: 500;
+    line-height: 1.08;
+    letter-spacing: -0.01em;
     margin-bottom: 1rem;
 }
 
@@ -179,11 +175,11 @@
    ======================================== */
 
 .sk-section-label {
-    font-family: var(--sk-font-display);
-    font-size: 1rem;
-    font-weight: 600;
+    font-family: var(--sk-font-mono);
+    font-size: 0.72rem;
+    font-weight: 500;
     text-transform: uppercase;
-    letter-spacing: 0.1em;
+    letter-spacing: 0.12em;
     color: var(--sk-color-muted);
     margin-bottom: 1.25rem;
 }
@@ -218,8 +214,8 @@
 }
 
 .sk-filter-pill.active {
-    color: var(--sk-color-bg);
-    background: var(--sk-gradient-accent);
+    color: var(--sk-color-on-accent);
+    background: var(--sk-color-accent);
     border-color: transparent;
     font-weight: 500;
 }
@@ -248,7 +244,7 @@
     position: relative;
     background: var(--sk-color-surface);
     border: 1px solid var(--sk-color-border);
-    border-radius: var(--sk-radius-xl);
+    border-radius: var(--sk-radius-lg);
     overflow: hidden;
     transition: all 0.35s cubic-bezier(0.25, 0.46, 0.45, 0.94);
 }
@@ -265,14 +261,13 @@
 }
 
 .sk-post-card:hover::before {
-    opacity: 1;
+    opacity: 0;
 }
 
 .sk-post-card:hover {
-    border-color: transparent;
-    transform: translateY(-4px);
-    box-shadow: 0 12px 40px rgba(52, 211, 153, 0.08),
-                0 4px 16px rgba(139, 92, 246, 0.06);
+    border-color: var(--sk-color-border-hover);
+    transform: translateY(-3px);
+    box-shadow: var(--sk-shadow-md);
 }
 
 .sk-post-card-inner {
@@ -290,11 +285,12 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    color: rgba(255, 255, 255, 0.2);
-    font-family: var(--sk-font-display);
-    font-size: 2rem;
-    font-weight: 600;
-    background: linear-gradient(135deg, var(--sk-color-accent), var(--sk-violet));
+    color: var(--sk-color-faint);
+    font-family: var(--sk-font-mono);
+    font-size: 0.7rem;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    background: repeating-linear-gradient(135deg, var(--sk-color-warm) 0 11px, transparent 11px 22px), var(--sk-color-surface-hover);
     overflow: hidden;
     aspect-ratio: 16 / 9;
 }
@@ -381,8 +377,8 @@
 }
 
 .sk-page-btn.active {
-    background: var(--sk-gradient-accent);
-    color: var(--sk-color-bg);
+    background: var(--sk-color-accent);
+    color: var(--sk-color-on-accent);
     border-color: transparent;
     font-weight: 600;
 }
@@ -407,8 +403,8 @@
 
 .sk-footer-brand {
     font-family: var(--sk-font-display);
-    font-size: 1.2rem;
-    font-weight: 700;
+    font-size: 1.3rem;
+    font-weight: 600;
     color: var(--sk-color-text);
     margin-bottom: 0.75rem;
     display: inline-block;
@@ -522,11 +518,11 @@ article footer {
 
 @media (prefers-color-scheme: light) {
     .sk-nav {
-        background: rgba(248, 250, 252, 0.85);
+        background: var(--sk-color-nav-bg);
     }
 
     .sk-nav-cta {
-        color: #fff;
+        color: var(--sk-color-on-accent);
     }
 
     .sk-post-card-inner {

--- a/skrift/static/css/skrift.css
+++ b/skrift/static/css/skrift.css
@@ -6,43 +6,51 @@
    ======================================== */
 
 :root {
-    /* Primitive palette */
-    --sk-emerald: #34D399;
-    --sk-teal: #2DD4BF;
-    --sk-violet: #8B5CF6;
-    --sk-rose: #F43F5E;
-    --sk-amber: #F59E0B;
+    /* Primitive palette — Editorial (warm ink-on-paper) */
+    --sk-terracotta: #b25438;
+    --sk-terracotta-soft: #d99a7e;
+    --sk-green: #5fa877;
+    --sk-amber: #c79a4f;
 
-    /* Core palette (Aurora dark default) */
-    --sk-color-bg: #070B14;
-    --sk-color-text: #E8ECF4;
-    --sk-color-text-secondary: rgba(255, 255, 255, 0.5);
-    --sk-color-muted: rgba(255, 255, 255, 0.4);
-    --sk-color-accent: var(--sk-emerald);
-    --sk-color-accent-hover: var(--sk-teal);
-    --sk-color-accent-soft: rgba(52, 211, 153, 0.08);
-    --sk-color-border: rgba(255, 255, 255, 0.08);
-    --sk-color-border-hover: rgba(255, 255, 255, 0.14);
-    --sk-color-surface: rgba(255, 255, 255, 0.04);
-    --sk-color-surface-hover: rgba(255, 255, 255, 0.07);
-    --sk-color-warm: rgba(255, 255, 255, 0.06);
+    /* Core palette (dark default) */
+    --sk-color-bg: #1a1917;
+    --sk-color-text: #ece9e3;
+    --sk-color-text-secondary: #bdb7ac;
+    --sk-color-muted: #948d81;
+    --sk-color-faint: #6b655b;
+    --sk-color-accent: var(--sk-terracotta);
+    --sk-color-accent-hover: #c9694c;
+    --sk-color-accent-text: #d99a7e;
+    --sk-color-accent-soft: rgba(178, 84, 56, 0.18);
+    --sk-color-on-accent: #ffffff;
+    --sk-color-border: rgba(235, 232, 226, 0.10);
+    --sk-color-border-hover: rgba(235, 232, 226, 0.18);
+    --sk-color-surface: #201f1d;
+    --sk-color-surface-hover: #292824;
+    --sk-color-surface-sunken: #141311;
+    --sk-color-warm: rgba(235, 232, 226, 0.06);
+    --sk-color-nav-bg: rgba(26, 25, 23, 0.82);
 
-    /* Gradient tokens */
-    --sk-gradient-brand: linear-gradient(135deg, var(--sk-emerald), var(--sk-teal), var(--sk-violet));
-    --sk-gradient-accent: linear-gradient(135deg, var(--sk-emerald), var(--sk-teal));
+    /* Gradient tokens (flat, editorial) */
+    --sk-gradient-brand: var(--sk-color-text);
+    --sk-gradient-accent: var(--sk-color-accent);
 
     /* Semantic colors */
-    --sk-color-success: var(--sk-emerald);
+    --sk-color-success: var(--sk-green);
+    --sk-color-success-soft: rgba(95, 168, 119, 0.14);
     --sk-color-warning: var(--sk-amber);
-    --sk-color-error: var(--sk-rose);
-    --sk-color-info: var(--sk-teal);
+    --sk-color-warning-soft: rgba(199, 154, 79, 0.16);
+    --sk-color-error: #d06a52;
+    --sk-color-error-soft: rgba(208, 106, 82, 0.16);
+    --sk-color-info: var(--sk-terracotta-soft);
 
     /* Typography */
-    --sk-font-body: 'Lexend', sans-serif;
-    --sk-font-display: 'Bricolage Grotesque', sans-serif;
-    --sk-font-mono: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace;
-    --sk-line-height: 1.6;
-    --sk-line-height-tight: 1.3;
+    --sk-font-body: 'Public Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif;
+    --sk-font-display: 'Newsreader', Georgia, 'Times New Roman', serif;
+    --sk-font-serif: var(--sk-font-display);
+    --sk-font-mono: 'IBM Plex Mono', ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+    --sk-line-height: 1.65;
+    --sk-line-height-tight: 1.2;
 
     /* Spacing scale */
     --sk-space-xs: 0.25rem;
@@ -53,23 +61,23 @@
     --sk-space-2xl: 3rem;
 
     /* Borders & radii */
-    --sk-radius-sm: 4px;
-    --sk-radius-md: 8px;
-    --sk-radius-lg: 12px;
-    --sk-radius-xl: 16px;
+    --sk-radius-sm: 3px;
+    --sk-radius-md: 6px;
+    --sk-radius-lg: 10px;
+    --sk-radius-xl: 14px;
     --sk-radius-pill: 999px;
 
-    /* Shadows (deeper for dark bg) */
-    --sk-shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.25);
-    --sk-shadow-md: 0 4px 12px rgba(0, 0, 0, 0.3);
-    --sk-shadow-lg: 0 4px 24px rgba(0, 0, 0, 0.5);
+    /* Shadows */
+    --sk-shadow-sm: 0 1px 3px rgba(0, 0, 0, 0.4);
+    --sk-shadow-md: 0 4px 14px rgba(0, 0, 0, 0.45);
+    --sk-shadow-lg: 0 10px 40px rgba(0, 0, 0, 0.55);
 
     /* Transitions */
     --sk-transition-fast: 150ms ease;
     --sk-transition-normal: 200ms ease;
 
     /* Aurora toggle (1 = on, 0 = off) */
-    --sk-aurora: 1;
+    --sk-aurora: 0;
 }
 
 /* ========================================
@@ -106,18 +114,12 @@ body {
    ======================================== */
 
 h1, h2, h3, h4, h5, h6 {
+    font-family: var(--sk-font-display);
     line-height: var(--sk-line-height-tight);
     font-weight: 600;
+    letter-spacing: -0.01em;
     margin-bottom: var(--sk-space-md);
-}
-
-h1, h2 {
-    font-family: var(--sk-font-display);
-    letter-spacing: -0.02em;
-}
-
-h3, h4, h5, h6 {
-    letter-spacing: -0.025em;
+    color: var(--sk-color-text);
 }
 
 h1 { font-size: clamp(2rem, 4vw, 2.5rem); }
@@ -251,8 +253,8 @@ input:focus,
 textarea:focus,
 select:focus {
     outline: none;
-    border-color: rgba(52, 211, 153, 0.3);
-    box-shadow: 0 0 0 3px rgba(52, 211, 153, 0.08);
+    border-color: var(--sk-color-accent);
+    box-shadow: 0 0 0 3px var(--sk-color-accent-soft);
 }
 
 input:disabled,
@@ -382,20 +384,20 @@ input[type="reset"] {
     justify-content: center;
     gap: var(--sk-space-sm);
     font-family: inherit;
-    font-size: 1rem;
+    font-size: 0.9rem;
     font-weight: 600;
     line-height: 1;
-    padding: 0.625rem 1.25rem;
+    padding: 0.625rem 1.15rem;
     border: 1px solid transparent;
-    border-radius: var(--sk-radius-pill);
-    background: var(--sk-gradient-accent);
-    color: var(--sk-color-bg);
+    border-radius: var(--sk-radius-md);
+    background: var(--sk-color-accent);
+    color: var(--sk-color-on-accent);
     cursor: pointer;
     text-decoration: none;
     transition: background-color var(--sk-transition-fast),
                 box-shadow var(--sk-transition-fast),
                 transform var(--sk-transition-fast);
-    box-shadow: var(--sk-shadow-sm);
+    box-shadow: none;
 }
 
 button:hover,
@@ -403,9 +405,8 @@ button:hover,
 input[type="submit"]:hover,
 input[type="button"]:hover,
 input[type="reset"]:hover {
-    opacity: 0.9;
-    color: var(--sk-color-bg);
-    box-shadow: 0 4px 20px rgba(52, 211, 153, 0.3);
+    background: var(--sk-color-accent-hover);
+    color: var(--sk-color-on-accent);
 }
 
 button:active,
@@ -460,8 +461,8 @@ button.sk-btn-outline:hover,
     font-size: 12px;
     padding: 7px 18px;
     border-radius: var(--sk-radius-md);
-    background: var(--sk-gradient-accent);
-    color: var(--sk-color-bg);
+    background: var(--sk-color-accent);
+    color: var(--sk-color-on-accent);
     font-weight: 600;
 }
 
@@ -1088,32 +1089,40 @@ hr {
 
 @media (prefers-color-scheme: light) {
     :root {
-        --sk-color-bg: #f8fafc;
-        --sk-color-text: #0f172a;
-        --sk-color-text-secondary: rgba(0, 0, 0, 0.5);
-        --sk-color-muted: #64748b;
-        --sk-color-accent: #059669;
-        --sk-color-accent-hover: #047857;
-        --sk-color-accent-soft: rgba(5, 150, 105, 0.08);
-        --sk-color-border: #e2e8f0;
-        --sk-color-border-hover: #cbd5e1;
+        --sk-color-bg: #f6f2ea;
+        --sk-color-text: #211e1a;
+        --sk-color-text-secondary: #534c42;
+        --sk-color-muted: #6b6358;
+        --sk-color-faint: #9b9183;
+        --sk-color-accent: #b25438;
+        --sk-color-accent-hover: #9a4630;
+        --sk-color-accent-text: #b25438;
+        --sk-color-accent-soft: rgba(178, 84, 56, 0.12);
+        --sk-color-on-accent: #ffffff;
+        --sk-color-border: rgba(33, 30, 26, 0.10);
+        --sk-color-border-hover: rgba(33, 30, 26, 0.18);
         --sk-color-surface: #ffffff;
-        --sk-color-surface-hover: #f1f5f9;
-        --sk-color-warm: #f1f5f9;
+        --sk-color-surface-hover: #efe8db;
+        --sk-color-surface-sunken: #efe8db;
+        --sk-color-warm: rgba(33, 30, 26, 0.05);
+        --sk-color-nav-bg: rgba(246, 242, 234, 0.82);
 
-        --sk-color-success: #059669;
-        --sk-color-warning: #d97706;
-        --sk-color-error: #dc2626;
-        --sk-color-info: #0891b2;
+        --sk-color-success: #3f7d52;
+        --sk-color-success-soft: rgba(63, 125, 82, 0.12);
+        --sk-color-warning: #9a6a1e;
+        --sk-color-warning-soft: rgba(154, 106, 30, 0.14);
+        --sk-color-error: #b03a2e;
+        --sk-color-error-soft: rgba(176, 58, 46, 0.12);
+        --sk-color-info: #b25438;
 
-        --sk-shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.05);
-        --sk-shadow-md: 0 4px 12px rgba(0, 0, 0, 0.06);
-        --sk-shadow-lg: 0 4px 24px rgba(0, 0, 0, 0.1);
+        --sk-shadow-sm: 0 1px 3px rgba(33, 30, 26, 0.08);
+        --sk-shadow-md: 0 4px 14px rgba(33, 30, 26, 0.10);
+        --sk-shadow-lg: 0 10px 40px rgba(33, 30, 26, 0.14);
     }
 
     .sk-dialog {
-        box-shadow: 0 24px 80px rgba(0, 0, 0, 0.15),
-                    0 0 0 1px rgba(0, 0, 0, 0.05);
+        box-shadow: 0 24px 80px rgba(33, 30, 26, 0.18),
+                    0 0 0 1px rgba(33, 30, 26, 0.06);
     }
 }
 
@@ -1140,4 +1149,64 @@ hr {
 
 .sk-nav-link.sk-linklike {
     text-decoration: none;
+    margin-top: 0;
+}
+
+/* Logout sits in a <form> inside the nav — neutralize the form-submit spacing
+   and button chrome so it aligns with the other nav links. */
+.sk-inline-logout {
+    display: inline-flex;
+    align-items: center;
+}
+
+.sk-inline-logout button {
+    margin-top: 0;
+}
+
+/* ========================================
+   Editorial additions
+   ======================================== */
+
+/* Flat paper background — the aurora orbs are off-brand for the editorial theme */
+.sk-aurora-bg { display: none; }
+
+/* Mono eyebrow / kicker label */
+.sk-eyebrow,
+.sk-kicker {
+    font-family: var(--sk-font-mono);
+    font-size: 0.72rem;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: var(--sk-color-accent-text);
+}
+
+.sk-kicker-muted {
+    color: var(--sk-color-muted);
+}
+
+/* Dark/ink button (inverts per mode) — e.g. Subscribe, primary CTA on paper */
+.sk-btn-dark,
+button.sk-btn-dark,
+[role="button"].sk-btn-dark {
+    background: var(--sk-color-text);
+    color: var(--sk-color-bg);
+    border-color: transparent;
+}
+
+.sk-btn-dark:hover,
+button.sk-btn-dark:hover,
+[role="button"].sk-btn-dark:hover {
+    background: var(--sk-color-text);
+    color: var(--sk-color-bg);
+    opacity: 0.88;
+}
+
+/* Serif utility */
+.sk-serif { font-family: var(--sk-font-display); }
+
+/* Links inside prose/markdown use the readable accent-text tone */
+.page-content a,
+.page-body a {
+    color: var(--sk-color-accent-text);
+    text-underline-offset: 2px;
 }

--- a/skrift/static/css/skrift.css
+++ b/skrift/static/css/skrift.css
@@ -881,11 +881,17 @@ hr {
 /* Form actions */
 .sk-form-actions {
     display: flex;
+    align-items: center;
     gap: var(--sk-space-md);
     margin-top: var(--sk-space-lg);
 }
 
+/* Zero the submit-button top margin (form button[type=submit] adds one) so the
+   action buttons line up instead of the submit floating below its siblings. */
 .sk-form-actions button,
+.sk-form-actions button[type="submit"],
+.sk-form-actions input[type="submit"],
+.sk-form-actions input[type="button"],
 .sk-form-actions [role="button"] {
     margin-top: 0;
 }

--- a/skrift/templates/account/index.html
+++ b/skrift/templates/account/index.html
@@ -6,55 +6,105 @@
 <style nonce="{{ csp_nonce() }}">
     .account-shell {
         max-width: 880px;
-        margin: 2rem auto;
+        margin: 2.5rem auto;
         display: grid;
         gap: 1.25rem;
     }
 
-    .account-header {
+    .account-intro {
+        margin-bottom: 0.5rem;
+    }
+    .account-intro .sk-eyebrow {
+        display: block;
+        margin-bottom: 0.6rem;
+    }
+    .account-intro h1 {
+        font-family: var(--sk-font-display);
+        font-size: 2rem;
+        font-weight: 600;
+        margin: 0 0 0.35rem;
+    }
+    .account-intro p {
+        color: var(--sk-color-muted);
+        margin: 0;
+    }
+
+    .account-profile {
         display: flex;
-        align-items: flex-start;
-        justify-content: space-between;
-        gap: 1rem;
+        align-items: center;
+        gap: 1.15rem;
+        padding: 1.25rem 1.5rem;
+        border: 1px solid var(--sk-color-border);
+        border-radius: var(--sk-radius-lg);
+        background: var(--sk-color-surface);
+    }
+    .account-avatar {
+        width: 56px;
+        height: 56px;
+        border-radius: 50%;
+        object-fit: cover;
+        flex-shrink: 0;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        background: var(--sk-color-accent);
+        color: var(--sk-color-on-accent);
+        font-family: var(--sk-font-display);
+        font-size: 1.4rem;
+        font-weight: 600;
+    }
+    .account-identity { flex: 1; min-width: 0; }
+    .account-identity .account-name {
+        font-family: var(--sk-font-display);
+        font-size: 1.35rem;
+        font-weight: 600;
+        line-height: 1.2;
+    }
+    .account-identity .account-sub {
+        color: var(--sk-color-muted);
+        font-size: 0.9rem;
+        margin-top: 0.2rem;
+    }
+    .account-actions {
+        display: flex;
+        gap: 0.6rem;
         flex-wrap: wrap;
     }
 
     .account-panel {
-        padding: 1.25rem;
-        border: 1px solid var(--sk-color-border, #e5e7eb);
-        border-radius: var(--sk-radius-lg, 0.75rem);
-        background: var(--sk-color-surface, rgba(255, 255, 255, 0.04));
+        padding: 1.4rem 1.5rem;
+        border: 1px solid var(--sk-color-border);
+        border-radius: var(--sk-radius-lg);
+        background: var(--sk-color-surface);
     }
-
     .account-panel h2,
     .account-panel h3 {
         margin-top: 0;
+        font-size: 1.05rem;
     }
 
     .account-detail-list {
         display: grid;
-        gap: 0.65rem;
+        gap: 0.75rem;
         margin: 0;
     }
-
     .account-detail-row {
         display: grid;
         grid-template-columns: minmax(8rem, 12rem) 1fr;
         gap: 1rem;
+        padding-bottom: 0.75rem;
+        border-bottom: 1px solid var(--sk-color-border);
     }
-
+    .account-detail-row:last-child {
+        padding-bottom: 0;
+        border-bottom: none;
+    }
     .account-detail-row dt {
-        color: var(--sk-color-muted, #6b7280);
-    }
-
-    .account-actions {
-        display: flex;
-        gap: 0.75rem;
-        flex-wrap: wrap;
+        color: var(--sk-color-muted);
     }
 
     .account-empty {
-        color: var(--sk-color-muted, #6b7280);
+        color: var(--sk-color-muted);
         margin-bottom: 0;
     }
 </style>
@@ -62,16 +112,30 @@
 
 {% block content %}
 <div class="account-shell">
-    <div class="account-header">
-        <hgroup>
-            <h1>Account</h1>
-            <p>Signed in as {{ user.email or user.name or user.id }}.</p>
-        </hgroup>
+    <div class="account-intro">
+        <span class="sk-eyebrow">Account</span>
+        <h1>Your account</h1>
+        <p>Manage your profile, sign-in &amp; security.</p>
+    </div>
+
+    <section class="account-profile">
+        {% if user.picture_url %}
+        <img class="account-avatar" src="{{ user.picture_url }}" alt="">
+        {% else %}
+        <span class="account-avatar">{{ (user.name or user.email or "?")[:1] | upper }}</span>
+        {% endif %}
+        <div class="account-identity">
+            <div class="account-name">{{ user.name or user.email or "Your profile" }}</div>
+            <div class="account-sub">
+                {{ user.email or user.id }}
+                {% if user.last_login_at %} · Last login {{ user.last_login_at.strftime('%b %d, %Y') }}{% endif %}
+            </div>
+        </div>
         <div class="account-actions">
             <a href="/auth/passkeys" role="button" class="sk-btn-outline">Passkeys</a>
             <a href="/admin" role="button" class="sk-btn-outline">Dashboard</a>
         </div>
-    </div>
+    </section>
 
     <section class="account-panel">
         <h2>Profile</h2>

--- a/skrift/templates/admin/base.html
+++ b/skrift/templates/admin/base.html
@@ -8,7 +8,7 @@
     {% if _fav %}<link rel="icon" href="{{ _fav | sized('icon') }}">{% endif %}
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:opsz,wght@12..96,200..800&family=Lexend:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Newsreader:ital,opsz,wght@0,6..72,400..600;1,6..72,400..500&family=IBM+Plex+Mono:wght@400;500;600&family=Public+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="{{ static_url('skrift/css/skrift.css') }}">
     <link rel="stylesheet" href="{{ static_url('skrift/css/aurora.css') }}">
     <link rel="stylesheet" href="{{ static_url('skrift/css/admin.css') }}">

--- a/skrift/templates/auth/base.html
+++ b/skrift/templates/auth/base.html
@@ -6,7 +6,7 @@
     <title>{% block title %}{{ site_name() }}{% endblock %}</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:opsz,wght@12..96,200..800&family=Lexend:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Newsreader:ital,opsz,wght@0,6..72,400..600;1,6..72,400..500&family=IBM+Plex+Mono:wght@400;500;600&family=Public+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="{{ static_url('skrift/css/skrift.css') }}">
     <link rel="stylesheet" href="{{ static_url('skrift/css/aurora.css') }}">
     {% block head %}{% endblock %}

--- a/skrift/templates/auth/dummy_login.html
+++ b/skrift/templates/auth/dummy_login.html
@@ -52,17 +52,21 @@
     }
 
     .admin-toggle input[type="checkbox"] {
-        width: auto;
+        width: 1.25rem;
+        height: 1.25rem;
+        padding: 0;
         margin: 0;
+        border-radius: var(--sk-radius-sm);
+        flex: none;
     }
 
     .submit-btn {
         width: 100%;
         padding: 1rem;
-        background: #6b7280;
-        color: white;
+        background: var(--sk-color-accent);
+        color: var(--sk-color-on-accent);
         border: none;
-        border-radius: 0.5rem;
+        border-radius: var(--sk-radius-md);
         font-size: 1rem;
         font-weight: 600;
         cursor: pointer;
@@ -70,7 +74,7 @@
     }
 
     .submit-btn:hover {
-        background: #4b5563;
+        background: var(--sk-color-accent-hover);
     }
 
     .back-link {

--- a/skrift/templates/auth/login.html
+++ b/skrift/templates/auth/login.html
@@ -31,6 +31,11 @@
 
     .oauth-btn:hover {
         opacity: 0.9;
+        color: #fff;
+    }
+
+    .oauth-btn-dummy:hover {
+        color: var(--sk-color-bg);
     }
 
     .oauth-btn-google {
@@ -70,13 +75,13 @@
     }
 
     .oauth-btn-dummy {
-        background: #6b7280;
-        color: white;
+        background: var(--sk-color-text);
+        color: var(--sk-color-bg);
     }
 
     .oauth-btn-passkey {
-        background: #0f172a;
-        color: white;
+        background: var(--sk-color-accent);
+        color: var(--sk-color-on-accent);
     }
 
     .dummy-separator {

--- a/skrift/templates/base.html
+++ b/skrift/templates/base.html
@@ -36,7 +36,7 @@
 
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:opsz,wght@12..96,200..800&family=Lexend:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Newsreader:ital,opsz,wght@0,6..72,400..600;1,6..72,400..500&family=IBM+Plex+Mono:wght@400;500;600&family=Public+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="{{ static_url('skrift/css/skrift.css') }}">
     <link rel="stylesheet" href="{{ static_url('skrift/css/aurora.css') }}">
     <link rel="stylesheet" href="{{ static_url('skrift/css/site.css') }}">

--- a/skrift/templates/index.html
+++ b/skrift/templates/index.html
@@ -4,52 +4,71 @@
 
 {% block head %}
 <style>
-    .sk-hero {
+    .sk-landing {
         max-width: 760px;
-        margin: 4rem auto 2rem;
+        margin: 0 auto;
+        padding: 5rem 1.5rem 2rem;
         text-align: center;
     }
-    .sk-hero h1 {
-        font-size: clamp(2rem, 5vw, 3.25rem);
-        line-height: 1.1;
-        margin: 0 0 1rem;
+    .sk-landing .sk-eyebrow {
+        display: block;
+        margin-bottom: 1.25rem;
     }
-    .sk-hero p {
-        font-size: 1.15rem;
-        color: var(--sk-color-text-secondary, rgba(255, 255, 255, 0.7));
-        margin: 0 auto 1.75rem;
-        max-width: 38rem;
+    .sk-landing h1 {
+        font-family: var(--sk-font-display);
+        font-size: clamp(2.25rem, 5vw, 3.4rem);
+        font-weight: 500;
+        line-height: 1.08;
+        letter-spacing: -0.01em;
+        margin: 0 0 1.25rem;
     }
-    .sk-hero .sk-cta {
+    .sk-landing .sk-lead {
+        font-size: 1.2rem;
+        line-height: 1.6;
+        color: var(--sk-color-text-secondary);
+        margin: 0 auto 2rem;
+        max-width: 40rem;
+    }
+    .sk-cta {
         display: inline-block;
-        padding: 0.75rem 1.75rem;
-        border-radius: 999px;
-        background: var(--sk-color-accent, #34D399);
-        color: #06251a;
+        padding: 0.7rem 1.6rem;
+        border-radius: var(--sk-radius-md);
+        background: var(--sk-color-accent);
+        color: var(--sk-color-on-accent);
         font-weight: 600;
+        font-size: 0.95rem;
         text-decoration: none;
+        transition: background var(--sk-transition-fast);
+    }
+    .sk-cta:hover {
+        background: var(--sk-color-accent-hover);
+        color: var(--sk-color-on-accent);
     }
     .sk-sections {
-        max-width: 960px;
-        margin: 2rem auto 4rem;
+        max-width: 1000px;
+        margin: 2.5rem auto 4rem;
         display: grid;
         gap: 1.5rem;
         grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
-        padding: 0 1rem;
+        padding: 0 1.5rem;
     }
     .sk-section-card {
-        padding: 1.5rem 1.75rem;
-        border-radius: 1rem;
-        border: 1px solid var(--sk-color-border, rgba(255, 255, 255, 0.08));
-        background: var(--sk-color-surface, rgba(255, 255, 255, 0.04));
+        margin: 0;
+        padding: 1.6rem 1.75rem;
+        border-radius: var(--sk-radius-lg);
+        border: 1px solid var(--sk-color-border);
+        background: var(--sk-color-surface);
     }
     .sk-section-card h2 {
+        font-family: var(--sk-font-display);
         margin: 0 0 0.5rem;
-        font-size: 1.25rem;
+        font-size: 1.3rem;
+        font-weight: 600;
     }
     .sk-section-card p {
         margin: 0;
-        color: var(--sk-color-text-secondary, rgba(255, 255, 255, 0.7));
+        color: var(--sk-color-text-secondary);
+        line-height: 1.6;
         white-space: pre-line;
     }
 </style>
@@ -57,9 +76,10 @@
 
 {% block content %}
 {% if content %}
-<section class="sk-hero">
+<section class="sk-landing">
+    <span class="sk-eyebrow">{{ site_name() }}</span>
     <h1>{{ content.hero_title }}</h1>
-    {% if content.hero_subtitle %}<p>{{ content.hero_subtitle }}</p>{% endif %}
+    {% if content.hero_subtitle %}<p class="sk-lead">{{ content.hero_subtitle }}</p>{% endif %}
     {% if content.cta.label %}
     <a class="sk-cta" href="{{ content.cta.url }}">{{ content.cta.label }}</a>
     {% endif %}
@@ -76,8 +96,8 @@
 </div>
 {% endif %}
 {% else %}
-<hgroup>
+<div class="sk-landing">
     <h1>{{ site_tagline() }}</h1>
-</hgroup>
+</div>
 {% endif %}
 {% endblock %}

--- a/skrift/templates/setup/base.html
+++ b/skrift/templates/setup/base.html
@@ -6,7 +6,7 @@
     <title>{% block title %}Setup - Skrift{% endblock %}</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:opsz,wght@12..96,200..800&family=Lexend:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Newsreader:ital,opsz,wght@0,6..72,400..600;1,6..72,400..500&family=IBM+Plex+Mono:wght@400;500;600&family=Public+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="{{ static_url('skrift/css/skrift.css') }}">
     <style nonce="{{ csp_nonce() }}">
         .setup-container {

--- a/tests/test_admin_feature_gating.py
+++ b/tests/test_admin_feature_gating.py
@@ -1,0 +1,80 @@
+"""Admin sub-controllers tied to a config-gated feature only register when the
+feature is enabled, so disabled features 404 (and drop out of the admin nav)."""
+
+from __future__ import annotations
+
+import pytest
+
+
+def _load_admin_controllers(mock_config_path, *, workers, webhooks, oauth2, api_keys):
+    """Run load_controllers() for a config with the AdminController and the
+    feature flags set in app.yaml."""
+    config = {
+        "controllers": ["skrift.admin.controller:AdminController"],
+        "oauth2_enabled": oauth2,
+        "api_keys": {"enabled": api_keys},
+        "workers": {"enabled": workers},
+        "webhooks": {"enabled": webhooks},
+    }
+    _patched, patcher = mock_config_path(config)
+    try:
+        from skrift.asgi import load_controllers
+
+        controllers = load_controllers()
+    finally:
+        patcher.stop()
+    return {c.__name__ for c in controllers}
+
+
+CORE = {
+    "UserAdminController",
+    "SettingsAdminController",
+    "ContentAdminController",
+    "MediaAdminController",
+}
+
+GATED = {
+    "WorkersAdminController",
+    "AgentUsageAdminController",
+    "WebhooksAdminController",
+    "OAuth2ClientAdminController",
+    "APIKeyAdminController",
+}
+
+
+class TestAdminFeatureGating:
+    def test_disabled_features_are_not_registered(self, mock_config_path):
+        names = _load_admin_controllers(
+            mock_config_path, workers=False, webhooks=False, oauth2=False, api_keys=False
+        )
+        assert not (GATED & names), f"gated controllers leaked: {GATED & names}"
+        assert CORE <= names, f"core controllers missing: {CORE - names}"
+
+    def test_enabled_features_are_registered(self, mock_config_path):
+        names = _load_admin_controllers(
+            mock_config_path, workers=True, webhooks=True, oauth2=True, api_keys=True
+        )
+        assert GATED <= names, f"enabled controllers missing: {GATED - names}"
+        assert CORE <= names
+
+    def test_workers_gate_covers_agent_usage(self, mock_config_path):
+        # Agent usage calls get_runtime(), so it is gated on the worker runtime.
+        names = _load_admin_controllers(
+            mock_config_path, workers=False, webhooks=True, oauth2=True, api_keys=True
+        )
+        assert "WorkersAdminController" not in names
+        assert "AgentUsageAdminController" not in names
+        assert "WebhooksAdminController" in names
+
+    @pytest.mark.parametrize("flag", ["workers", "webhooks", "oauth2", "api_keys"])
+    def test_each_flag_gates_independently(self, mock_config_path, flag):
+        kwargs = {"workers": True, "webhooks": True, "oauth2": True, "api_keys": True}
+        kwargs[flag] = False
+        names = _load_admin_controllers(mock_config_path, **kwargs)
+        expected_absent = {
+            "workers": {"WorkersAdminController", "AgentUsageAdminController"},
+            "webhooks": {"WebhooksAdminController"},
+            "oauth2": {"OAuth2ClientAdminController"},
+            "api_keys": {"APIKeyAdminController"},
+        }[flag]
+        assert not (expected_absent & names), f"{flag} off but present: {expected_absent & names}"

--- a/uv.lock
+++ b/uv.lock
@@ -2137,7 +2137,7 @@ wheels = [
 
 [[package]]
 name = "skrift"
-version = "0.2.0a9"
+version = "0.2.0a11"
 source = { editable = "." }
 dependencies = [
     { name = "advanced-alchemy" },


### PR DESCRIPTION
## Summary

Re-skins the default Skrift theme to the **Editorial** design direction (light + dark), only registers admin pages for features that are enabled in config, and fixes a couple of layout bugs.

## Changes

### New Features / Direction
- **Editorial theme**: warm ink-on-paper palette, Newsreader serif headings, IBM Plex Mono labels, Public Sans body; terracotta accent; flat background. Applied across public site, account, admin, auth, and error pages, in both light and dark mode. Verified with Playwright.

### Improvements
- **Config-gated admin pages**: admin sub-controllers tied to a feature (workers, webhooks, OAuth2 server, API keys) are only registered when that feature is enabled. Disabled features now 404 and drop out of the admin nav instead of 500ing.

### Bug Fixes
- Fixed 500s on `/admin/workers`, `/admin/workers/dlq`, and `/admin/agent-usage` when the worker runtime isn't configured (they now 404 when workers are disabled).
- Fixed the nav logout button and the form-actions Save/Cancel bar floating out of alignment (global `form button[type=submit]` top-margin leaking into flex button groups).
- Fixed the dummy-login admin checkbox sizing and the passkey button's unreadable hover text.

### Tests
- `tests/test_admin_feature_gating.py` — 7 tests covering per-feature gating. Full suite: 1464 passed.

## Release version
`0.2.0a10` -> `0.2.0a11`