### PR TITLE
Release v0.2.0a12 — Worker idle query storm fix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "skrift"
-version = "0.2.0a11"
+version = "0.2.0a12"
 description = "A lightweight async Python CMS for crafting modern websites"
 readme = "README.md"
 requires-python = ">=3.13"


### PR DESCRIPTION
## Summary

Cuts alpha `0.2.0a12`, whose headline change is the worker idle query-storm fix (#161, PR #162). Idle worker tiers no longer hammer the database with hundreds of empty polls per second.

## Changes

### Bug Fixes
- Fix worker idle query storm (#161, #162): idle poll backoff, a standalone reaper timer decoupled from poll frequency, the `worker_state` TTL delete lifted off the read path with an idle-aware history loop and a new `text_pattern_ops` key index, and an opt-in asyncpg statement-cache toggle for pgbouncer transaction mode.

### Improvements
- New `workers` knobs `max_poll_interval`, `poll_backoff_factor`, `reaper_interval` and `db` knobs `pgbouncer_transaction_mode`, `statement_cache_size`, documented in the workers reference and configuration guides.

### Notes
- Idle poll backoff is on by default: the first job after an idle stretch can take up to `max_poll_interval` (default `2.0s`) to pick up, resetting to `poll_interval` immediately on a claim. Tune `max_poll_interval` to taste. The asyncpg/pgbouncer knobs are opt-in and change nothing by default.

## Release version
`0.2.0a11` -> `0.2.0a12`