### PR TITLE
Release v0.2.0a13 — MCP-ready OAuth2 identity provider + per-turn deps_ref fix

### DIFF
--- a/.claude/skills/skrift-auth/SKILL.md
+++ b/.claude/skills/skrift-auth/SKILL.md
@@ -169,7 +169,7 @@ User clicks "Login with Skrift"
 oauth2_enabled: true
 ```
 
-When enabled: `OAuth2Controller` is auto-registered, OAuth token endpoints are CSRF-exempt, `/.well-known/openid-configuration` is active, and admin shows "OAuth Clients" (requires `manage-oauth-clients` permission).
+When enabled: `OAuth2Controller` is auto-registered, OAuth token endpoints are CSRF-exempt, `/.well-known/openid-configuration` + `/.well-known/oauth-authorization-server` are active, and admin shows "OAuth Clients" (requires `manage-oauth-clients` permission). Add `oauth2_dynamic_registration_enabled: true` to open `POST /oauth/register` for machine clients (e.g. Claude custom connectors); it 404s otherwise.
 
 Clients are managed via admin UI at `/admin/oauth-clients`:
 
@@ -206,7 +206,10 @@ Multiple hubs: use the `provider` field to decouple key from type (see Provider 
 | `GET` | `/oauth/userinfo` | Scope-filtered user claims (Bearer token) |
 | `POST` | `/oauth/revoke` | Revoke a token (RFC 7009) |
 | `POST` | `/oauth/introspect` | Token introspection (RFC 7662, requires client auth) |
+| `POST` | `/oauth/register` | Dynamic Client Registration (RFC 7591) — gated by `oauth2_dynamic_registration_enabled` |
+| `GET` | `/oauth/jwks` | Public JWK Set for ES256 access-token verification |
 | `GET` | `/.well-known/openid-configuration` | OIDC Discovery |
+| `GET` | `/.well-known/oauth-authorization-server` | Authorization Server Metadata (RFC 8414) |
 
 ### Scope Registry
 
@@ -221,17 +224,25 @@ Scopes control authorization (validated against client's `allowed_scopes`) and c
 
 ### Token Architecture
 
-| Token | TTL | Payload includes |
-|-------|-----|-----------------|
-| Auth code | 10 min | user_id, email, name, client_id, redirect_uri, scope, code_challenge |
-| Access token | 15 min | user_id, email, name, client_id, scope |
-| Refresh token | 30 days | user_id, client_id, scope |
+| Token | TTL | Signing | Payload / claims |
+|-------|-----|---------|------------------|
+| Auth code | 10 min | HMAC-SHA256 (`secret_key`) | user_id, email, name, client_id, redirect_uri, scope, code_challenge, resource |
+| Access token | 15 min (`oauth2_access_token_ttl`) | ES256 JWT (rotating EC P-256 key) | iss, sub, client_id, scope, aud (when `resource` requested), iat, exp, jti |
+| Refresh token | 30 days | HMAC-SHA256 (`secret_key`) | user_id, client_id, scope, family_id, resource |
 
-All tokens are HMAC-SHA256 signed with `settings.secret_key`. Each includes a `jti` for revocation. Refresh token exchange performs rotation (old token revoked).
+Access tokens are **ES256 JWTs** (RFC 9068) verifiable offline against `GET /oauth/jwks`; codes and refresh tokens stay HMAC and never leave the client↔server exchange. HMAC tokens include a `jti` for revocation. Refresh exchange rotates (old token revoked; reuse of a rotated token mass-revokes its `family_id`). Signing keys rotate via `oauth2_signing_key_service.rotate()` / `prune_expired()`.
+
+### Remembered Consent
+
+`ConsentGrant` (unique per user + client) records approved scopes. `/oauth/authorize` skips the consent screen and issues a code directly when a stored grant covers all requested scopes; broader scopes re-prompt and widen the grant on approval. Grants cascade-delete when the client is deleted or pruned. Service: `skrift/db/services/oauth2_consent_service.py` (`find_grant`, `upsert_grant`, `revoke_grant`, `delete_grants_for_clients`).
 
 ### PKCE
 
-S256 only. **Required** for public clients (no `client_secret`), optional for confidential clients.
+S256 only. **Required** for all clients (OAuth 2.1); `plain` is rejected.
+
+### MCP / Bearer JWT guard
+
+Downstream MCP resource servers protect routes with `BearerJWTAuth(audience=..., scopes=[...])` from `skrift/auth/bearer.py`, listed in a route's `guards` alongside `auth_guard`. It verifies the JWT against the JWKS, checks `iss`/`exp`/`aud`, enforces scopes, and resolves `sub` to the same `UserPermissions` identity as the session/API-key paths (so `Permission()`/`Role()` compose). Fail-closed 401 with `WWW-Authenticate: Bearer error="invalid_token"` (or `insufficient_scope`). See `docs/reference/mcp-identity-provider.md`.
 
 ## Security Notes
 
@@ -247,16 +258,22 @@ S256 only. **Required** for public clients (no `client_secret`), optional for co
 |------|---------|
 | `skrift/auth/` | Guards, roles, permissions |
 | `skrift/auth/providers.py` | OAuth provider classes, `get_oauth_provider()`, dynamic import |
-| `skrift/auth/tokens.py` | `create_signed_token()` / `verify_signed_token()` |
+| `skrift/auth/tokens.py` | `create_signed_token()` / `verify_signed_token()` (HMAC codes/refresh) |
+| `skrift/auth/jwt_tokens.py` | `create_access_token_jwt()` / `verify_access_token_jwt()` (ES256 access tokens) |
+| `skrift/auth/bearer.py` | `BearerJWTAuth` guard marker for MCP resource servers |
 | `skrift/auth/scopes.py` | Scope registry |
 | `skrift/auth/oauth_account_service.py` | `find_or_create_oauth_user()` with token persistence |
 | `skrift/controllers/auth.py` | OAuth login/callback controller |
-| `skrift/controllers/oauth2.py` | OAuth2Controller — authorize, token, userinfo, revoke, introspect |
-| `skrift/config.py` | `AuthConfig`, `SkriftProviderConfig`, `oauth2_enabled` |
+| `skrift/controllers/oauth2.py` | OAuth2Controller — authorize, token, userinfo, revoke, introspect, register, jwks |
+| `skrift/config.py` | `AuthConfig`, `SkriftProviderConfig`, `oauth2_enabled`, `oauth2_dynamic_registration_enabled`, `oauth2_issuer`, `oauth2_access_token_ttl`, `oauth2_allowed_resources` |
 | `skrift/db/models/user.py` | `User` model |
 | `skrift/db/models/oauth_account.py` | `OAuthAccount` model |
 | `skrift/db/models/oauth2_client.py` | `OAuth2Client` model |
+| `skrift/db/models/oauth2_consent_grant.py` | `ConsentGrant` model (remembered consent) |
+| `skrift/db/models/oauth2_signing_key.py` | `OAuth2SigningKey` model (rotating ES256 keys) |
 | `skrift/db/models/revoked_token.py` | `RevokedToken` model |
 | `skrift/db/services/oauth2_service.py` | Client CRUD, revocation |
+| `skrift/db/services/oauth2_consent_service.py` | Remembered-consent CRUD + client-delete cascade |
+| `skrift/db/services/oauth2_signing_key_service.py` | Signing-key lifecycle (`rotate`, `prune_expired`) |
 | `skrift/admin/oauth2_clients.py` | Admin UI for OAuth2 clients |
 | `skrift/setup/providers.py` | `OAuthProviderInfo` definitions |

--- a/docs/guides/agent-object-processing.md
+++ b/docs/guides/agent-object-processing.md
@@ -96,9 +96,9 @@ decision = await chat.send_typed(
 
 ## Queued typed turns
 
-If a typed send arrives while another turn is running, Skrift stores the message, output type, model override, reasoning level, and other turn kwargs with the pending turn. When that turn activates, the stored configuration is decoded and passed to Pydantic AI.
+If a typed send arrives while another turn is running, Skrift stores the message, output type, model override, reasoning level, `deps_ref`, and other turn kwargs with the pending turn. When that turn activates, the stored configuration is decoded and passed to Pydantic AI.
 
-This matters for multi-step object processing because a queued turn can safely request a different output type or model from the active turn.
+This matters for multi-step object processing because a queued turn can safely request a different output type, model, or `deps_ref` from the active turn. A per-turn `deps_ref` follows replace-when-provided semantics — `None` keeps the stored reference, any dict replaces it — and is applied only when that turn activates, so the in-flight turn keeps the `deps_ref` it started with. Changing the stored reference emits a `DepsRefUpdated` audit event.
 
 Most server handlers should still await each send in order. If your UI deliberately allows multiple pending requests for the same chat key, Skrift stores each turn's output type and turn kwargs with that pending message before activation.
 

--- a/docs/guides/agents.md
+++ b/docs/guides/agents.md
@@ -193,6 +193,24 @@ assistant = skrift.Agent(
 )
 ```
 
+Passing `deps_ref` for an agent that has no `deps_factory` raises `AgentSessionError` on `Agent.run()`, `Session.send()`, and the chat sends, because the reference would be silently ignored.
+
+### Updating `deps_ref` across turns
+
+`deps_ref` is not frozen at session creation. Every send may carry a fresh `deps_ref`, and the semantics are **replace-when-provided**:
+
+- `deps_ref=None` (the default) leaves the session's stored `deps_ref` unchanged.
+- Any dict — including an empty `{}` — replaces the stored `deps_ref` for the turn it is submitted with and every turn after it. There is no merging.
+
+The new reference is applied to durable state at the moment the turn it rode in on **activates**, never earlier. Each queued turn therefore runs with the `deps_ref` it was submitted with, even when several sends are in flight at once:
+
+- Two rapid sends each keep their own `deps_ref`; the second does not overwrite the first turn before it runs.
+- A send that arrives while a turn is mid-flight (for example `awaiting_approval`) does not change the in-flight turn's deps when it resumes. The in-flight turn finishes with its original `deps_ref`, and the queued turn activates with the new one.
+
+When a turn activates with a `deps_ref` that differs from the stored value, the runtime appends a `DepsRefUpdated` audit event carrying the new `deps_ref`, the `turn_id`, and the actor. No event is emitted when the provided `deps_ref` equals the stored one.
+
+For chat, `Chat(..., deps_ref=...)` is passed on every turn — not just the first — so a chat reconstructed with a fresh `deps_ref` under the same key updates the session going forward. A per-call `chat.send(..., deps_ref=...)` or `chat.send_typed(..., deps_ref=...)` overrides the constructor default for that turn.
+
 ## Resume model
 
 Skrift resumes agents from committed durable boundaries:
@@ -202,6 +220,6 @@ Skrift resumes agents from committed durable boundaries:
 - approval decisions
 - queued user turns
 - stored run kwargs
-- `deps_ref`
+- `deps_ref` (as last replaced by an activated turn)
 
 The runtime does not try to resume from arbitrary internal Pydantic AI graph nodes. That avoids repeating model calls or tool work from an unsafe mid-step checkpoint.

--- a/docs/guides/pydantic-ai-agents.md
+++ b/docs/guides/pydantic-ai-agents.md
@@ -95,6 +95,17 @@ chat = assistant.chat(
 )
 ```
 
+`deps_ref` is not fixed at session creation. The constructor value is re-sent on every turn, and any send may supply a fresh reference. The semantics are replace-when-provided: `deps_ref=None` leaves the stored reference unchanged, and any dict (including `{}`) replaces it — no merging. The new reference takes effect when the turn it was submitted with activates, so each queued turn runs with its own `deps_ref` even when several sends overlap. A per-call override wins over the constructor default:
+
+```python
+reply = await chat.send(
+    "Now act on behalf of a different tenant.",
+    deps_ref={"tenant_id": other_tenant.id},
+)
+```
+
+Passing `deps_ref` to an agent that has no `deps_factory` raises `AgentSessionError`. Each turn that changes the stored reference emits a `DepsRefUpdated` audit event.
+
 ## Run kwargs
 
 Skrift forwards common Pydantic AI run kwargs through durable state:

--- a/docs/reference/agents.md
+++ b/docs/reference/agents.md
@@ -81,7 +81,7 @@ Creates a high-level chat facade for a stable conversation key.
 | --- | --- |
 | `key` | Stable application conversation key. The same key reuses the same durable session. |
 | `actor` | Optional default actor for audit events. May be a string, dict, or `Actor`. |
-| `deps_ref` | Serializable dependency reference passed to `deps_factory`. |
+| `deps_ref` | Serializable dependency reference passed to `deps_factory`. Re-sent on every turn (not just the first), and any dict replaces the session's stored reference. A per-call `send()`/`send_typed()` `deps_ref` overrides this default. |
 | `**defaults` | Default turn kwargs applied to `send()` and `send_typed()`. |
 
 ### `Agent.run()`
@@ -104,7 +104,7 @@ Starts a low-level durable run and returns `Session`.
 | `dispatch` | `"queued"`, `"inline"`, `"inline_then_queued"`, or `"same_worker"`. `"inline"` and `"same_worker"` start immediately in the caller process and resume inline on approval; `"inline_then_queued"` starts immediately but resumes through the normal queue; `"queued"` uses the normal agent queue from the start. |
 | `session_id` | Optional explicit durable session id. Raises `AgentSessionError` if it already exists. |
 | `actor` | Actor written to audit events. |
-| `deps_ref` | Serializable dependency reference. |
+| `deps_ref` | Serializable dependency reference stored on the new session. Raises `AgentSessionError` if the agent has no `deps_factory`. |
 | `parent_session_id` / `root_session_id` | Optional lineage overrides for sub-agent workflows. |
 | `**kwargs` | Pydantic AI run kwargs plus Skrift `reasoning`. |
 
@@ -137,8 +137,11 @@ Supported turn kwargs include:
 - `capabilities`
 - `spec`
 - `reasoning`
+- `deps_ref`
 
 `reasoning` may be a string or `ReasoningLevel`. Skrift maps it to `model_settings["thinking"]` and stores it in metadata as `skrift_reasoning`.
+
+`deps_ref` overrides the `Chat` constructor default for this turn only. It follows replace-when-provided semantics: `None` keeps the session's stored reference, any dict (including `{}`) replaces it. The change takes effect when this turn activates, so overlapping turns each run with their own reference, and a changed reference emits a `DepsRefUpdated` audit event.
 
 ### `Chat.send_typed()`
 
@@ -159,6 +162,7 @@ Takes a string and returns the requested output type.
 | `actor` | Optional actor override for this turn. |
 | `model` | Optional model override for this turn. |
 | `reasoning` | Optional string or `ReasoningLevel`. |
+| `deps_ref` | Optional per-turn dependency reference. `None` keeps the stored reference; any dict replaces it when this turn activates. Overrides the `Chat` constructor default. |
 | `**kwargs` | Additional Pydantic AI run kwargs. |
 
 ### `Chat.status()`
@@ -195,7 +199,7 @@ Low-level durable run handle.
 | `status()` | Return current status. |
 | `messages()` | Return raw durable message records. |
 | `lineage()` | Return parent/root session ids. |
-| `send(message, **kwargs)` | Record a new user turn and return its `turn_id`. |
+| `send(message, deps_ref=None, **kwargs)` | Record a new user turn and return its `turn_id`. A `deps_ref` dict replaces the session's stored reference when the turn activates (`None` leaves it unchanged); passing one for an agent without a `deps_factory` raises `AgentSessionError`. |
 | `result(turn_id=None)` | Wait for session output or a specific turn output. |
 | `pause()` | Pause a queued/running/approval session. |
 | `resume()` | Resume a paused session. |
@@ -308,7 +312,7 @@ Passed to `deps_factory`.
 | `session_id` | Durable session id. |
 | `tool_call_id` | Current tool call id when relevant. |
 | `actor` | Actor associated with the resume context. |
-| `deps_ref` | Serializable dependency reference supplied at chat/run creation. |
+| `deps_ref` | Serializable dependency reference for the active turn — the value most recently supplied by a send, or the creation value if no later turn replaced it. |
 | `metadata` | Runtime metadata, including worker job id when running in a worker. |
 
 ## Audit and Replay
@@ -324,6 +328,8 @@ audit = await skrift.audit_export(session_id, include_lineage=True)
 - `usage_totals`: aggregate usage across exported records.
 
 Tool events may include `payload.display` when a tool display formatter is configured. The raw audit fields remain present.
+
+When a turn activates with a `deps_ref` that differs from the session's stored reference, the export includes a `DepsRefUpdated` event carrying the new `deps_ref`, the `turn_id`, and the actor. Turns that reuse the stored reference emit no such event.
 
 ## Usage Tracking
 

--- a/docs/reference/mcp-identity-provider.md
+++ b/docs/reference/mcp-identity-provider.md
@@ -53,6 +53,7 @@ oauth2_allowed_resources:                 # allowlist of canonical resource iden
 | `oauth2_allowed_resources` | `[]` | RFC 8707 resource allowlist; empty allows any absolute URI |
 | `oauth2_dynamic_registration_ip_limit` | `20` | Max dynamic registrations per IP per window |
 | `oauth2_dynamic_registration_ip_window_seconds` | `3600` | Registration rate-limit window |
+| `oauth2_dynamic_registration_total_limit` | `1000` | Hard cap on total dynamically-registered clients |
 | `oauth2_dynamic_client_max_age_days` | `7` | Unused dynamic clients are pruned after this age |
 
 !!! warning "Set a stable issuer in production"

--- a/docs/reference/mcp-identity-provider.md
+++ b/docs/reference/mcp-identity-provider.md
@@ -1,0 +1,248 @@
+# MCP Identity Provider
+
+Skrift's [OAuth2 Authorization Server](oauth2-server.md) doubles as an identity provider for [Model Context Protocol](https://modelcontextprotocol.io) (MCP) resource servers — including **Claude custom connectors**. A connector runs the standard Authorization Code + PKCE flow against Skrift, self-registers through Dynamic Client Registration, and receives an **ES256 JWT access token** that any downstream MCP resource server can verify offline against Skrift's published JWKS.
+
+This page covers the pieces specific to the MCP use case: enabling the server for connectors, the audience naming convention, signing-key rotation, remembered consent, and a worked downstream resource-server example. For the endpoint reference and hub/spoke federation, see [OAuth2 Server](oauth2-server.md).
+
+## Architecture
+
+```
+Claude custom connector          Skrift (Authorization Server)      MCP resource server
+        │                                    │                              │
+        │  POST /oauth/register  ───────────►│  (Dynamic Client Reg.)       │
+        │◄───────────── client_id ───────────│                              │
+        │                                    │                              │
+        │  /oauth/authorize (PKCE) ─────────►│  login + consent             │
+        │◄───────────── code ────────────────│                              │
+        │  POST /oauth/token ───────────────►│  issue ES256 JWT access token│
+        │◄───────────── access_token ────────│                              │
+        │                                    │                              │
+        │  MCP request + Bearer <JWT>  ──────┼─────────────────────────────►│
+        │                                    │   verify via GET /oauth/jwks ◄┤
+        │◄─────────────── MCP response ──────┼──────────────────────────────│
+```
+
+The connector and the resource server can be the same deployment or separate ones. The trust anchor between them is Skrift's JWKS endpoint plus the token's `iss` and `aud` claims.
+
+## Enabling the Server for Connectors
+
+Two flags in `app.yaml`:
+
+```yaml
+oauth2_enabled: true                     # registers the OAuth2 endpoints
+oauth2_dynamic_registration_enabled: true  # opens POST /oauth/register
+```
+
+`oauth2_dynamic_registration_enabled` is gated on top of `oauth2_enabled`; the registration endpoint returns `404` while it is `false`. Enable it only when you want machine clients such as Claude connectors to self-register.
+
+Recommended companion settings:
+
+```yaml
+oauth2_issuer: "https://id.example.com"   # stable issuer baked into every token's `iss`
+oauth2_access_token_ttl: 900              # access-token lifetime in seconds (default 15 min)
+oauth2_allowed_resources:                 # allowlist of canonical resource identifiers
+  - "https://app.example.com/mcp"
+```
+
+| Setting | Default | Purpose |
+|---------|---------|---------|
+| `oauth2_enabled` | `false` | Registers the OAuth2 Authorization Server endpoints |
+| `oauth2_dynamic_registration_enabled` | `false` | Opens `POST /oauth/register` (RFC 7591) |
+| `oauth2_issuer` | `""` | Issuer (`iss`) claim; empty falls back to the request base URL |
+| `oauth2_access_token_ttl` | `900` | Access-token lifetime in seconds |
+| `oauth2_allowed_resources` | `[]` | RFC 8707 resource allowlist; empty allows any absolute URI |
+| `oauth2_dynamic_registration_ip_limit` | `20` | Max dynamic registrations per IP per window |
+| `oauth2_dynamic_registration_ip_window_seconds` | `3600` | Registration rate-limit window |
+| `oauth2_dynamic_client_max_age_days` | `7` | Unused dynamic clients are pruned after this age |
+
+!!! warning "Set a stable issuer in production"
+    Downstream resource servers verify the `iss` claim against a configured value. If `oauth2_issuer` is left empty, `iss` is derived from the incoming request's base URL, which can vary behind proxies or across hostnames and will break verification. Always pin `oauth2_issuer` for any deployment that issues tokens to resource servers.
+
+### Registering a Claude custom connector
+
+When you point a Claude custom connector at `https://id.example.com`, it discovers the endpoints from `/.well-known/oauth-authorization-server` and self-registers:
+
+```http
+POST /oauth/register
+Content-Type: application/json
+
+{
+  "client_name": "Claude",
+  "redirect_uris": ["https://claude.ai/api/mcp/auth_callback"],
+  "token_endpoint_auth_method": "none",
+  "grant_types": ["authorization_code", "refresh_token"],
+  "response_types": ["code"],
+  "scope": "openid profile email"
+}
+```
+
+Dynamic clients are always **public** (`token_endpoint_auth_method` must be `none`) and authenticate with PKCE alone. Redirect URIs must be `https` (loopback `http://127.0.0.1` / `http://localhost` is the only exception). The connector then runs the ordinary authorize/token flow described in [OAuth2 Server](oauth2-server.md).
+
+## Audience Naming Convention
+
+An MCP access token should name the resource server it is meant for so that server can reject tokens minted for anyone else. Skrift implements this with the RFC 8707 `resource` indicator, which becomes the JWT `aud` claim.
+
+**Use the resource server's canonical resource identifier as the audience** — the stable, absolute HTTPS URL of the MCP endpoint, with no fragment and no trailing slash:
+
+```
+https://app.example.com/mcp
+```
+
+The connector passes it as `resource` on both the authorize and token requests:
+
+```
+GET /oauth/authorize?...&resource=https://app.example.com/mcp
+POST /oauth/token       ...&resource=https://app.example.com/mcp
+```
+
+Skrift validates the value against `oauth2_allowed_resources` (when configured) and stamps it into the token's `aud`. Rules:
+
+- The audience is a **canonical resource identifier**, not a random string — the resource server compares the token's `aud` to its own identity.
+- Keep it **absolute and fragment-free**; Skrift rejects relative or fragment-bearing resources with `invalid_target`.
+- A token-endpoint `resource` may **narrow** but never **widen** the grant: it must equal the value authorized at `/oauth/authorize` (or restrict an otherwise unrestricted grant).
+- Populate `oauth2_allowed_resources` with the exact identifiers you recognize so a client cannot request a token for an arbitrary audience.
+
+A token minted for `https://app.example.com/mcp` carries `"aud": "https://app.example.com/mcp"`. The resource server MUST verify that its own identifier appears in `aud` (see the worked example below).
+
+## Access-Token Format and JWKS
+
+Access tokens are **ES256 JWTs** (RFC 9068 `at+jwt` profile) signed by a rotating EC P-256 key. Authorization codes and refresh tokens stay HMAC-signed and never leave the client↔server exchange. An access-token JWT carries:
+
+| Claim | Meaning |
+|-------|---------|
+| `iss` | The issuer (`oauth2_issuer` or request base URL) |
+| `sub` | The Skrift user id (UUID) |
+| `aud` | The resource identifier, when a `resource` was requested |
+| `client_id` | The client the token was issued to |
+| `scope` | Space-separated granted scopes |
+| `iat` / `exp` | Issued-at / expiry |
+| `jti` | Unique id, used for revocation checks |
+
+Public keys are published at `GET /oauth/jwks`. Resource servers fetch and cache this JWKS to verify token signatures offline — no network round-trip to Skrift per request. The active key signs new tokens; retired keys stay published until every token they signed has expired.
+
+## Signing-Key Rotation
+
+Rotation lives in `skrift.db.services.oauth2_signing_key_service`:
+
+| Function | Effect |
+|----------|--------|
+| `get_or_create_active_key(db_session)` | Returns the active signing key, generating the first one on demand |
+| `rotate(db_session)` | Generates a fresh key, marks it active, and retires the previous one (kept in the JWKS until it ages out) |
+| `list_jwks_keys(db_session)` | Public JWKs for every still-published key — what `/oauth/jwks` serves |
+| `prune_expired(db_session, now, access_token_ttl, clock_skew)` | Deletes retired keys older than `retired_at + access_token_ttl + clock_skew`, once no live token could still be signed by them |
+
+A first key is created automatically the first time a token is minted or `/oauth/jwks` is requested, so no setup is required to start issuing tokens.
+
+To rotate on a schedule, run `rotate` then `prune_expired` from a maintenance task, mirroring the dynamic-client pruning worker in `skrift/oauth2_maintenance.py`:
+
+```python
+from datetime import datetime, timezone
+
+from skrift.db.services import oauth2_signing_key_service
+
+
+async def rotate_signing_keys(session_maker, *, access_token_ttl: int) -> None:
+    async with session_maker() as db_session:
+        await oauth2_signing_key_service.rotate(db_session)
+        await oauth2_signing_key_service.prune_expired(
+            db_session,
+            now=datetime.now(tz=timezone.utc),
+            access_token_ttl=access_token_ttl,
+            clock_skew=60,
+        )
+```
+
+Rotation is safe while tokens are live: because retired keys remain in the JWKS until they age past the access-token lifetime, any token signed just before a rotation still verifies until it expires. Rotate on a cadence longer than `oauth2_access_token_ttl` (e.g. daily or weekly), and rotate immediately if a signing key is ever suspected compromised — followed by revoking outstanding tokens.
+
+## Remembered Consent
+
+Once a user approves a client's scopes, Skrift records the grant (`ConsentGrant`, keyed uniquely on user + client). On the next `/oauth/authorize` request from the same user for that client:
+
+- If the stored grant **covers every requested scope**, the consent screen is skipped and the authorization code is issued directly — PKCE and the resource indicator are still bound to the code.
+- If the request asks for **scopes beyond** the grant, the consent screen is shown again to approve the wider set. Approving it **widens** the stored grant (scopes are unioned, never dropped).
+
+This makes reconnecting a Claude connector a one-click (or zero-click) experience after the first authorization, without weakening scope enforcement.
+
+Grants are removed automatically when their client is deleted — both the admin delete action and the dynamic-client pruning sweep cascade to the client's consent grants. A grant can also be revoked programmatically:
+
+```python
+from skrift.db.services import oauth2_consent_service
+
+await oauth2_consent_service.revoke_grant(db_session, user_id, client_id)
+```
+
+## Downstream Resource Server
+
+A resource server (your MCP endpoint) does two things: advertise where its authorization server lives, and reject requests that don't carry a valid, correctly-audienced token.
+
+### 1. Protected-resource metadata
+
+Publish [RFC 9728](https://www.rfc-editor.org/rfc/rfc9728) metadata so clients can discover the authorization server from a `401`:
+
+```http
+GET /.well-known/oauth-protected-resource
+
+200 OK
+Content-Type: application/json
+
+{
+  "resource": "https://app.example.com/mcp",
+  "authorization_servers": ["https://id.example.com"],
+  "scopes_supported": ["openid", "profile", "email"],
+  "bearer_methods_supported": ["header"]
+}
+```
+
+`resource` is the canonical identifier used as the token `aud`; `authorization_servers` points at the Skrift issuer, whose `/.well-known/oauth-authorization-server` the client reads to find the authorize, token, register, and JWKS endpoints.
+
+### 2. Challenge unauthenticated requests
+
+An MCP request with no (or a bad) token gets a `401` whose `WWW-Authenticate` header points at the metadata, per RFC 9728:
+
+```http
+HTTP/1.1 401 Unauthorized
+WWW-Authenticate: Bearer resource_metadata="https://app.example.com/.well-known/oauth-protected-resource",
+                  error="invalid_token"
+```
+
+### 3. Verify the token with the Bearer guard
+
+When the resource server is itself a Skrift instance, protect routes with the reusable **Bearer JWT guard** (`skrift.auth.bearer`). List the marker in a route's `guards`; it verifies the JWT against the JWKS, checks `iss`, `exp`, and that the configured audience appears in `aud`, enforces the required scopes, resolves `sub` to a `User`, and populates the same identity the session and API-key paths use — so `Permission()` / `Role()` guards compose unchanged.
+
+```python
+from litestar import Controller, get
+
+from skrift.auth.bearer import BearerJWTAuth
+from skrift.auth.guards import auth_guard
+from skrift.auth.permissions import Permission
+
+
+class MCPResourceController(Controller):
+    path = "/mcp"
+
+    @get(
+        "/context",
+        guards=[
+            auth_guard,
+            BearerJWTAuth(audience="https://app.example.com/mcp", scopes=["profile"]),
+            Permission("read-context"),
+        ],
+    )
+    async def context(self) -> dict:
+        return {"ok": True}
+```
+
+Failure modes are fail-closed and return `401`:
+
+- Missing / expired / tampered token, or wrong `aud` / `iss` → `WWW-Authenticate: Bearer error="invalid_token"`.
+- Valid token missing a required scope → `WWW-Authenticate: Bearer error="insufficient_scope"`.
+
+The guard distinguishes a JWT (three dot-separated segments) from an API key (`sk_` prefix), so a JWT never satisfies an API-key-only route and vice-versa.
+
+For a non-Skrift resource server, verify tokens with any JOSE library: fetch `https://id.example.com/oauth/jwks`, verify the ES256 signature by `kid`, and assert `iss == "https://id.example.com"`, `exp` is in the future, and your resource identifier is in `aud`.
+
+## See Also
+
+- [OAuth2 Server](oauth2-server.md) — full endpoint reference, scopes, hub/spoke federation
+- [Auth Providers](auth-providers.md) — configuring Skrift as an OAuth client
+- [API Keys](api-keys.md) — the other Bearer scheme (`sk_` keys) the guard understands

--- a/docs/reference/oauth2-server.md
+++ b/docs/reference/oauth2-server.md
@@ -2,6 +2,9 @@
 
 Skrift can act as an OAuth2 Authorization Server, allowing other applications (including other Skrift instances) to authenticate users via the Authorization Code grant with PKCE.
 
+!!! tip "Using Skrift with Claude custom connectors / MCP"
+    This page is the endpoint reference. For turning the server into an identity provider for MCP resource servers and Claude custom connectors — Dynamic Client Registration, the audience naming convention, signing-key rotation, and a worked downstream resource-server example — see [MCP Identity Provider](mcp-identity-provider.md).
+
 ## Enabling the Server
 
 Add to your `app.yaml`:
@@ -44,7 +47,10 @@ Toggle the **Active** checkbox off. Inactive clients are rejected at all OAuth2 
 | `GET` | `/oauth/userinfo` | User claims — requires Bearer access token |
 | `POST` | `/oauth/revoke` | Token revocation (RFC 7009) |
 | `POST` | `/oauth/introspect` | Token introspection (RFC 7662) |
+| `POST` | `/oauth/register` | Dynamic Client Registration (RFC 7591) — when enabled |
+| `GET` | `/oauth/jwks` | JWK Set — public keys for access-token verification |
 | `GET` | `/.well-known/openid-configuration` | OIDC Discovery document |
+| `GET` | `/.well-known/oauth-authorization-server` | Authorization Server Metadata (RFC 8414) |
 
 ### Authorization (`GET /oauth/authorize`)
 
@@ -140,17 +146,23 @@ Custom scopes appear in the admin UI's scope checkboxes and are validated during
 
 ## Token Architecture
 
-Tokens are HMAC-SHA256 signed JSON payloads (not JWT). Each token contains:
+Access tokens are **ES256 JWTs** (RFC 9068 `at+jwt` profile) signed by a rotating EC P-256 key, so third-party resource servers can verify them offline against the public keys at `GET /oauth/jwks`. Authorization codes and refresh tokens stay **HMAC-SHA256** signed JSON payloads that never leave the client↔server exchange. Every token carries:
 
-- `type` — prevents cross-use (`code`, `access`, `refresh`)
+- `type` (HMAC tokens) — prevents cross-use (`code`, `refresh`)
 - `jti` — unique ID for revocation tracking
 - `exp` — expiration timestamp
 
-| Token | Lifetime |
-|-------|----------|
-| Authorization code | 10 minutes |
-| Access token | 15 minutes |
-| Refresh token | 30 days |
+Access-token JWTs additionally carry `iss`, `sub`, `client_id`, `scope`, and — when a `resource` was requested — `aud`. See [MCP Identity Provider](mcp-identity-provider.md) for the audience convention and JWKS verification.
+
+| Token | Lifetime | Signing |
+|-------|----------|---------|
+| Authorization code | 10 minutes | HMAC-SHA256 (`secret_key`) |
+| Access token | 15 minutes (`oauth2_access_token_ttl`) | ES256 JWT (rotating key) |
+| Refresh token | 30 days | HMAC-SHA256 (`secret_key`) |
+
+## Remembered Consent
+
+After a user approves a client's scopes, the grant is remembered (one per user + client). A later `/oauth/authorize` request from the same user for that client **skips the consent screen** and issues the code directly when the stored grant covers every requested scope; a request for broader scopes re-prompts and, on approval, widens the stored grant. Grants are deleted automatically when their client is deleted or pruned. See [MCP Identity Provider](mcp-identity-provider.md#remembered-consent) for details.
 
 ## PKCE
 
@@ -184,5 +196,6 @@ The spoke will redirect users to the hub for authentication and receive user dat
 
 ## See Also
 
+- [MCP Identity Provider](mcp-identity-provider.md) — Dynamic Client Registration, JWT access tokens, audience convention, signing-key rotation, downstream resource servers
 - [Auth Providers](auth-providers.md) — OAuth provider configuration (client side)
 - [Security Features](security-features.md) — CSRF, rate limiting, security headers

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -97,6 +97,7 @@ nav:
     - Page Types: reference/page-types.md
     - OAuth Providers: reference/auth-providers.md
     - OAuth2 Server: reference/oauth2-server.md
+    - MCP Identity Provider: reference/mcp-identity-provider.md
     - API Keys: reference/api-keys.md
     - API Permission Grants: reference/api-grants.md
     - Republishing: reference/republish.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "skrift"
-version = "0.2.0a12"
+version = "0.2.0a13"
 description = "A lightweight async Python CMS for crafting modern websites"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
     "mdit-py-plugins>=0.4.0",
     "pillow>=10.0.0",
     "aiosmtplib>=3.0.0",
+    "joserfc>=1.0.0",
 ]
 
 [project.scripts]

--- a/skrift/admin/oauth2_clients.py
+++ b/skrift/admin/oauth2_clients.py
@@ -192,6 +192,12 @@ class OAuth2ClientAdminController(Controller):
             flash_error(request, "Client not found")
             return Redirect(path="/admin/oauth-clients")
 
+        # Dynamically-registered clients are public by construction; issuing a
+        # secret would promote them to confidential, which DCR does not permit.
+        if client.is_dynamically_registered:
+            flash_error(request, "Dynamically registered clients are public and cannot be given a secret")
+            return Redirect(path=f"/admin/oauth-clients/{client_db_id}/edit")
+
         new_secret = await oauth2_service.regenerate_client_secret(db_session, client)
         request.session["new_secret"] = new_secret
         flash_success(request, f"Secret regenerated for '{client.display_name}'")

--- a/skrift/agents/agent.py
+++ b/skrift/agents/agent.py
@@ -380,6 +380,10 @@ class Agent:
                 f"Agent {self.skrift_name!r} uses deps_factory; pass durable "
                 "dependencies through deps_ref=..., not deps=."
             )
+        if deps_ref is not None and self.deps_factory is None:
+            raise AgentSessionError(
+                f"Agent {self.skrift_name!r} has no deps_factory; deps_ref would be ignored."
+            )
         run_kwargs = normalize_turn_kwargs(kwargs)
         inherited_parent_session_id = parent_session_id or current_session_id()
         inherited_root_session_id = root_session_id

--- a/skrift/agents/chat.py
+++ b/skrift/agents/chat.py
@@ -33,6 +33,7 @@ class Chat:
         actor: Any = None,
         model: Any = None,
         reasoning: str | Any | None = None,
+        deps_ref: dict[str, Any] | None = None,
         **kwargs: Any,
     ) -> str:
         """Send a chat message and return this turn's string reply."""
@@ -43,6 +44,7 @@ class Chat:
             actor=actor,
             model=model,
             reasoning=reasoning,
+            deps_ref=deps_ref,
             **kwargs,
         )
         return result if isinstance(result, str) else str(result)
@@ -55,13 +57,16 @@ class Chat:
         actor: Any = None,
         model: Any = None,
         reasoning: str | Any | None = None,
+        deps_ref: dict[str, Any] | None = None,
         **kwargs: Any,
     ) -> T:
         """Send a message and return this turn's typed output."""
 
         turn_kwargs = self._turn_kwargs(model=model, reasoning=reasoning, **kwargs)
         turn_kwargs["output_type"] = output_type
-        session, turn_id = await self._submit(message, actor=actor, turn_kwargs=turn_kwargs)
+        session, turn_id = await self._submit(
+            message, actor=actor, deps_ref=deps_ref, turn_kwargs=turn_kwargs
+        )
         return await session.result(turn_id=turn_id)
 
     async def status(self) -> str:
@@ -101,17 +106,19 @@ class Chat:
         message: str,
         *,
         actor: Any,
+        deps_ref: dict[str, Any] | None,
         turn_kwargs: dict[str, Any],
     ) -> tuple[Session, str]:
         session = await self._session_or_none()
         resolved_actor = actor if actor is not None else self.actor
+        resolved_deps_ref = deps_ref if deps_ref is not None else self.deps_ref
         if session is None:
             session_id = self._session_id()
             session = await self.agent.run(
                 message,
                 session_id=session_id,
                 actor=resolved_actor,
-                deps_ref=self.deps_ref,
+                deps_ref=resolved_deps_ref,
                 **turn_kwargs,
             )
             await self._store_chat_state(session.id)
@@ -119,7 +126,9 @@ class Chat:
             if state.current_turn_id is None:
                 raise RuntimeError("Agent run did not create a turn id")
             return session, state.current_turn_id
-        turn_id = await session.send(message, actor=resolved_actor, **turn_kwargs)
+        turn_id = await session.send(
+            message, actor=resolved_actor, deps_ref=resolved_deps_ref, **turn_kwargs
+        )
         await self._store_chat_state(session.id)
         return session, turn_id
 

--- a/skrift/agents/runtime.py
+++ b/skrift/agents/runtime.py
@@ -785,6 +785,19 @@ def _activate_next_pending_turn(runstate: Any) -> bool:
     runstate.messages.append(
         {"role": "user", "content": turn.get("message"), "turn_id": turn.get("turn_id")}
     )
+    turn_deps_ref = turn.get("deps_ref")
+    if turn_deps_ref is not None and turn_deps_ref != runstate.deps_ref:
+        runstate.deps_ref = dict(turn_deps_ref)
+        append_event(
+            runstate,
+            "DepsRefUpdated",
+            {
+                "deps_ref": dict(turn_deps_ref),
+                "turn_id": turn.get("turn_id"),
+                "actor": turn.get("actor"),
+                "updated_at": utcnow().isoformat(),
+            },
+        )
     runstate.status = "queued"
     runstate.terminal_at = None
     runstate.error = None

--- a/skrift/agents/session.py
+++ b/skrift/agents/session.py
@@ -67,6 +67,7 @@ class Session:
         message: Any,
         *,
         actor: Actor | dict | str | None = None,
+        deps_ref: dict[str, Any] | None = None,
         **kwargs: Any,
     ) -> str:
         resolved = resolve_actor(actor)
@@ -81,7 +82,26 @@ class Session:
                 f"Agent {state.agent_name!r} uses deps_factory; pass durable "
                 "dependencies through deps_ref=..., not deps=."
             )
+        if deps_ref is not None and definition.deps_factory is None:
+            raise AgentSessionError(
+                f"Agent {state.agent_name!r} has no deps_factory; deps_ref would be ignored."
+            )
         run_kwargs = normalize_turn_kwargs(kwargs)
+
+        def apply_deps_ref(state: RunState) -> None:
+            if deps_ref is None or deps_ref == state.deps_ref:
+                return
+            state.deps_ref = dict(deps_ref)
+            append_event(
+                state,
+                "DepsRefUpdated",
+                {
+                    "deps_ref": dict(deps_ref),
+                    "turn_id": turn_id,
+                    "actor": actor_payload(resolved),
+                    "updated_at": utcnow().isoformat(),
+                },
+            )
 
         async def mutate(state: RunState) -> RunState:
             queued_for_later = False
@@ -91,6 +111,7 @@ class Session:
                 "message": message,
                 "actor": actor_payload(resolved),
                 "run_kwargs": run_kwargs,
+                "deps_ref": dict(deps_ref) if deps_ref is not None else None,
                 "submitted_at": utcnow().isoformat(),
             }
             if state.status == "completed" or state.status in {"failed", "cancelled"}:
@@ -106,6 +127,7 @@ class Session:
                 state.paused_at = None
                 state.status_before_pause = None
                 state.run_kwargs = run_kwargs
+                apply_deps_ref(state)
                 submit_job_id = job_id
             else:
                 queued_for_later = True
@@ -144,6 +166,7 @@ class Session:
                         state.current_run_job_id = job_id
                         state.current_turn_id = turn_id
                         state.run_kwargs = run_kwargs
+                        apply_deps_ref(state)
                         submit_job_id = job_id
             append_event(
                 state,

--- a/skrift/alembic/versions/20260718_add_oauth2_signing_keys.py
+++ b/skrift/alembic/versions/20260718_add_oauth2_signing_keys.py
@@ -1,0 +1,51 @@
+"""Add oauth2_signing_keys table for asymmetric access-token signing.
+
+Stores the rotating EC P-256 key pairs used to sign OAuth2 access-token
+JWTs. The active key signs new tokens; retired keys stay published at the
+JWKS endpoint until they age past the access-token lifetime.
+
+Revision ID: a1c2e3f4b5d6
+Revises: 9f8e7d6c5b4a
+Create Date: 2026-07-18
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "a1c2e3f4b5d6"
+down_revision = "9f8e7d6c5b4a"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "oauth2_signing_keys",
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("kid", sa.String(64), nullable=False),
+        sa.Column("private_key_pem", sa.Text(), nullable=False),
+        sa.Column("algorithm", sa.String(16), nullable=False, server_default="ES256"),
+        sa.Column("is_active", sa.Boolean(), nullable=False, server_default=sa.text("true")),
+        sa.Column("retired_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.Column("sa_orm_sentinel", sa.Integer(), nullable=True),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "ix_oauth2_signing_keys_kid",
+        "oauth2_signing_keys",
+        ["kid"],
+        unique=True,
+    )
+    op.create_index(
+        "ix_oauth2_signing_keys_is_active",
+        "oauth2_signing_keys",
+        ["is_active"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_oauth2_signing_keys_is_active", table_name="oauth2_signing_keys")
+    op.drop_index("ix_oauth2_signing_keys_kid", table_name="oauth2_signing_keys")
+    op.drop_table("oauth2_signing_keys")

--- a/skrift/alembic/versions/20260719_add_oauth2_dynamic_registration.py
+++ b/skrift/alembic/versions/20260719_add_oauth2_dynamic_registration.py
@@ -1,0 +1,66 @@
+"""Add Dynamic Client Registration metadata to oauth2_clients.
+
+Adds the RFC 7591 columns used by POST /oauth/register: a flag marking a
+client as dynamically registered, its token-endpoint auth method, and the
+provenance/liveness timestamps the pruning job reads (issued-at, last-used,
+registering IP).
+
+Revision ID: b2d3e4f5a6c7
+Revises: a1c2e3f4b5d6
+Create Date: 2026-07-19
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "b2d3e4f5a6c7"
+down_revision = "a1c2e3f4b5d6"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "oauth2_clients",
+        sa.Column(
+            "is_dynamically_registered",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.false(),
+        ),
+    )
+    op.add_column(
+        "oauth2_clients",
+        sa.Column(
+            "token_endpoint_auth_method",
+            sa.String(64),
+            nullable=False,
+            server_default="client_secret_post",
+        ),
+    )
+    op.add_column(
+        "oauth2_clients",
+        sa.Column("last_used_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.add_column(
+        "oauth2_clients",
+        sa.Column("registered_by_ip", sa.String(45), nullable=True),
+    )
+    op.add_column(
+        "oauth2_clients",
+        sa.Column("client_id_issued_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.create_index(
+        "ix_oauth2_clients_registered_by_ip",
+        "oauth2_clients",
+        ["registered_by_ip"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_oauth2_clients_registered_by_ip", table_name="oauth2_clients")
+    op.drop_column("oauth2_clients", "client_id_issued_at")
+    op.drop_column("oauth2_clients", "registered_by_ip")
+    op.drop_column("oauth2_clients", "last_used_at")
+    op.drop_column("oauth2_clients", "token_endpoint_auth_method")
+    op.drop_column("oauth2_clients", "is_dynamically_registered")

--- a/skrift/alembic/versions/20260720_add_oauth2_consent_grants.py
+++ b/skrift/alembic/versions/20260720_add_oauth2_consent_grants.py
@@ -1,0 +1,49 @@
+"""Add oauth2_consent_grants table for remembered consent.
+
+Stores that a user has approved a set of scopes for an OAuth2 client so the
+``/oauth/authorize`` consent screen can be skipped when a later request stays
+within the granted scopes. One grant per (user, client); deleting a client
+cascades to its grants.
+
+Revision ID: c3e4f5a6b7d8
+Revises: b2d3e4f5a6c7
+Create Date: 2026-07-20
+"""
+
+from advanced_alchemy.types import GUID, DateTimeUTC
+from alembic import op
+import sqlalchemy as sa
+
+revision = "c3e4f5a6b7d8"
+down_revision = "b2d3e4f5a6c7"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "oauth2_consent_grants",
+        sa.Column("id", GUID(length=16), nullable=False),
+        sa.Column(
+            "user_id",
+            GUID(length=16),
+            sa.ForeignKey("users.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("client_id", sa.String(255), nullable=False),
+        sa.Column("scopes", sa.Text(), nullable=False, server_default=""),
+        sa.Column("granted_at", DateTimeUTC(timezone=True), nullable=False),
+        sa.Column("created_at", DateTimeUTC(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.Column("updated_at", DateTimeUTC(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.Column("sa_orm_sentinel", sa.Integer(), nullable=True),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("user_id", "client_id", name="uq_oauth2_consent_grants_user_client"),
+    )
+    op.create_index("ix_oauth2_consent_grants_user_id", "oauth2_consent_grants", ["user_id"])
+    op.create_index("ix_oauth2_consent_grants_client_id", "oauth2_consent_grants", ["client_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_oauth2_consent_grants_client_id", table_name="oauth2_consent_grants")
+    op.drop_index("ix_oauth2_consent_grants_user_id", table_name="oauth2_consent_grants")
+    op.drop_table("oauth2_consent_grants")

--- a/skrift/asgi.py
+++ b/skrift/asgi.py
@@ -1104,6 +1104,11 @@ def create_app() -> ASGIApp:
 
             configure_webhooks(settings.webhooks, session_maker=db_config.get_session)
 
+        if settings.oauth2_enabled and settings.oauth2_dynamic_registration_enabled:
+            from skrift.oauth2_maintenance import configure_oauth2_maintenance
+
+            configure_oauth2_maintenance(session_maker=db_config.get_session)
+
         if settings.workers.enabled:
             from skrift.agents.config import configure_agent_runtime
             from skrift.workers import configure_workers
@@ -1113,6 +1118,8 @@ def create_app() -> ASGIApp:
             configure_agent_runtime(settings.agents)
             if settings.webhooks.enabled:
                 import skrift.webhooks.jobs  # noqa: F401 - register built-in handlers
+            if settings.oauth2_enabled and settings.oauth2_dynamic_registration_enabled:
+                import skrift.oauth2_maintenance  # noqa: F401 - register prune handler
 
             worker_runtime = configure_workers(
                 mode=settings.workers.execution,

--- a/skrift/auth/__init__.py
+++ b/skrift/auth/__init__.py
@@ -1,5 +1,6 @@
 """Authentication and authorization module."""
 
+from skrift.auth.bearer import BearerJWTAuth, BearerJWTOnly
 from skrift.auth.guards import (
     ADMINISTRATOR_PERMISSION,
     AndRequirement,
@@ -77,6 +78,8 @@ __all__ = [
     "ADMINISTRATOR_PERMISSION",
     "AndRequirement",
     "AuthRequirement",
+    "BearerJWTAuth",
+    "BearerJWTOnly",
     "OrRequirement",
     "OwnerOrPermission",
     "Permission",

--- a/skrift/auth/bearer.py
+++ b/skrift/auth/bearer.py
@@ -1,0 +1,146 @@
+"""Bearer JWT route guards for OAuth2-protected resources.
+
+``BearerJWTAuth``/``BearerJWTOnly`` are marker guards (the same pattern as
+``APIKeyAuth``/``APIKeyOnly`` in :mod:`skrift.auth.guards`): listing one on a
+route switches ``auth_guard`` into accepting ES256 access-token JWTs minted
+by the OAuth2 Authorization Server. The two bearer schemes share the
+``Authorization`` header, so routing is disambiguated by shape — API keys are
+``sk_``-prefixed, a compact JWS has exactly three dot-separated segments.
+
+Verification is fail-closed: signature (against the signing-key JWKS),
+``iss``, ``exp``, audience membership in ``aud``, ``jti`` revocation, required
+scopes, and an existing active subject are all enforced before the request is
+granted the user's permissions.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from uuid import UUID
+
+from litestar.connection import ASGIConnection
+from litestar.exceptions import NotAuthorizedException
+
+from skrift.auth.guards import AuthRequirement
+from skrift.auth.jwt_tokens import verify_access_token_jwt
+from skrift.auth.services import get_user_permissions
+from skrift.config import get_settings
+from skrift.db.models.user import User
+from skrift.db.services import oauth2_service, oauth2_signing_key_service
+
+if TYPE_CHECKING:
+    from skrift.auth.services import UserPermissions
+
+
+class BearerJWTAuth(AuthRequirement):
+    """Marker guard: route accepts session auth and OAuth2 JWT bearer tokens.
+
+    ``audience`` is the canonical resource identifier this route serves
+    (e.g. ``https://app.example.com/mcp``); only tokens carrying it in
+    ``aud`` are accepted. ``scopes`` lists OAuth2 scopes the token must have
+    been granted.
+
+    Usage::
+
+        @get("/mcp/pages", guards=[auth_guard, BearerJWTAuth(audience="https://app.example.com/mcp", scopes=["mcp"]), Permission("manage-pages")])
+        async def list_pages(self): ...
+    """
+
+    def __init__(self, audience: str, scopes: list[str] | None = None):
+        self.audience = audience
+        self.required_scopes = list(scopes) if scopes else []
+
+    async def check(self, permissions: "UserPermissions") -> bool:
+        return True  # Marker only — actual verification happens in auth_guard
+
+
+class BearerJWTOnly(BearerJWTAuth):
+    """Marker guard: route accepts ONLY JWT bearer authentication (no session).
+
+    Usage::
+
+        @post("/mcp/sync", guards=[auth_guard, BearerJWTOnly(audience="https://app.example.com/mcp")])
+        async def sync(self): ...
+    """
+
+
+def is_jwt_shaped(token: str) -> bool:
+    """Whether a bearer token is a compact JWS rather than an API key.
+
+    API keys are ``sk_``-prefixed and take precedence; a compact JWS is
+    exactly three dot-separated segments. This is the single routing rule
+    keeping the two bearer schemes from colliding.
+    """
+    return not token.startswith("sk_") and token.count(".") == 2
+
+
+def _invalid_token_error(description: str) -> NotAuthorizedException:
+    return NotAuthorizedException(
+        description,
+        headers={"WWW-Authenticate": 'Bearer error="invalid_token"'},
+    )
+
+
+def _insufficient_scope_error(required_scopes: list[str]) -> NotAuthorizedException:
+    scope_value = " ".join(required_scopes)
+    return NotAuthorizedException(
+        "Insufficient scope",
+        headers={"WWW-Authenticate": f'Bearer error="insufficient_scope", scope="{scope_value}"'},
+    )
+
+
+def missing_bearer_error() -> NotAuthorizedException:
+    """The RFC 6750 challenge for a protected route with no usable bearer."""
+    return NotAuthorizedException(
+        "Authentication required",
+        headers={"WWW-Authenticate": "Bearer"},
+    )
+
+
+async def resolve_bearer_jwt_permissions(
+    connection: ASGIConnection,
+    token: str,
+    marker: BearerJWTAuth,
+) -> tuple[str, "UserPermissions"]:
+    """Verify a JWT bearer token and resolve its subject's permissions.
+
+    Returns ``(user_id, permissions)`` so JWT-authenticated requests carry
+    the same :class:`UserPermissions` identity as the session and API-key
+    paths, letting ``Permission()``/``Role()`` guards compose unchanged.
+    Raises :class:`NotAuthorizedException` (fail closed) on any failure.
+    """
+    settings = get_settings()
+    issuer = settings.oauth2_issuer or str(connection.base_url).rstrip("/")
+
+    session_maker = connection.app.state.session_maker_class
+    async with session_maker() as db_session:
+        jwks = await oauth2_signing_key_service.list_jwks_keys(db_session)
+        if not jwks:
+            raise _invalid_token_error("No signing keys published")
+
+        claims = verify_access_token_jwt(
+            token, jwks=jwks, issuer=issuer, audience=marker.audience
+        )
+        if claims is None:
+            raise _invalid_token_error("Invalid or expired access token")
+
+        jti = claims.get("jti", "")
+        if jti and await oauth2_service.is_token_revoked(db_session, jti):
+            raise _invalid_token_error("Access token has been revoked")
+
+        granted_scopes = set(claims.get("scope", "").split())
+        if any(scope not in granted_scopes for scope in marker.required_scopes):
+            raise _insufficient_scope_error(marker.required_scopes)
+
+        subject = claims.get("sub", "")
+        try:
+            subject_uuid = UUID(subject)
+        except (ValueError, TypeError):
+            raise _invalid_token_error("Token subject is not a known user") from None
+
+        user = await db_session.get(User, subject_uuid)
+        if user is None or not user.is_active:
+            raise _invalid_token_error("Token subject is not a known user")
+
+        permissions = await get_user_permissions(db_session, subject)
+        return subject, permissions

--- a/skrift/auth/guards.py
+++ b/skrift/auth/guards.py
@@ -216,8 +216,17 @@ async def auth_guard(
     """Litestar guard that checks authentication and authorization requirements.
 
     Supports session-based auth (default), API key auth (when ``APIKeyAuth``
-    or ``APIKeyOnly`` markers are present in the route guards), or both.
+    or ``APIKeyOnly`` markers are present in the route guards), OAuth2 JWT
+    bearer auth (when ``BearerJWTAuth``/``BearerJWTOnly`` markers are
+    present), or any combination.
     """
+    from skrift.auth.bearer import (
+        BearerJWTAuth,
+        BearerJWTOnly,
+        is_jwt_shaped,
+        missing_bearer_error,
+        resolve_bearer_jwt_permissions,
+    )
     from skrift.auth.services import get_user_permissions
 
     # Get the guards from the route handler
@@ -226,18 +235,25 @@ async def auth_guard(
     # Determine auth mode from guard markers
     api_only = any(isinstance(g, APIKeyOnly) for g in guards)
     api_compatible = api_only or any(isinstance(g, APIKeyAuth) for g in guards)
+    jwt_marker = next((g for g in guards if isinstance(g, BearerJWTAuth)), None)
+    jwt_only = isinstance(jwt_marker, BearerJWTOnly)
 
     user_id: str | None = None
     permissions: UserPermissions | None = None
 
-    # Try API key auth if route supports it
-    if api_compatible:
-        bearer = _extract_bearer_token(connection)
-        if bearer and bearer.startswith("sk_"):
-            user_id, permissions = await _resolve_api_key_permissions(connection, bearer)
+    bearer = _extract_bearer_token(connection) if api_compatible or jwt_marker else None
 
-    # Fall back to session auth (unless API-only)
-    if not user_id and not api_only:
+    # Try API key auth if route supports it (``sk_`` bearers only)
+    if api_compatible and bearer and bearer.startswith("sk_"):
+        user_id, permissions = await _resolve_api_key_permissions(connection, bearer)
+
+    # Try JWT bearer auth if route supports it. A presented JWT must verify
+    # or the request fails — an invalid token never falls through to session.
+    if user_id is None and jwt_marker is not None and bearer and is_jwt_shaped(bearer):
+        user_id, permissions = await resolve_bearer_jwt_permissions(connection, bearer, jwt_marker)
+
+    # Fall back to session auth (unless the route is bearer-only)
+    if not user_id and not api_only and not jwt_only:
         user_id = connection.session.get(SESSION_USER_ID) if connection.session else None
         if user_id:
             session_maker = connection.app.state.session_maker_class
@@ -245,13 +261,15 @@ async def auth_guard(
                 permissions = await get_user_permissions(session, user_id)
 
     if not user_id or permissions is None:
+        if jwt_marker is not None:
+            raise missing_bearer_error()
         raise NotAuthorizedException("Authentication required")
 
     # Find AuthRequirement guards (exclude marker guards)
     auth_requirements = [
         g for g in guards
         if isinstance(g, AuthRequirement)
-        and not isinstance(g, (APIKeyAuth, APIKeyOnly))
+        and not isinstance(g, (APIKeyAuth, APIKeyOnly, BearerJWTAuth))
     ]
 
     if not auth_requirements:

--- a/skrift/auth/jwt_tokens.py
+++ b/skrift/auth/jwt_tokens.py
@@ -16,6 +16,7 @@ from joserfc.jwk import ECKey, KeySet
 from skrift.db.models.oauth2_signing_key import OAuth2SigningKey
 
 ACCESS_TOKEN_JWT_TYPE = "at+jwt"
+ACCEPTED_ACCESS_TOKEN_JWT_TYPES = frozenset({"at+jwt", "application/at+jwt"})
 SUPPORTED_ACCESS_TOKEN_ALGORITHMS = ["ES256"]
 
 
@@ -65,10 +66,13 @@ def verify_access_token_jwt(
 ) -> dict | None:
     """Verify an access-token JWT against a JWK set.
 
-    Validates the signature (selecting the JWKS key matching the token's
-    ``kid``), ``exp``, ``iss``, and — when ``audience`` is given — that it
-    appears in the token's ``aud``. Passing ``audience=None`` skips only the
-    audience check (used by userinfo/introspection, which serve any audience).
+    Validates the header ``typ`` (RFC 9068 §4 — anything but ``at+jwt`` is
+    rejected so other JWT kinds signed with the same key can never pass as
+    access tokens), the signature (selecting the JWKS key matching the
+    token's ``kid``), ``exp``, ``iss``, and — when ``audience`` is given —
+    that it appears in the token's ``aud``. Passing ``audience=None`` skips
+    only the audience check (used by userinfo/introspection, which serve any
+    audience).
 
     Returns the claims dict, or ``None`` on any failure (fail closed).
     """
@@ -76,6 +80,10 @@ def verify_access_token_jwt(
         key_set = KeySet.import_key_set({"keys": jwks})
         decoded = jwt.decode(token, key_set, algorithms=SUPPORTED_ACCESS_TOKEN_ALGORITHMS)
     except (JoseError, ValueError):
+        return None
+
+    declared_type = decoded.header.get("typ")
+    if not isinstance(declared_type, str) or declared_type.lower() not in ACCEPTED_ACCESS_TOKEN_JWT_TYPES:
         return None
 
     claims = decoded.claims

--- a/skrift/auth/jwt_tokens.py
+++ b/skrift/auth/jwt_tokens.py
@@ -1,0 +1,101 @@
+"""JWT access tokens for the OAuth2 Authorization Server.
+
+Access tokens are ES256 JWTs (RFC 9068 profile) signed by the rotating server
+key so third-party resource servers can verify them against the published
+JWKS. Authorization codes and refresh tokens stay HMAC — see
+``skrift.auth.tokens``.
+"""
+
+import time
+import uuid
+
+from joserfc import jwt
+from joserfc.errors import JoseError
+from joserfc.jwk import ECKey, KeySet
+
+from skrift.db.models.oauth2_signing_key import OAuth2SigningKey
+
+ACCESS_TOKEN_JWT_TYPE = "at+jwt"
+SUPPORTED_ACCESS_TOKEN_ALGORITHMS = ["ES256"]
+
+
+def create_access_token_jwt(
+    *,
+    subject: str,
+    client_id: str,
+    scope: str,
+    audience: str | None,
+    issuer: str,
+    signing_key: OAuth2SigningKey,
+    expires_in: int,
+) -> str:
+    """Mint a signed access-token JWT.
+
+    ``aud`` is set only when the grant carried an RFC 8707 resource; ``jti``
+    is kept so revocation checks against :class:`RevokedToken` still work.
+    """
+    issued_at = int(time.time())
+    claims: dict = {
+        "iss": issuer,
+        "sub": subject,
+        "client_id": client_id,
+        "scope": scope,
+        "iat": issued_at,
+        "exp": issued_at + expires_in,
+        "jti": uuid.uuid4().hex,
+    }
+    if audience:
+        claims["aud"] = audience
+
+    header = {
+        "alg": signing_key.algorithm,
+        "kid": signing_key.kid,
+        "typ": ACCESS_TOKEN_JWT_TYPE,
+    }
+    private_key = ECKey.import_key(signing_key.private_key_pem)
+    return jwt.encode(header, claims, private_key, algorithms=[signing_key.algorithm])
+
+
+def verify_access_token_jwt(
+    token: str,
+    *,
+    jwks: list[dict],
+    issuer: str,
+    audience: str | None,
+) -> dict | None:
+    """Verify an access-token JWT against a JWK set.
+
+    Validates the signature (selecting the JWKS key matching the token's
+    ``kid``), ``exp``, ``iss``, and — when ``audience`` is given — that it
+    appears in the token's ``aud``. Passing ``audience=None`` skips only the
+    audience check (used by userinfo/introspection, which serve any audience).
+
+    Returns the claims dict, or ``None`` on any failure (fail closed).
+    """
+    try:
+        key_set = KeySet.import_key_set({"keys": jwks})
+        decoded = jwt.decode(token, key_set, algorithms=SUPPORTED_ACCESS_TOKEN_ALGORITHMS)
+    except (JoseError, ValueError):
+        return None
+
+    claims = decoded.claims
+    if claims.get("iss") != issuer:
+        return None
+
+    expires_at = claims.get("exp")
+    if not isinstance(expires_at, (int, float)) or time.time() > expires_at:
+        return None
+
+    if audience is not None and audience not in _audience_values(claims.get("aud")):
+        return None
+
+    return claims
+
+
+def _audience_values(audience_claim) -> list[str]:
+    """Normalize an ``aud`` claim (string, list, or absent) to a list."""
+    if isinstance(audience_claim, str):
+        return [audience_claim]
+    if isinstance(audience_claim, list):
+        return [value for value in audience_claim if isinstance(value, str)]
+    return []

--- a/skrift/claude_skill/skrift-auth/SKILL.md
+++ b/skrift/claude_skill/skrift-auth/SKILL.md
@@ -169,7 +169,7 @@ User clicks "Login with Skrift"
 oauth2_enabled: true
 ```
 
-When enabled: `OAuth2Controller` is auto-registered, OAuth token endpoints are CSRF-exempt, `/.well-known/openid-configuration` is active, and admin shows "OAuth Clients" (requires `manage-oauth-clients` permission).
+When enabled: `OAuth2Controller` is auto-registered, OAuth token endpoints are CSRF-exempt, `/.well-known/openid-configuration` + `/.well-known/oauth-authorization-server` are active, and admin shows "OAuth Clients" (requires `manage-oauth-clients` permission). Add `oauth2_dynamic_registration_enabled: true` to open `POST /oauth/register` for machine clients (e.g. Claude custom connectors); it 404s otherwise.
 
 Clients are managed via admin UI at `/admin/oauth-clients`:
 
@@ -206,7 +206,10 @@ Multiple hubs: use the `provider` field to decouple key from type (see Provider 
 | `GET` | `/oauth/userinfo` | Scope-filtered user claims (Bearer token) |
 | `POST` | `/oauth/revoke` | Revoke a token (RFC 7009) |
 | `POST` | `/oauth/introspect` | Token introspection (RFC 7662, requires client auth) |
+| `POST` | `/oauth/register` | Dynamic Client Registration (RFC 7591) — gated by `oauth2_dynamic_registration_enabled` |
+| `GET` | `/oauth/jwks` | Public JWK Set for ES256 access-token verification |
 | `GET` | `/.well-known/openid-configuration` | OIDC Discovery |
+| `GET` | `/.well-known/oauth-authorization-server` | Authorization Server Metadata (RFC 8414) |
 
 ### Scope Registry
 
@@ -221,17 +224,25 @@ Scopes control authorization (validated against client's `allowed_scopes`) and c
 
 ### Token Architecture
 
-| Token | TTL | Payload includes |
-|-------|-----|-----------------|
-| Auth code | 10 min | user_id, email, name, client_id, redirect_uri, scope, code_challenge |
-| Access token | 15 min | user_id, email, name, client_id, scope |
-| Refresh token | 30 days | user_id, client_id, scope |
+| Token | TTL | Signing | Payload / claims |
+|-------|-----|---------|------------------|
+| Auth code | 10 min | HMAC-SHA256 (`secret_key`) | user_id, email, name, client_id, redirect_uri, scope, code_challenge, resource |
+| Access token | 15 min (`oauth2_access_token_ttl`) | ES256 JWT (rotating EC P-256 key) | iss, sub, client_id, scope, aud (when `resource` requested), iat, exp, jti |
+| Refresh token | 30 days | HMAC-SHA256 (`secret_key`) | user_id, client_id, scope, family_id, resource |
 
-All tokens are HMAC-SHA256 signed with `settings.secret_key`. Each includes a `jti` for revocation. Refresh token exchange performs rotation (old token revoked).
+Access tokens are **ES256 JWTs** (RFC 9068) verifiable offline against `GET /oauth/jwks`; codes and refresh tokens stay HMAC and never leave the client↔server exchange. HMAC tokens include a `jti` for revocation. Refresh exchange rotates (old token revoked; reuse of a rotated token mass-revokes its `family_id`). Signing keys rotate via `oauth2_signing_key_service.rotate()` / `prune_expired()`.
+
+### Remembered Consent
+
+`ConsentGrant` (unique per user + client) records approved scopes. `/oauth/authorize` skips the consent screen and issues a code directly when a stored grant covers all requested scopes; broader scopes re-prompt and widen the grant on approval. Grants cascade-delete when the client is deleted or pruned. Service: `skrift/db/services/oauth2_consent_service.py` (`find_grant`, `upsert_grant`, `revoke_grant`, `delete_grants_for_clients`).
 
 ### PKCE
 
-S256 only. **Required** for public clients (no `client_secret`), optional for confidential clients.
+S256 only. **Required** for all clients (OAuth 2.1); `plain` is rejected.
+
+### MCP / Bearer JWT guard
+
+Downstream MCP resource servers protect routes with `BearerJWTAuth(audience=..., scopes=[...])` from `skrift/auth/bearer.py`, listed in a route's `guards` alongside `auth_guard`. It verifies the JWT against the JWKS, checks `iss`/`exp`/`aud`, enforces scopes, and resolves `sub` to the same `UserPermissions` identity as the session/API-key paths (so `Permission()`/`Role()` compose). Fail-closed 401 with `WWW-Authenticate: Bearer error="invalid_token"` (or `insufficient_scope`). See `docs/reference/mcp-identity-provider.md`.
 
 ## Security Notes
 
@@ -247,16 +258,22 @@ S256 only. **Required** for public clients (no `client_secret`), optional for co
 |------|---------|
 | `skrift/auth/` | Guards, roles, permissions |
 | `skrift/auth/providers.py` | OAuth provider classes, `get_oauth_provider()`, dynamic import |
-| `skrift/auth/tokens.py` | `create_signed_token()` / `verify_signed_token()` |
+| `skrift/auth/tokens.py` | `create_signed_token()` / `verify_signed_token()` (HMAC codes/refresh) |
+| `skrift/auth/jwt_tokens.py` | `create_access_token_jwt()` / `verify_access_token_jwt()` (ES256 access tokens) |
+| `skrift/auth/bearer.py` | `BearerJWTAuth` guard marker for MCP resource servers |
 | `skrift/auth/scopes.py` | Scope registry |
 | `skrift/auth/oauth_account_service.py` | `find_or_create_oauth_user()` with token persistence |
 | `skrift/controllers/auth.py` | OAuth login/callback controller |
-| `skrift/controllers/oauth2.py` | OAuth2Controller — authorize, token, userinfo, revoke, introspect |
-| `skrift/config.py` | `AuthConfig`, `SkriftProviderConfig`, `oauth2_enabled` |
+| `skrift/controllers/oauth2.py` | OAuth2Controller — authorize, token, userinfo, revoke, introspect, register, jwks |
+| `skrift/config.py` | `AuthConfig`, `SkriftProviderConfig`, `oauth2_enabled`, `oauth2_dynamic_registration_enabled`, `oauth2_issuer`, `oauth2_access_token_ttl`, `oauth2_allowed_resources` |
 | `skrift/db/models/user.py` | `User` model |
 | `skrift/db/models/oauth_account.py` | `OAuthAccount` model |
 | `skrift/db/models/oauth2_client.py` | `OAuth2Client` model |
+| `skrift/db/models/oauth2_consent_grant.py` | `ConsentGrant` model (remembered consent) |
+| `skrift/db/models/oauth2_signing_key.py` | `OAuth2SigningKey` model (rotating ES256 keys) |
 | `skrift/db/models/revoked_token.py` | `RevokedToken` model |
 | `skrift/db/services/oauth2_service.py` | Client CRUD, revocation |
+| `skrift/db/services/oauth2_consent_service.py` | Remembered-consent CRUD + client-delete cascade |
+| `skrift/db/services/oauth2_signing_key_service.py` | Signing-key lifecycle (`rotate`, `prune_expired`) |
 | `skrift/admin/oauth2_clients.py` | Admin UI for OAuth2 clients |
 | `skrift/setup/providers.py` | `OAuthProviderInfo` definitions |

--- a/skrift/config.py
+++ b/skrift/config.py
@@ -181,6 +181,7 @@ _RESERVED_CONFIG_KEYS = frozenset(
         "oauth2_dynamic_registration_enabled",
         "oauth2_dynamic_registration_ip_limit",
         "oauth2_dynamic_registration_ip_window_seconds",
+        "oauth2_dynamic_registration_total_limit",
         "oauth2_dynamic_client_max_age_days",
         "controllers",
         "models",
@@ -1198,6 +1199,10 @@ class Settings(BaseSettings):
     oauth2_dynamic_registration_ip_limit: int = 20
     oauth2_dynamic_registration_ip_window_seconds: int = 3600
 
+    # Hard cap on the total number of dynamically-registered clients. The
+    # per-IP limit only bounds the registration rate; this bounds the table.
+    oauth2_dynamic_registration_total_limit: int = 1000
+
     # Dynamically registered clients that are never used are pruned once they
     # age past this many days (client_id_issued_at older, last_used_at IS NULL).
     oauth2_dynamic_client_max_age_days: int = 7
@@ -1372,6 +1377,11 @@ def get_settings() -> Settings:
     if "oauth2_dynamic_registration_ip_window_seconds" in app_config:
         kwargs["oauth2_dynamic_registration_ip_window_seconds"] = app_config[
             "oauth2_dynamic_registration_ip_window_seconds"
+        ]
+
+    if "oauth2_dynamic_registration_total_limit" in app_config:
+        kwargs["oauth2_dynamic_registration_total_limit"] = app_config[
+            "oauth2_dynamic_registration_total_limit"
         ]
 
     if "oauth2_dynamic_client_max_age_days" in app_config:

--- a/skrift/config.py
+++ b/skrift/config.py
@@ -175,6 +175,9 @@ _RESERVED_CONFIG_KEYS = frozenset(
         "domain",
         "security_contact",
         "oauth2_enabled",
+        "oauth2_issuer",
+        "oauth2_access_token_ttl",
+        "oauth2_allowed_resources",
         "controllers",
         "models",
         "middleware",
@@ -1173,6 +1176,15 @@ class Settings(BaseSettings):
     # OAuth2 Authorization Server enabled flag
     oauth2_enabled: bool = False
 
+    # OAuth2 access-token issuer; empty falls back to the request base URL
+    oauth2_issuer: str = ""
+
+    # OAuth2 access-token lifetime in seconds
+    oauth2_access_token_ttl: int = 900
+
+    # RFC 8707 resource allowlist; empty allows any valid absolute resource URI
+    oauth2_allowed_resources: list[str] = []
+
     # API key configuration
     api_keys: APIKeyConfig = APIKeyConfig()
 
@@ -1324,6 +1336,15 @@ def get_settings() -> Settings:
 
     if "oauth2_enabled" in app_config:
         kwargs["oauth2_enabled"] = app_config["oauth2_enabled"]
+
+    if "oauth2_issuer" in app_config:
+        kwargs["oauth2_issuer"] = app_config["oauth2_issuer"]
+
+    if "oauth2_access_token_ttl" in app_config:
+        kwargs["oauth2_access_token_ttl"] = app_config["oauth2_access_token_ttl"]
+
+    if "oauth2_allowed_resources" in app_config:
+        kwargs["oauth2_allowed_resources"] = list(app_config["oauth2_allowed_resources"])
 
     if "storage" in app_config:
         storage_data = app_config["storage"]

--- a/skrift/config.py
+++ b/skrift/config.py
@@ -178,6 +178,10 @@ _RESERVED_CONFIG_KEYS = frozenset(
         "oauth2_issuer",
         "oauth2_access_token_ttl",
         "oauth2_allowed_resources",
+        "oauth2_dynamic_registration_enabled",
+        "oauth2_dynamic_registration_ip_limit",
+        "oauth2_dynamic_registration_ip_window_seconds",
+        "oauth2_dynamic_client_max_age_days",
         "controllers",
         "models",
         "middleware",
@@ -1185,6 +1189,19 @@ class Settings(BaseSettings):
     # RFC 8707 resource allowlist; empty allows any valid absolute resource URI
     oauth2_allowed_resources: list[str] = []
 
+    # RFC 7591 Dynamic Client Registration (POST /oauth/register). Gated on top
+    # of oauth2_enabled; the registration endpoint 404s while this is False.
+    oauth2_dynamic_registration_enabled: bool = False
+
+    # Max dynamic registrations accepted from a single IP within the window
+    # below, and the window length in seconds.
+    oauth2_dynamic_registration_ip_limit: int = 20
+    oauth2_dynamic_registration_ip_window_seconds: int = 3600
+
+    # Dynamically registered clients that are never used are pruned once they
+    # age past this many days (client_id_issued_at older, last_used_at IS NULL).
+    oauth2_dynamic_client_max_age_days: int = 7
+
     # API key configuration
     api_keys: APIKeyConfig = APIKeyConfig()
 
@@ -1345,6 +1362,20 @@ def get_settings() -> Settings:
 
     if "oauth2_allowed_resources" in app_config:
         kwargs["oauth2_allowed_resources"] = list(app_config["oauth2_allowed_resources"])
+
+    if "oauth2_dynamic_registration_enabled" in app_config:
+        kwargs["oauth2_dynamic_registration_enabled"] = app_config["oauth2_dynamic_registration_enabled"]
+
+    if "oauth2_dynamic_registration_ip_limit" in app_config:
+        kwargs["oauth2_dynamic_registration_ip_limit"] = app_config["oauth2_dynamic_registration_ip_limit"]
+
+    if "oauth2_dynamic_registration_ip_window_seconds" in app_config:
+        kwargs["oauth2_dynamic_registration_ip_window_seconds"] = app_config[
+            "oauth2_dynamic_registration_ip_window_seconds"
+        ]
+
+    if "oauth2_dynamic_client_max_age_days" in app_config:
+        kwargs["oauth2_dynamic_client_max_age_days"] = app_config["oauth2_dynamic_client_max_age_days"]
 
     if "storage" in app_config:
         storage_data = app_config["storage"]

--- a/skrift/controllers/oauth2.py
+++ b/skrift/controllers/oauth2.py
@@ -17,11 +17,13 @@ from litestar.response import Redirect, Response, Template as TemplateResponse
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from skrift.auth.client_secret import verify_client_secret
+from skrift.auth.jwt_tokens import create_access_token_jwt, verify_access_token_jwt
 from skrift.auth.scopes import SCOPE_DEFINITIONS
 from skrift.auth.session_keys import SESSION_USER_EMAIL, SESSION_USER_ID, SESSION_USER_NAME, SESSION_USER_PICTURE_URL
 from skrift.auth.tokens import create_signed_token, verify_signed_token
 from skrift.config import get_settings
-from skrift.db.services import oauth2_service, oauth_service
+from skrift.db.models.user import User
+from skrift.db.services import oauth2_service, oauth2_signing_key_service, oauth_service
 from skrift.forms import verify_csrf
 from skrift.middleware.security import add_form_action_source, apply_csp_nonce, csp_nonce_var
 
@@ -45,6 +47,38 @@ def _verify_pkce(code_verifier: str, code_challenge: str) -> bool:
     digest = hashlib.sha256(code_verifier.encode()).digest()
     computed = base64.urlsafe_b64encode(digest).decode().rstrip("=")
     return computed == code_challenge
+
+
+def _resolve_issuer(settings, request: Request) -> str:
+    """The token issuer: configured value, or this request's base URL."""
+    return settings.oauth2_issuer or str(request.base_url).rstrip("/")
+
+
+def _extract_resource_values(params) -> list[str]:
+    """Collect RFC 8707 ``resource`` values from query or form parameters.
+
+    Litestar multi-dicts expose ``getall`` (needed to detect the invalid
+    multiple-``resource`` case); plain mappings fall back to the single value.
+    """
+    getall = getattr(params, "getall", None)
+    if getall is None:
+        value = params.get("resource", "")
+        return [value] if value else []
+    return [value for value in getall("resource", []) if value]
+
+
+def _validate_resource_indicator(resource: str, allowed_resources: list[str]) -> bool:
+    """Validate an RFC 8707 resource indicator.
+
+    Must be an absolute URI without a fragment and — when an allowlist is
+    configured — one of the allowed resources.
+    """
+    parts = urlsplit(resource)
+    if not parts.scheme or parts.fragment:
+        return False
+    if allowed_resources and resource not in allowed_resources:
+        return False
+    return True
 
 
 async def verify_oauth_token(token: str, secret: str, db_session: AsyncSession) -> dict | None:
@@ -107,6 +141,15 @@ class OAuth2Controller(Controller):
             if allowed and s not in allowed:
                 return _json_error("invalid_scope", f"Scope not allowed for this client: {s}")
 
+        # RFC 8707 resource indicator — optional, at most one, and must be a
+        # valid (allowlisted) target so the access token's `aud` is trustworthy.
+        resource_values = _extract_resource_values(params)
+        if len(resource_values) > 1:
+            return _json_error("invalid_target", "Multiple resource parameters are not supported")
+        resource = resource_values[0] if resource_values else ""
+        if resource and not _validate_resource_indicator(resource, get_settings().oauth2_allowed_resources):
+            return _json_error("invalid_target", "Invalid or disallowed resource")
+
         # Check if user is logged in
         user_id = request.session.get(SESSION_USER_ID)
         if not user_id:
@@ -119,6 +162,7 @@ class OAuth2Controller(Controller):
                 "scope": scope,
                 "code_challenge": code_challenge,
                 "code_challenge_method": code_challenge_method,
+                "resource": resource,
             })
             next_url = f"/oauth/authorize?{query}"
             # next_url carries its own query string; it must be encoded as a
@@ -133,6 +177,7 @@ class OAuth2Controller(Controller):
             "state": state,
             "scope": scope,
             "code_challenge": code_challenge,
+            "resource": resource,
         }
 
         # Build scope descriptions for the consent screen
@@ -211,6 +256,7 @@ class OAuth2Controller(Controller):
         state = authorize_data["state"]
         scope = authorize_data.get("scope", "")
         code_challenge = authorize_data.get("code_challenge", "")
+        resource = authorize_data.get("resource", "")
 
         # User denied
         if action == "deny":
@@ -234,6 +280,7 @@ class OAuth2Controller(Controller):
             "redirect_uri": redirect_uri,
             "scope": scope,
             "code_challenge": code_challenge,
+            "resource": resource,
         }
 
         code = create_signed_token(code_payload, settings.secret_key, AUTH_CODE_TTL)
@@ -247,15 +294,16 @@ class OAuth2Controller(Controller):
         """Token endpoint — exchange auth code or refresh token for access token."""
         form_data = await request.form()
         grant_type = form_data.get("grant_type", "")
+        issuer = _resolve_issuer(get_settings(), request)
 
         if grant_type == "authorization_code":
-            return await self._handle_authorization_code(form_data, db_session)
+            return await self._handle_authorization_code(form_data, db_session, issuer)
         elif grant_type == "refresh_token":
-            return await self._handle_refresh_token(form_data, db_session)
+            return await self._handle_refresh_token(form_data, db_session, issuer)
         else:
             return _json_error("unsupported_grant_type", f"Unsupported grant_type: {grant_type}")
 
-    async def _handle_authorization_code(self, form_data, db_session: AsyncSession) -> Response:
+    async def _handle_authorization_code(self, form_data, db_session: AsyncSession, issuer: str) -> Response:
         """Handle grant_type=authorization_code."""
         settings = get_settings()
 
@@ -298,6 +346,20 @@ class OAuth2Controller(Controller):
         if not _verify_pkce(code_verifier, stored_challenge):
             return _json_error("invalid_grant", "PKCE verification failed")
 
+        # RFC 8707: a token-endpoint `resource` may narrow the authorized
+        # target (equal it, or restrict an unrestricted grant) but never widen.
+        granted_resource = payload.get("resource", "")
+        resource_values = _extract_resource_values(form_data)
+        if len(resource_values) > 1:
+            return _json_error("invalid_target", "Multiple resource parameters are not supported")
+        requested_resource = resource_values[0] if resource_values else ""
+        if requested_resource:
+            if not _validate_resource_indicator(requested_resource, settings.oauth2_allowed_resources):
+                return _json_error("invalid_target", "Invalid or disallowed resource")
+            if granted_resource and requested_resource != granted_resource:
+                return _json_error("invalid_target", "resource was not authorized by this grant")
+        effective_resource = requested_resource or granted_resource
+
         # Revoke the auth code before issuing tokens so a concurrent replay fails.
         code_jti = payload.get("jti")
         if code_jti:
@@ -310,25 +372,27 @@ class OAuth2Controller(Controller):
         # (presenting a previously-rotated token) and mass-revoke the lineage.
         family_id = uuid.uuid4().hex
 
-        # Issue tokens
-        access_payload = {
-            "type": "access",
-            "user_id": payload["user_id"],
-            "email": payload["email"],
-            "name": payload["name"],
-            "picture_url": payload["picture_url"],
-            "client_id": client_id,
-            "scope": scope,
-        }
+        # Issue tokens — the access token is an asymmetric JWT third parties
+        # can verify via /oauth/jwks; the refresh token stays HMAC and carries
+        # the resource so refreshed access tokens keep the same audience.
+        signing_key = await oauth2_signing_key_service.get_or_create_active_key(db_session)
+        access_token = create_access_token_jwt(
+            subject=payload["user_id"],
+            client_id=client_id,
+            scope=scope,
+            audience=effective_resource or None,
+            issuer=issuer,
+            signing_key=signing_key,
+            expires_in=settings.oauth2_access_token_ttl,
+        )
         refresh_payload = {
             "type": "refresh",
             "user_id": payload["user_id"],
             "client_id": client_id,
             "scope": scope,
             "family_id": family_id,
+            "resource": effective_resource,
         }
-
-        access_token = create_signed_token(access_payload, settings.secret_key, ACCESS_TOKEN_TTL)
         refresh_token = create_signed_token(refresh_payload, settings.secret_key, REFRESH_TOKEN_TTL)
 
         return Response(
@@ -336,14 +400,14 @@ class OAuth2Controller(Controller):
                 "access_token": access_token,
                 "refresh_token": refresh_token,
                 "token_type": "bearer",
-                "expires_in": ACCESS_TOKEN_TTL,
+                "expires_in": settings.oauth2_access_token_ttl,
                 "scope": scope,
             },
             status_code=200,
             media_type="application/json",
         )
 
-    async def _handle_refresh_token(self, form_data, db_session: AsyncSession) -> Response:
+    async def _handle_refresh_token(self, form_data, db_session: AsyncSession, issuer: str) -> Response:
         """Handle grant_type=refresh_token with RFC 6749 §10.4 reuse detection.
 
         Three outcomes for a presented refresh token:
@@ -423,6 +487,19 @@ class OAuth2Controller(Controller):
         else:
             effective_scope = original_scope
 
+        # Resource binding mirrors the code grant: equal/narrow only.
+        granted_resource = payload.get("resource", "")
+        resource_values = _extract_resource_values(form_data)
+        if len(resource_values) > 1:
+            return _json_error("invalid_target", "Multiple resource parameters are not supported")
+        requested_resource = resource_values[0] if resource_values else ""
+        if requested_resource:
+            if not _validate_resource_indicator(requested_resource, settings.oauth2_allowed_resources):
+                return _json_error("invalid_target", "Invalid or disallowed resource")
+            if granted_resource and requested_resource != granted_resource:
+                return _json_error("invalid_target", "resource was not authorized by this grant")
+        effective_resource = requested_resource or granted_resource
+
         # Revoke the old refresh token (normal rotation path).
         if old_jti:
             expires_at = datetime.fromtimestamp(payload["exp"], tz=timezone.utc)
@@ -430,24 +507,24 @@ class OAuth2Controller(Controller):
 
         # Issue new access + refresh tokens (token rotation); stay on the
         # same family so future rotations remain linkable for reuse checks.
-        access_payload = {
-            "type": "access",
-            "user_id": payload["user_id"],
-            "email": "",
-            "name": "",
-            "picture_url": "",
-            "client_id": client_id,
-            "scope": effective_scope,
-        }
+        signing_key = await oauth2_signing_key_service.get_or_create_active_key(db_session)
+        access_token = create_access_token_jwt(
+            subject=payload["user_id"],
+            client_id=client_id,
+            scope=effective_scope,
+            audience=effective_resource or None,
+            issuer=issuer,
+            signing_key=signing_key,
+            expires_in=settings.oauth2_access_token_ttl,
+        )
         refresh_payload = {
             "type": "refresh",
             "user_id": payload["user_id"],
             "client_id": client_id,
             "scope": effective_scope,
             "family_id": family_id,
+            "resource": effective_resource,
         }
-
-        access_token = create_signed_token(access_payload, settings.secret_key, ACCESS_TOKEN_TTL)
         new_refresh_token = create_signed_token(refresh_payload, settings.secret_key, REFRESH_TOKEN_TTL)
 
         return Response(
@@ -455,12 +532,51 @@ class OAuth2Controller(Controller):
                 "access_token": access_token,
                 "refresh_token": new_refresh_token,
                 "token_type": "bearer",
-                "expires_in": ACCESS_TOKEN_TTL,
+                "expires_in": settings.oauth2_access_token_ttl,
                 "scope": effective_scope,
             },
             status_code=200,
             media_type="application/json",
         )
+
+    @get("/jwks")
+    async def jwks(self, db_session: AsyncSession) -> Response:
+        """JWK Set endpoint — public keys for access-token verification."""
+        await oauth2_signing_key_service.get_or_create_active_key(db_session)
+        keys = await oauth2_signing_key_service.list_jwks_keys(db_session)
+        return Response(
+            content={"keys": keys},
+            status_code=200,
+            media_type="application/json",
+        )
+
+    async def _verify_jwt_access_claims(
+        self, request: Request, db_session: AsyncSession, token: str
+    ) -> dict | None:
+        """Verify a JWT access token against the JWKS and the revocation list.
+
+        Audience is intentionally not enforced here — userinfo and
+        introspection serve tokens minted for any resource.
+        """
+        if token.count(".") != 2:
+            return None
+
+        settings = get_settings()
+        jwks = await oauth2_signing_key_service.list_jwks_keys(db_session)
+        if not jwks:
+            return None
+
+        claims = verify_access_token_jwt(
+            token, jwks=jwks, issuer=_resolve_issuer(settings, request), audience=None
+        )
+        if claims is None:
+            return None
+
+        jti = claims.get("jti", "")
+        if jti and await oauth2_service.is_token_revoked(db_session, jti):
+            return None
+
+        return claims
 
     @get("/userinfo")
     async def userinfo(self, request: Request, db_session: AsyncSession) -> Response:
@@ -473,13 +589,33 @@ class OAuth2Controller(Controller):
 
         token = auth_header[7:]  # Strip "Bearer "
         payload = await verify_oauth_token(token, settings.secret_key, db_session)
-        if not payload or payload.get("type") != "access":
-            return _json_error("invalid_token", "Invalid or expired access token", status_code=401)
+        if payload is not None and payload.get("type") == "access":
+            # Legacy HMAC access token — the profile travels in the payload.
+            subject = payload["user_id"]
+            scope_str = payload.get("scope", "")
+            profile = {
+                "email": payload.get("email", ""),
+                "name": payload.get("name", ""),
+                "picture": payload.get("picture_url", ""),
+            }
+        else:
+            jwt_claims = await self._verify_jwt_access_claims(request, db_session, token)
+            if jwt_claims is None:
+                return _json_error("invalid_token", "Invalid or expired access token", status_code=401)
+            # JWT access tokens carry no profile claims — read them from the
+            # user record so userinfo stays authoritative.
+            subject = jwt_claims["sub"]
+            scope_str = jwt_claims.get("scope", "")
+            user = await db_session.get(User, UUID(subject))
+            profile = {
+                "email": (user.email if user else "") or "",
+                "name": (user.name if user else "") or "",
+                "picture": (user.picture_url if user else "") or "",
+            }
 
         # Build claims strictly from granted scopes. A token minted with
         # no scopes gets only `sub` — prior backwards-compat code returned
         # the full profile + email, which silently defeated scope filtering.
-        scope_str = payload.get("scope", "")
         granted_scopes = scope_str.split() if scope_str else []
 
         allowed_claims: set[str] = set()
@@ -489,22 +625,21 @@ class OAuth2Controller(Controller):
                 allowed_claims.update(defn.claims)
 
         # Always include sub — the minimum subject identifier required by OIDC.
-        claims: dict = {"sub": payload["user_id"]}
+        claims: dict = {"sub": subject}
 
         if "email" in allowed_claims:
-            email = payload.get("email", "")
-            claims["email"] = email
+            claims["email"] = profile["email"]
             # Report verification from this server's own records — never a
             # blanket true. ``email_verified`` is set only when the user has a
             # linked identity whose email was attested as verified, mirroring
             # the gate that protects the email-match auto-link path.
             claims["email_verified"] = await oauth_service.is_email_verified_for_user(
-                db_session, UUID(payload["user_id"]), email
+                db_session, UUID(subject), profile["email"]
             )
         if "name" in allowed_claims:
-            claims["name"] = payload.get("name", "")
+            claims["name"] = profile["name"]
         if "picture" in allowed_claims:
-            claims["picture"] = payload.get("picture_url", "")
+            claims["picture"] = profile["picture"]
 
         return Response(
             content=claims,
@@ -529,6 +664,11 @@ class OAuth2Controller(Controller):
             await oauth2_service.revoke_token(
                 db_session, payload["jti"], payload.get("type", "unknown"), expires_at
             )
+        elif payload is None:
+            jwt_claims = await self._verify_jwt_access_claims(request, db_session, token_str)
+            if jwt_claims and jwt_claims.get("jti"):
+                expires_at = datetime.fromtimestamp(jwt_claims["exp"], tz=timezone.utc)
+                await oauth2_service.revoke_token(db_session, jwt_claims["jti"], "access", expires_at)
 
         # RFC 7009: always return 200, even if token was invalid
         return Response(content={}, status_code=200, media_type="application/json")
@@ -557,6 +697,17 @@ class OAuth2Controller(Controller):
 
         settings = get_settings()
         payload = await verify_oauth_token(token_str, settings.secret_key, db_session)
+        if payload is None:
+            jwt_claims = await self._verify_jwt_access_claims(request, db_session, token_str)
+            if jwt_claims is not None:
+                payload = {
+                    "type": "access",
+                    "user_id": jwt_claims.get("sub", ""),
+                    "client_id": jwt_claims.get("client_id", ""),
+                    "scope": jwt_claims.get("scope", ""),
+                    "exp": jwt_claims.get("exp"),
+                    "aud": jwt_claims.get("aud", ""),
+                }
 
         if not payload:
             return Response(content={"active": False}, status_code=200, media_type="application/json")
@@ -576,6 +727,8 @@ class OAuth2Controller(Controller):
                 "scope": payload.get("scope", ""),
                 "exp": payload.get("exp"),
             }
+            if payload.get("aud"):
+                result["aud"] = payload["aud"]
         else:
             result = {
                 "active": True,

--- a/skrift/controllers/oauth2.py
+++ b/skrift/controllers/oauth2.py
@@ -7,12 +7,14 @@ instance can act as an identity hub for spoke sites.
 
 import base64
 import hashlib
+import re
 import uuid
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from uuid import UUID
 from urllib.parse import urlencode, urlsplit
 
 from litestar import Controller, Request, get, post
+from litestar.exceptions import NotFoundException
 from litestar.response import Redirect, Response, Template as TemplateResponse
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -25,12 +27,18 @@ from skrift.config import get_settings
 from skrift.db.models.user import User
 from skrift.db.services import oauth2_service, oauth2_signing_key_service, oauth_service
 from skrift.forms import verify_csrf
+from skrift.lib.client_ip import get_client_ip
 from skrift.middleware.security import add_form_action_source, apply_csp_nonce, csp_nonce_var
 
 # Token lifetimes
 AUTH_CODE_TTL = 600        # 10 minutes
 ACCESS_TOKEN_TTL = 900     # 15 minutes
 REFRESH_TOKEN_TTL = 2592000  # 30 days
+
+# Longest client_name accepted at Dynamic Client Registration. client_name is
+# attacker-controlled and echoed on the consent screen, so it is length-capped
+# here and rendered through the templating engine's autoescape.
+CLIENT_NAME_MAX_LENGTH = 255
 
 
 def _json_error(error: str, description: str, status_code: int = 400) -> Response:
@@ -79,6 +87,74 @@ def _validate_resource_indicator(resource: str, allowed_resources: list[str]) ->
     if allowed_resources and resource not in allowed_resources:
         return False
     return True
+
+
+def _is_loopback_host(host: str) -> bool:
+    """Loopback hosts that may use plain http in a redirect_uri (RFC 8252)."""
+    return host == "127.0.0.1" or host == "localhost"
+
+
+# A registered host may only contain characters that are unambiguously part of
+# a DNS name or dotted-quad IP. This deliberately excludes spaces, ';', '*',
+# '@', and every other character that could smuggle extra tokens or directives
+# into the consent-page ``form-action`` CSP allowlist (see _consent_csp_headers)
+# or confuse a URL parser.
+_REDIRECT_HOST_RE = re.compile(r"^[A-Za-z0-9.\-]+$")
+
+
+def _redirect_uri_origin(uri: str) -> str | None:
+    """Return the safe ``scheme://host[:port]`` origin of a redirect_uri.
+
+    Returns ``None`` when the URI cannot be reduced to a trustworthy origin —
+    the single choke point both the registration validator and the consent CSP
+    builder rely on so neither can be fed an origin that injects CSP tokens.
+
+    Rejected: URIs with any whitespace/control character (which URL parsers
+    silently strip, letting a newline smuggle a second, unvalidated URI through
+    the newline-delimited ``redirect_uris`` storage), embedded userinfo
+    (``user:pass@host``), a host outside :data:`_REDIRECT_HOST_RE`, or an
+    unparseable port.
+    """
+    if not uri or any(character.isspace() or ord(character) < 0x20 or ord(character) == 0x7F for character in uri):
+        return None
+    parts = urlsplit(uri)
+    if not parts.scheme or not parts.netloc:
+        return None
+    if parts.username is not None or parts.password is not None or "@" in parts.netloc:
+        return None
+    host = parts.hostname
+    if not host or not _REDIRECT_HOST_RE.match(host):
+        return None
+    try:
+        port = parts.port
+    except ValueError:
+        return None
+    origin = f"{parts.scheme}://{host}"
+    if port is not None:
+        origin = f"{origin}:{port}"
+    return origin
+
+
+def _validate_registration_redirect_uri(uri: str) -> bool:
+    """Validate a redirect_uri submitted to Dynamic Client Registration.
+
+    Hardening rules (audited): the URI must reduce to a safe origin (see
+    :func:`_redirect_uri_origin` — absolute, no whitespace/control chars, no
+    embedded credentials, strict host charset), carry no fragment, and use
+    ``https`` — the sole exception being loopback ``http://127.0.0.1`` /
+    ``http://localhost`` (with an optional port), which native/CLI clients rely
+    on. Anything else is rejected.
+    """
+    if _redirect_uri_origin(uri) is None:
+        return False
+    parts = urlsplit(uri)
+    if parts.fragment:
+        return False
+    if parts.scheme == "https":
+        return True
+    if parts.scheme == "http":
+        return _is_loopback_host(parts.hostname or "")
+    return False
 
 
 async def verify_oauth_token(token: str, secret: str, db_session: AsyncSession) -> dict | None:
@@ -224,8 +300,13 @@ class OAuth2Controller(Controller):
         if not security.enabled or not security.content_security_policy:
             return {}
 
-        parts = urlsplit(redirect_uri)
-        origin = f"{parts.scheme}://{parts.netloc}"
+        # Build the form-action source from a sanitized origin, never the raw
+        # redirect_uri. A host containing a space, ';' or '*' would otherwise
+        # inject extra CSP tokens/directives (e.g. widening form-action to '*').
+        # Fail closed: if the origin cannot be trusted, don't widen the policy.
+        origin = _redirect_uri_origin(redirect_uri)
+        if origin is None:
+            return {}
         csp = add_form_action_source(security.content_security_policy, origin)
 
         # The middleware skips its own CSP (and nonce injection) once a response
@@ -395,6 +476,10 @@ class OAuth2Controller(Controller):
         }
         refresh_token = create_signed_token(refresh_payload, settings.secret_key, REFRESH_TOKEN_TTL)
 
+        # Stamp liveness so the dynamic-client pruning job never retires a
+        # client that has actually issued a token.
+        await oauth2_service.mark_client_used(db_session, client, datetime.now(tz=timezone.utc))
+
         return Response(
             content={
                 "access_token": access_token,
@@ -527,6 +612,9 @@ class OAuth2Controller(Controller):
         }
         new_refresh_token = create_signed_token(refresh_payload, settings.secret_key, REFRESH_TOKEN_TTL)
 
+        # Stamp liveness so refreshed dynamic clients stay out of the pruner.
+        await oauth2_service.mark_client_used(db_session, client, datetime.now(tz=timezone.utc))
+
         return Response(
             content={
                 "access_token": access_token,
@@ -536,6 +624,98 @@ class OAuth2Controller(Controller):
                 "scope": effective_scope,
             },
             status_code=200,
+            media_type="application/json",
+        )
+
+    @post("/register")
+    async def register(self, request: Request, db_session: AsyncSession) -> Response:
+        """Dynamic Client Registration endpoint (RFC 7591).
+
+        Machine clients (e.g. Claude custom connectors) self-register a public
+        client here. The route is CSRF-exempt like ``/oauth/token`` — there is
+        no browser session to protect — and 404s unless dynamic registration is
+        explicitly enabled on top of ``oauth2_enabled``.
+        """
+        settings = get_settings()
+        if not settings.oauth2_enabled or not settings.oauth2_dynamic_registration_enabled:
+            raise NotFoundException()
+
+        try:
+            body = await request.json()
+        except ValueError:
+            return _json_error("invalid_client_metadata", "Request body must be valid JSON")
+
+        if not isinstance(body, dict):
+            return _json_error("invalid_client_metadata", "Request body must be a JSON object")
+
+        redirect_uris = body.get("redirect_uris")
+        if not isinstance(redirect_uris, list) or not redirect_uris:
+            return _json_error("invalid_client_metadata", "redirect_uris is required")
+        if not all(isinstance(uri, str) for uri in redirect_uris):
+            return _json_error("invalid_redirect_uri", "Each redirect_uri must be a string")
+        for uri in redirect_uris:
+            if not _validate_registration_redirect_uri(uri):
+                return _json_error("invalid_redirect_uri", f"Invalid redirect_uri: {uri}")
+
+        # Public DCR only: the sole accepted auth method is `none` (PKCE).
+        auth_method = body.get("token_endpoint_auth_method", "none")
+        if auth_method != "none":
+            return _json_error(
+                "invalid_client_metadata", "token_endpoint_auth_method must be 'none'"
+            )
+
+        grant_types = body.get("grant_types") or ["authorization_code", "refresh_token"]
+        response_types = body.get("response_types") or ["code"]
+
+        client_name = body.get("client_name", "")
+        if not isinstance(client_name, str):
+            return _json_error("invalid_client_metadata", "client_name must be a string")
+        display_name = client_name[:CLIENT_NAME_MAX_LENGTH].strip() or "Dynamic Client"
+
+        scope = body.get("scope", "")
+        if not isinstance(scope, str):
+            return _json_error("invalid_client_metadata", "scope must be a string")
+        requested_scopes = scope.split()
+        for requested_scope in requested_scopes:
+            if requested_scope not in SCOPE_DEFINITIONS:
+                return _json_error("invalid_client_metadata", f"Unknown scope: {requested_scope}")
+
+        # Per-IP registration cap — counts this IP's recent dynamic clients and
+        # rejects once it reaches the configured limit within the window.
+        client_ip = get_client_ip(request.scope)
+        now = datetime.now(tz=timezone.utc)
+        window_start = now - timedelta(seconds=settings.oauth2_dynamic_registration_ip_window_seconds)
+        recent = await oauth2_service.count_recent_dynamic_registrations(
+            db_session, client_ip, window_start
+        )
+        if recent >= settings.oauth2_dynamic_registration_ip_limit:
+            return _json_error(
+                "too_many_requests",
+                "Registration rate limit exceeded for this client",
+                status_code=429,
+            )
+
+        client = await oauth2_service.create_dynamic_client(
+            db_session,
+            display_name=display_name,
+            redirect_uris=redirect_uris,
+            allowed_scopes=requested_scopes,
+            registered_by_ip=client_ip,
+            issued_at=now,
+        )
+
+        return Response(
+            content={
+                "client_id": client.client_id,
+                "client_id_issued_at": int(now.timestamp()),
+                "token_endpoint_auth_method": "none",
+                "grant_types": grant_types,
+                "response_types": response_types,
+                "redirect_uris": client.redirect_uri_list,
+                "client_name": display_name,
+                "scope": " ".join(requested_scopes),
+            },
+            status_code=201,
             media_type="application/json",
         )
 

--- a/skrift/controllers/oauth2.py
+++ b/skrift/controllers/oauth2.py
@@ -25,7 +25,12 @@ from skrift.auth.session_keys import SESSION_USER_EMAIL, SESSION_USER_ID, SESSIO
 from skrift.auth.tokens import create_signed_token, verify_signed_token
 from skrift.config import get_settings
 from skrift.db.models.user import User
-from skrift.db.services import oauth2_service, oauth2_signing_key_service, oauth_service
+from skrift.db.services import (
+    oauth2_consent_service,
+    oauth2_service,
+    oauth2_signing_key_service,
+    oauth_service,
+)
 from skrift.forms import verify_csrf
 from skrift.lib.client_ip import get_client_ip
 from skrift.middleware.security import add_form_action_source, apply_csp_nonce, csp_nonce_var
@@ -173,6 +178,41 @@ async def verify_oauth_token(token: str, secret: str, db_session: AsyncSession) 
     return payload
 
 
+def _issue_authorization_code(
+    request: Request,
+    settings,
+    *,
+    client_id: str,
+    redirect_uri: str,
+    state: str,
+    scope: str,
+    code_challenge: str,
+    resource: str,
+) -> Redirect:
+    """Mint an authorization code for the logged-in user and redirect back.
+
+    Shared by the consent-approval path and the remembered-consent skip path
+    so both bind the same PKCE challenge, resource, and session profile onto
+    the code.
+    """
+    code_payload = {
+        "type": "code",
+        "user_id": request.session.get(SESSION_USER_ID),
+        "email": request.session.get(SESSION_USER_EMAIL, ""),
+        "name": request.session.get(SESSION_USER_NAME, ""),
+        "picture_url": request.session.get(SESSION_USER_PICTURE_URL, ""),
+        "client_id": client_id,
+        "redirect_uri": redirect_uri,
+        "scope": scope,
+        "code_challenge": code_challenge,
+        "resource": resource,
+    }
+    code = create_signed_token(code_payload, settings.secret_key, AUTH_CODE_TTL)
+    sep = "&" if "?" in redirect_uri else "?"
+    callback_url = f"{redirect_uri}{sep}" + urlencode({"code": code, "state": state})
+    return Redirect(path=callback_url)
+
+
 class OAuth2Controller(Controller):
     path = "/oauth"
 
@@ -245,6 +285,23 @@ class OAuth2Controller(Controller):
             # single value or its `&`-separated params (response_type, ...) leak
             # out of `next` and are lost across the login round-trip.
             return Redirect(path=f"/auth/login?{urlencode({'next': next_url})}")
+
+        # Remembered consent: if a prior grant for this (user, client) already
+        # covers every requested scope, skip the consent screen and issue the
+        # code directly — still binding PKCE and the resource onto it. A request
+        # for scopes beyond the grant falls through to the consent screen.
+        grant = await oauth2_consent_service.find_grant(db_session, user_id, client_id)
+        if grant is not None and set(requested_scopes).issubset(set(grant.scope_list)):
+            return _issue_authorization_code(
+                request,
+                get_settings(),
+                client_id=client_id,
+                redirect_uri=redirect_uri,
+                state=state,
+                scope=scope,
+                code_challenge=code_challenge,
+                resource=resource,
+            )
 
         # Store params in session for POST consent
         request.session["oauth_authorize"] = {
@@ -345,30 +402,30 @@ class OAuth2Controller(Controller):
             deny_url = f"{redirect_uri}{sep}" + urlencode({"error": "access_denied", "state": state})
             return Redirect(path=deny_url)
 
-        # User approved — create auth code
+        # User approved — remember this consent, then issue the auth code.
         settings = get_settings()
         user_id = request.session.get(SESSION_USER_ID)
         if not user_id:
             return _json_error("invalid_request", "User not logged in")
 
-        code_payload = {
-            "type": "code",
-            "user_id": user_id,
-            "email": request.session.get(SESSION_USER_EMAIL, ""),
-            "name": request.session.get(SESSION_USER_NAME, ""),
-            "picture_url": request.session.get(SESSION_USER_PICTURE_URL, ""),
-            "client_id": client_id,
-            "redirect_uri": redirect_uri,
-            "scope": scope,
-            "code_challenge": code_challenge,
-            "resource": resource,
-        }
+        await oauth2_consent_service.upsert_grant(
+            db_session,
+            user_id=user_id,
+            client_id=client_id,
+            scopes=scope.split() if scope else [],
+            granted_at=datetime.now(tz=timezone.utc),
+        )
 
-        code = create_signed_token(code_payload, settings.secret_key, AUTH_CODE_TTL)
-
-        sep = "&" if "?" in redirect_uri else "?"
-        callback_url = f"{redirect_uri}{sep}" + urlencode({"code": code, "state": state})
-        return Redirect(path=callback_url)
+        return _issue_authorization_code(
+            request,
+            settings,
+            client_id=client_id,
+            redirect_uri=redirect_uri,
+            state=state,
+            scope=scope,
+            code_challenge=code_challenge,
+            resource=resource,
+        )
 
     @post("/token")
     async def token_exchange(self, request: Request, db_session: AsyncSession) -> Response:

--- a/skrift/controllers/oauth2.py
+++ b/skrift/controllers/oauth2.py
@@ -45,6 +45,18 @@ REFRESH_TOKEN_TTL = 2592000  # 30 days
 # here and rendered through the templating engine's autoescape.
 CLIENT_NAME_MAX_LENGTH = 255
 
+# The only grant/response types this server supports for dynamically-registered
+# (public, PKCE-only) clients. RFC 7591 §2: unsupported requested values are
+# rejected rather than echoed back as if they were registered.
+DYNAMIC_CLIENT_GRANT_TYPES = ("authorization_code", "refresh_token")
+DYNAMIC_CLIENT_RESPONSE_TYPES = ("code",)
+
+# Scopes a dynamic registration gets when it omits `scope`. An empty
+# allowed_scopes list means "unrestricted" at /oauth/authorize, so omission
+# must fall back to this minimal identity set — never to every registered
+# scope.
+DYNAMIC_CLIENT_DEFAULT_SCOPES = ("openid", "profile", "email")
+
 
 def _json_error(error: str, description: str, status_code: int = 400) -> Response:
     """Return an OAuth2 JSON error response."""
@@ -721,8 +733,25 @@ class OAuth2Controller(Controller):
                 "invalid_client_metadata", "token_endpoint_auth_method must be 'none'"
             )
 
-        grant_types = body.get("grant_types") or ["authorization_code", "refresh_token"]
-        response_types = body.get("response_types") or ["code"]
+        grant_types = body.get("grant_types") or list(DYNAMIC_CLIENT_GRANT_TYPES)
+        if not isinstance(grant_types, list) or not all(
+            isinstance(grant_type, str) for grant_type in grant_types
+        ):
+            return _json_error("invalid_client_metadata", "grant_types must be a list of strings")
+        for grant_type in grant_types:
+            if grant_type not in DYNAMIC_CLIENT_GRANT_TYPES:
+                return _json_error("invalid_client_metadata", f"Unsupported grant_type: {grant_type}")
+
+        response_types = body.get("response_types") or list(DYNAMIC_CLIENT_RESPONSE_TYPES)
+        if not isinstance(response_types, list) or not all(
+            isinstance(response_type, str) for response_type in response_types
+        ):
+            return _json_error("invalid_client_metadata", "response_types must be a list of strings")
+        for response_type in response_types:
+            if response_type not in DYNAMIC_CLIENT_RESPONSE_TYPES:
+                return _json_error(
+                    "invalid_client_metadata", f"Unsupported response_type: {response_type}"
+                )
 
         client_name = body.get("client_name", "")
         if not isinstance(client_name, str):
@@ -736,6 +765,12 @@ class OAuth2Controller(Controller):
         for requested_scope in requested_scopes:
             if requested_scope not in SCOPE_DEFINITIONS:
                 return _json_error("invalid_client_metadata", f"Unknown scope: {requested_scope}")
+        if not requested_scopes:
+            requested_scopes = [
+                default_scope
+                for default_scope in DYNAMIC_CLIENT_DEFAULT_SCOPES
+                if default_scope in SCOPE_DEFINITIONS
+            ]
 
         # Per-IP registration cap — counts this IP's recent dynamic clients and
         # rejects once it reaches the configured limit within the window.
@@ -749,6 +784,16 @@ class OAuth2Controller(Controller):
             return _json_error(
                 "too_many_requests",
                 "Registration rate limit exceeded for this client",
+                status_code=429,
+            )
+
+        # Global cap — the per-IP window only bounds the rate, so a distributed
+        # attacker could otherwise grow oauth2_clients without limit.
+        total_dynamic = await oauth2_service.count_dynamic_clients(db_session)
+        if total_dynamic >= settings.oauth2_dynamic_registration_total_limit:
+            return _json_error(
+                "too_many_requests",
+                "Dynamic client registration capacity reached",
                 status_code=429,
             )
 
@@ -926,7 +971,16 @@ class OAuth2Controller(Controller):
         if not client:
             return _json_error("invalid_client", "Unknown client_id")
 
-        if client.client_secret and not verify_client_secret(client_secret, client.client_secret):
+        # RFC 7662 §2.1: introspection must be limited to authenticated
+        # callers. Public (secretless) clients — e.g. dynamically-registered
+        # ones — cannot authenticate here, so they may not introspect at all;
+        # anything less turns this endpoint into an unauthenticated
+        # token-validity oracle.
+        if not client.client_secret:
+            return _json_error(
+                "invalid_client", "Public clients may not introspect tokens", status_code=401
+            )
+        if not verify_client_secret(client_secret, client.client_secret):
             return _json_error("invalid_client", "Invalid client_secret")
 
         if not token_str:

--- a/skrift/controllers/sitemap.py
+++ b/skrift/controllers/sitemap.py
@@ -16,9 +16,14 @@ from skrift.lib.client_ip import get_client_ip
 from skrift.hooks import hooks, ROBOTS_TXT, ROBOTS_TXT_FETCHED, SITEMAP_PAGE, SITEMAP_URLS
 
 
-def build_authorization_server_metadata(issuer: str) -> dict:
-    """RFC 8414 / OIDC discovery metadata shared by both well-known routes."""
-    return {
+def build_authorization_server_metadata(issuer: str, *, registration_enabled: bool = False) -> dict:
+    """RFC 8414 / OIDC discovery metadata shared by both well-known routes.
+
+    ``registration_endpoint`` (RFC 7591) is advertised only when Dynamic
+    Client Registration is enabled, so discovery matches what the server
+    actually accepts.
+    """
+    metadata = {
         "issuer": issuer,
         "authorization_endpoint": f"{issuer}/oauth/authorize",
         "token_endpoint": f"{issuer}/oauth/token",
@@ -33,6 +38,9 @@ def build_authorization_server_metadata(issuer: str) -> dict:
         "code_challenge_methods_supported": ["S256"],
         "token_endpoint_auth_methods_supported": ["client_secret_post", "none"],
     }
+    if registration_enabled:
+        metadata["registration_endpoint"] = f"{issuer}/oauth/register"
+    return metadata
 
 
 @dataclass
@@ -167,7 +175,10 @@ Sitemap: {sitemap_url}
         issuer = settings.oauth2_issuer or str(request.base_url).rstrip("/")
 
         return Response(
-            content=build_authorization_server_metadata(issuer),
+            content=build_authorization_server_metadata(
+                issuer,
+                registration_enabled=settings.oauth2_dynamic_registration_enabled,
+            ),
             status_code=200,
             media_type="application/json",
         )

--- a/skrift/controllers/sitemap.py
+++ b/skrift/controllers/sitemap.py
@@ -9,10 +9,30 @@ from litestar.exceptions import NotFoundException
 from litestar.response import Response
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from skrift.auth.scopes import SCOPE_DEFINITIONS
 from skrift.db.services import page_service
 from skrift.db.services.setting_service import get_cached_site_base_url, get_cached_robots_txt
 from skrift.lib.client_ip import get_client_ip
 from skrift.hooks import hooks, ROBOTS_TXT, ROBOTS_TXT_FETCHED, SITEMAP_PAGE, SITEMAP_URLS
+
+
+def build_authorization_server_metadata(issuer: str) -> dict:
+    """RFC 8414 / OIDC discovery metadata shared by both well-known routes."""
+    return {
+        "issuer": issuer,
+        "authorization_endpoint": f"{issuer}/oauth/authorize",
+        "token_endpoint": f"{issuer}/oauth/token",
+        "userinfo_endpoint": f"{issuer}/oauth/userinfo",
+        "revocation_endpoint": f"{issuer}/oauth/revoke",
+        "introspection_endpoint": f"{issuer}/oauth/introspect",
+        "jwks_uri": f"{issuer}/oauth/jwks",
+        "response_types_supported": ["code"],
+        "grant_types_supported": ["authorization_code", "refresh_token"],
+        "scopes_supported": sorted(SCOPE_DEFINITIONS),
+        "claims_supported": ["sub", "name", "email", "email_verified", "picture"],
+        "code_challenge_methods_supported": ["S256"],
+        "token_endpoint_auth_methods_supported": ["client_secret_post", "none"],
+    }
 
 
 @dataclass
@@ -136,37 +156,31 @@ Sitemap: {sitemap_url}
             headers={"Content-Type": "text/plain; charset=utf-8"},
         )
 
-    @get("/.well-known/openid-configuration")
-    async def openid_configuration(self, request: Request) -> Response:
-        """OIDC Discovery document."""
+    def _authorization_server_metadata_response(self, request: Request) -> Response:
+        """Shared body for the OIDC and RFC 8414 discovery documents."""
         from skrift.config import get_settings
 
         settings = get_settings()
         if not settings.oauth2_enabled:
             raise NotFoundException()
 
-        issuer = str(request.base_url).rstrip("/")
-
-        discovery = {
-            "issuer": issuer,
-            "authorization_endpoint": f"{issuer}/oauth/authorize",
-            "token_endpoint": f"{issuer}/oauth/token",
-            "userinfo_endpoint": f"{issuer}/oauth/userinfo",
-            "revocation_endpoint": f"{issuer}/oauth/revoke",
-            "introspection_endpoint": f"{issuer}/oauth/introspect",
-            "response_types_supported": ["code"],
-            "grant_types_supported": ["authorization_code", "refresh_token"],
-            "scopes_supported": ["openid", "profile", "email"],
-            "claims_supported": ["sub", "name", "email", "email_verified", "picture"],
-            "code_challenge_methods_supported": ["S256"],
-            "token_endpoint_auth_methods_supported": ["client_secret_post", "none"],
-        }
+        issuer = settings.oauth2_issuer or str(request.base_url).rstrip("/")
 
         return Response(
-            content=discovery,
+            content=build_authorization_server_metadata(issuer),
             status_code=200,
             media_type="application/json",
         )
+
+    @get("/.well-known/openid-configuration")
+    async def openid_configuration(self, request: Request) -> Response:
+        """OIDC Discovery document."""
+        return self._authorization_server_metadata_response(request)
+
+    @get("/.well-known/oauth-authorization-server")
+    async def oauth_authorization_server(self, request: Request) -> Response:
+        """OAuth 2.0 Authorization Server Metadata (RFC 8414)."""
+        return self._authorization_server_metadata_response(request)
 
     @get("/.well-known/security.txt")
     async def security_txt(self, request: Request) -> Response:

--- a/skrift/db/models/__init__.py
+++ b/skrift/db/models/__init__.py
@@ -3,6 +3,7 @@ from skrift.db.models.asset import Asset
 from skrift.db.models.content_area import ContentAreaRecord
 from skrift.db.models.notification import DismissedNotification, StoredNotification
 from skrift.db.models.oauth2_client import OAuth2Client
+from skrift.db.models.oauth2_consent_grant import ConsentGrant
 from skrift.db.models.oauth2_signing_key import OAuth2SigningKey
 from skrift.db.models.oauth_account import OAuthAccount
 from skrift.db.models.page import Page
@@ -30,6 +31,7 @@ from skrift.db.models.worker import (
 __all__ = [
     "APIKey",
     "Asset",
+    "ConsentGrant",
     "ContentAreaRecord",
     "DismissedNotification",
     "OAuth2Client",

--- a/skrift/db/models/__init__.py
+++ b/skrift/db/models/__init__.py
@@ -3,6 +3,7 @@ from skrift.db.models.asset import Asset
 from skrift.db.models.content_area import ContentAreaRecord
 from skrift.db.models.notification import DismissedNotification, StoredNotification
 from skrift.db.models.oauth2_client import OAuth2Client
+from skrift.db.models.oauth2_signing_key import OAuth2SigningKey
 from skrift.db.models.oauth_account import OAuthAccount
 from skrift.db.models.page import Page
 from skrift.db.models.page_asset import page_assets
@@ -32,6 +33,7 @@ __all__ = [
     "ContentAreaRecord",
     "DismissedNotification",
     "OAuth2Client",
+    "OAuth2SigningKey",
     "OAuthAccount",
     "Page",
     "PageRepublish",

--- a/skrift/db/models/oauth2_client.py
+++ b/skrift/db/models/oauth2_client.py
@@ -1,6 +1,8 @@
 """OAuth2 client model for the authorization server."""
 
-from sqlalchemy import String, Text, Boolean
+from datetime import datetime
+
+from sqlalchemy import String, Text, Boolean, DateTime
 from sqlalchemy.orm import Mapped, mapped_column
 
 from skrift.db.base import Base
@@ -17,6 +19,17 @@ class OAuth2Client(Base):
     redirect_uris: Mapped[str] = mapped_column(Text, default="", nullable=False)
     allowed_scopes: Mapped[str] = mapped_column(Text, default="", nullable=False)
     is_active: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)
+
+    # Dynamic Client Registration (RFC 7591) metadata. Confidential clients
+    # created through the admin UI leave these at their defaults; clients
+    # created via POST /oauth/register are public and flagged here.
+    is_dynamically_registered: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
+    token_endpoint_auth_method: Mapped[str] = mapped_column(
+        String(64), default="client_secret_post", nullable=False
+    )
+    last_used_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    registered_by_ip: Mapped[str | None] = mapped_column(String(45), index=True, nullable=True)
+    client_id_issued_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
 
     @property
     def redirect_uri_list(self) -> list[str]:

--- a/skrift/db/models/oauth2_consent_grant.py
+++ b/skrift/db/models/oauth2_consent_grant.py
@@ -1,0 +1,39 @@
+"""Remembered OAuth2 consent grant model.
+
+Records that a user has approved a set of scopes for an OAuth2 client so the
+``/oauth/authorize`` consent screen can be skipped on a later authorization
+request that stays within the already-granted scopes. A request for scopes
+beyond the grant re-prompts, and approval widens the stored grant.
+"""
+
+from datetime import datetime
+from uuid import UUID
+
+from advanced_alchemy.types import DateTimeUTC
+from sqlalchemy import ForeignKey, String, Text, UniqueConstraint
+from sqlalchemy.orm import Mapped, mapped_column
+
+from skrift.db.base import Base
+
+
+class ConsentGrant(Base):
+    """A user's remembered consent for an OAuth2 client's scopes."""
+
+    __tablename__ = "oauth2_consent_grants"
+    __table_args__ = (
+        UniqueConstraint(
+            "user_id", "client_id", name="uq_oauth2_consent_grants_user_client"
+        ),
+    )
+
+    user_id: Mapped[UUID] = mapped_column(
+        ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    client_id: Mapped[str] = mapped_column(String(255), nullable=False, index=True)
+    scopes: Mapped[str] = mapped_column(Text, default="", nullable=False)
+    granted_at: Mapped[datetime] = mapped_column(DateTimeUTC(timezone=True), nullable=False)
+
+    @property
+    def scope_list(self) -> list[str]:
+        """Parse newline-delimited scopes into a list."""
+        return [scope.strip() for scope in self.scopes.split("\n") if scope.strip()]

--- a/skrift/db/models/oauth2_signing_key.py
+++ b/skrift/db/models/oauth2_signing_key.py
@@ -1,0 +1,29 @@
+"""OAuth2 signing key model for asymmetric access-token signing."""
+
+from datetime import datetime
+
+from advanced_alchemy.types import DateTimeUTC
+from sqlalchemy import String, Text, Boolean
+from sqlalchemy.orm import Mapped, mapped_column
+
+from skrift.db.base import Base
+
+
+class OAuth2SigningKey(Base):
+    """An asymmetric key pair used to sign OAuth2 access-token JWTs.
+
+    The private key is stored PEM-encoded. Third parties verify tokens
+    against the matching public key published at the JWKS endpoint, keyed
+    by ``kid``. Exactly one key is active at a time; retired keys stay
+    published until they age out so tokens they signed remain verifiable.
+    """
+
+    __tablename__ = "oauth2_signing_keys"
+
+    kid: Mapped[str] = mapped_column(String(64), unique=True, index=True, nullable=False)
+    private_key_pem: Mapped[str] = mapped_column(Text, nullable=False)
+    algorithm: Mapped[str] = mapped_column(String(16), default="ES256", nullable=False)
+    is_active: Mapped[bool] = mapped_column(Boolean, default=True, index=True, nullable=False)
+    retired_at: Mapped[datetime | None] = mapped_column(
+        DateTimeUTC(timezone=True), nullable=True
+    )

--- a/skrift/db/services/oauth2_consent_service.py
+++ b/skrift/db/services/oauth2_consent_service.py
@@ -1,0 +1,90 @@
+"""OAuth2 remembered-consent service.
+
+Persists a user's approval of an OAuth2 client's scopes so the
+``/oauth/authorize`` consent screen can be skipped when a later request stays
+within the already-granted scopes, and cascades client deletion to the grants
+that referenced the client.
+"""
+
+from datetime import datetime
+
+from sqlalchemy import delete, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from skrift.db.models.oauth2_consent_grant import ConsentGrant
+from skrift.hooks import hooks
+
+
+async def find_grant(
+    db_session: AsyncSession, user_id: str, client_id: str
+) -> ConsentGrant | None:
+    """Return the remembered consent grant for a user + client, if any."""
+    result = await db_session.execute(
+        select(ConsentGrant).where(
+            ConsentGrant.user_id == user_id,
+            ConsentGrant.client_id == client_id,
+        )
+    )
+    return result.scalar_one_or_none()
+
+
+async def upsert_grant(
+    db_session: AsyncSession,
+    *,
+    user_id: str,
+    client_id: str,
+    scopes: list[str],
+    granted_at: datetime,
+) -> ConsentGrant:
+    """Create or widen a user's remembered consent for a client.
+
+    Newly approved scopes are unioned with any previously granted scopes so a
+    remembered grant only ever grows — a narrower later request never silently
+    drops a scope the user already consented to.
+    """
+    grant = await find_grant(db_session, user_id, client_id)
+    existing_scopes = set(grant.scope_list) if grant is not None else set()
+    merged_scopes = "\n".join(sorted(existing_scopes | set(scopes)))
+    if grant is None:
+        grant = ConsentGrant(
+            user_id=user_id,
+            client_id=client_id,
+            scopes=merged_scopes,
+            granted_at=granted_at,
+        )
+        db_session.add(grant)
+    else:
+        grant.scopes = merged_scopes
+        grant.granted_at = granted_at
+    await db_session.commit()
+    await hooks.do_action("after_oauth2_consent_granted", grant)
+    return grant
+
+
+async def revoke_grant(db_session: AsyncSession, user_id: str, client_id: str) -> None:
+    """Delete a user's remembered consent for a client."""
+    await db_session.execute(
+        delete(ConsentGrant).where(
+            ConsentGrant.user_id == user_id,
+            ConsentGrant.client_id == client_id,
+        )
+    )
+    await db_session.commit()
+    await hooks.do_action("after_oauth2_consent_revoked", user_id, client_id)
+
+
+async def delete_grants_for_clients(
+    db_session: AsyncSession, client_ids: list[str]
+) -> int:
+    """Delete every remembered consent grant for the given client_ids.
+
+    Cascades an OAuth2 client deletion — the admin delete action and the
+    dynamic-client pruning sweep — to the consent grants that referenced it.
+    """
+    if not client_ids:
+        return 0
+    result = await db_session.execute(
+        delete(ConsentGrant).where(ConsentGrant.client_id.in_(client_ids))
+    )
+    await db_session.commit()
+    return result.rowcount

--- a/skrift/db/services/oauth2_service.py
+++ b/skrift/db/services/oauth2_service.py
@@ -2,10 +2,10 @@
 
 import secrets
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, timedelta
 from uuid import UUID
 
-from sqlalchemy import select, delete
+from sqlalchemy import select, delete, func
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from skrift.auth.client_secret import hash_client_secret
@@ -71,6 +71,99 @@ async def create_client(
     await db_session.commit()
     await hooks.do_action("after_oauth2_client_created", client)
     return ClientCreateResult(client=client, plaintext_secret=plaintext_secret)
+
+
+async def create_dynamic_client(
+    db_session: AsyncSession,
+    *,
+    display_name: str,
+    redirect_uris: list[str],
+    allowed_scopes: list[str],
+    registered_by_ip: str | None,
+    issued_at: datetime,
+) -> OAuth2Client:
+    """Create a public client via RFC 7591 Dynamic Client Registration.
+
+    Dynamic clients are always public: ``client_secret`` is empty and the
+    token-endpoint auth method is ``none``, so they authenticate with PKCE
+    alone. ``issued_at`` is recorded so the pruning job can retire clients
+    that are registered but never used.
+    """
+    client = OAuth2Client(
+        client_id=secrets.token_urlsafe(24),
+        client_secret="",
+        display_name=display_name,
+        redirect_uris="\n".join(redirect_uris),
+        allowed_scopes="\n".join(allowed_scopes),
+        is_dynamically_registered=True,
+        token_endpoint_auth_method="none",
+        registered_by_ip=registered_by_ip,
+        client_id_issued_at=issued_at,
+    )
+    db_session.add(client)
+    await db_session.commit()
+    await hooks.do_action("after_oauth2_client_created", client)
+    return client
+
+
+async def count_recent_dynamic_registrations(
+    db_session: AsyncSession,
+    registered_by_ip: str,
+    since: datetime,
+) -> int:
+    """Count dynamic client registrations from an IP at or after ``since``.
+
+    Backs the per-IP registration cap: the caller compares this against the
+    configured limit before creating another dynamic client for the same IP.
+    """
+    result = await db_session.execute(
+        select(func.count())
+        .select_from(OAuth2Client)
+        .where(
+            OAuth2Client.is_dynamically_registered == True,  # noqa: E712
+            OAuth2Client.registered_by_ip == registered_by_ip,
+            OAuth2Client.client_id_issued_at >= since,
+        )
+    )
+    return int(result.scalar_one())
+
+
+async def mark_client_used(
+    db_session: AsyncSession,
+    client: OAuth2Client,
+    used_at: datetime,
+) -> None:
+    """Stamp ``last_used_at`` on a client after a token is issued for it.
+
+    Keeps dynamically-registered clients out of the pruning job's reach once
+    they have actually been used at least once.
+    """
+    client.last_used_at = used_at
+    await db_session.commit()
+
+
+async def prune_stale_dynamic_clients(
+    db_session: AsyncSession,
+    *,
+    now: datetime,
+    max_age_days: int,
+) -> int:
+    """Delete dynamically-registered clients that were registered but never used.
+
+    A client is pruned only when it is dynamic, has never issued a token
+    (``last_used_at IS NULL``), and was registered more than ``max_age_days``
+    ago. Admin-created and actively-used clients are never touched.
+    """
+    cutoff = now - timedelta(days=max_age_days)
+    result = await db_session.execute(
+        delete(OAuth2Client).where(
+            OAuth2Client.is_dynamically_registered == True,  # noqa: E712
+            OAuth2Client.last_used_at.is_(None),
+            OAuth2Client.client_id_issued_at < cutoff,
+        )
+    )
+    await db_session.commit()
+    return result.rowcount
 
 
 async def update_client(

--- a/skrift/db/services/oauth2_service.py
+++ b/skrift/db/services/oauth2_service.py
@@ -129,6 +129,21 @@ async def count_recent_dynamic_registrations(
     return int(result.scalar_one())
 
 
+async def count_dynamic_clients(db_session: AsyncSession) -> int:
+    """Count every dynamically-registered client currently in the table.
+
+    Backs the global registration cap: the per-IP window only bounds the
+    registration rate, so this total keeps a distributed attacker from
+    growing ``oauth2_clients`` without limit.
+    """
+    result = await db_session.execute(
+        select(func.count())
+        .select_from(OAuth2Client)
+        .where(OAuth2Client.is_dynamically_registered == True)  # noqa: E712
+    )
+    return int(result.scalar_one())
+
+
 async def mark_client_used(
     db_session: AsyncSession,
     client: OAuth2Client,

--- a/skrift/db/services/oauth2_service.py
+++ b/skrift/db/services/oauth2_service.py
@@ -12,6 +12,7 @@ from skrift.auth.client_secret import hash_client_secret
 from skrift.db.models.oauth2_client import OAuth2Client
 from skrift.db.models.revoked_family import RevokedFamily
 from skrift.db.models.revoked_token import RevokedToken
+from skrift.db.services import oauth2_consent_service
 from skrift.hooks import hooks
 
 
@@ -155,12 +156,19 @@ async def prune_stale_dynamic_clients(
     ago. Admin-created and actively-used clients are never touched.
     """
     cutoff = now - timedelta(days=max_age_days)
-    result = await db_session.execute(
-        delete(OAuth2Client).where(
+    stale = await db_session.execute(
+        select(OAuth2Client.client_id).where(
             OAuth2Client.is_dynamically_registered == True,  # noqa: E712
             OAuth2Client.last_used_at.is_(None),
             OAuth2Client.client_id_issued_at < cutoff,
         )
+    )
+    client_ids = [row[0] for row in stale.all()]
+    if not client_ids:
+        return 0
+    await oauth2_consent_service.delete_grants_for_clients(db_session, client_ids)
+    result = await db_session.execute(
+        delete(OAuth2Client).where(OAuth2Client.client_id.in_(client_ids))
     )
     await db_session.commit()
     return result.rowcount
@@ -196,6 +204,7 @@ async def delete_client(db_session: AsyncSession, client_id: UUID) -> None:
     client = result.scalar_one_or_none()
     if client:
         await hooks.do_action("before_oauth2_client_deleted", client)
+        await oauth2_consent_service.delete_grants_for_clients(db_session, [client.client_id])
         await db_session.delete(client)
         await db_session.commit()
         await hooks.do_action("after_oauth2_client_deleted", client_id)

--- a/skrift/db/services/oauth2_signing_key_service.py
+++ b/skrift/db/services/oauth2_signing_key_service.py
@@ -1,0 +1,130 @@
+"""OAuth2 signing key service — asymmetric access-token key lifecycle.
+
+Access tokens are ES256 JWTs signed by a rotating EC P-256 key. The active
+key signs new tokens; retired keys stay published at the JWKS endpoint until
+they age past the access-token lifetime so tokens they signed keep verifying.
+"""
+
+from datetime import datetime, timedelta, timezone
+
+from joserfc.jwk import ECKey
+from sqlalchemy import select, delete
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from skrift.db.models.oauth2_signing_key import OAuth2SigningKey
+from skrift.hooks import hooks
+
+
+SIGNING_ALGORITHM = "ES256"
+_ELLIPTIC_CURVE = "P-256"
+
+
+def _generate_key_material() -> tuple[str, str]:
+    """Generate a fresh EC P-256 key pair.
+
+    Returns the RFC 7638 thumbprint (used as the ``kid``) and the private
+    key PEM. Pure — performs no database work.
+    """
+    key = ECKey.generate_key(_ELLIPTIC_CURVE)
+    kid = key.thumbprint()
+    private_key_pem = key.as_pem(private=True).decode("ascii")
+    return kid, private_key_pem
+
+
+def public_jwk(signing_key: OAuth2SigningKey) -> dict:
+    """Render a signing key's public half as a JWK dict for the JWKS set.
+
+    Pure — reads only the passed model. The ``kid``, ``use`` and ``alg``
+    are attached so third-party verifiers can select the matching key.
+    """
+    key = ECKey.import_key(
+        signing_key.private_key_pem,
+        parameters={"kid": signing_key.kid, "use": "sig", "alg": signing_key.algorithm},
+    )
+    return key.as_dict(private=False)
+
+
+async def get_or_create_active_key(db_session: AsyncSession) -> OAuth2SigningKey:
+    """Return the active signing key, generating one on first use."""
+    result = await db_session.execute(
+        select(OAuth2SigningKey).where(OAuth2SigningKey.is_active == True)  # noqa: E712
+    )
+    active_key = result.scalars().first()
+    if active_key is not None:
+        return active_key
+
+    kid, private_key_pem = _generate_key_material()
+    active_key = OAuth2SigningKey(
+        kid=kid,
+        private_key_pem=private_key_pem,
+        algorithm=SIGNING_ALGORITHM,
+        is_active=True,
+    )
+    db_session.add(active_key)
+    await db_session.commit()
+    await hooks.do_action("after_oauth2_signing_key_created", active_key)
+    return active_key
+
+
+async def rotate(db_session: AsyncSession) -> OAuth2SigningKey:
+    """Promote a freshly generated key to active and retire the old one.
+
+    Retired keys keep their rows (and stay published in the JWKS set) until
+    :func:`prune_expired` removes them once they have aged out.
+    """
+    now = datetime.now(tz=timezone.utc)
+    result = await db_session.execute(
+        select(OAuth2SigningKey).where(OAuth2SigningKey.is_active == True)  # noqa: E712
+    )
+    for previous_key in result.scalars().all():
+        previous_key.is_active = False
+        previous_key.retired_at = now
+
+    kid, private_key_pem = _generate_key_material()
+    new_key = OAuth2SigningKey(
+        kid=kid,
+        private_key_pem=private_key_pem,
+        algorithm=SIGNING_ALGORITHM,
+        is_active=True,
+    )
+    db_session.add(new_key)
+    await db_session.commit()
+    await hooks.do_action("after_oauth2_signing_key_rotated", new_key)
+    return new_key
+
+
+async def list_jwks_keys(db_session: AsyncSession) -> list[dict]:
+    """Return public JWK dicts for every key still published in the JWKS set.
+
+    Keys that :func:`prune_expired` has already removed are gone from the
+    table, so every remaining row is fair to publish.
+    """
+    result = await db_session.execute(
+        select(OAuth2SigningKey).order_by(
+            OAuth2SigningKey.is_active.desc(), OAuth2SigningKey.created_at.desc()
+        )
+    )
+    return [public_jwk(signing_key) for signing_key in result.scalars().all()]
+
+
+async def prune_expired(
+    db_session: AsyncSession,
+    now: datetime,
+    access_token_ttl: int,
+    clock_skew: int,
+) -> int:
+    """Delete retired keys older than the access-token lifetime plus skew.
+
+    A key is safe to drop once ``retired_at + access_token_ttl + clock_skew``
+    has passed, since no unexpired token could still be signed by it. Returns
+    the number of rows deleted.
+    """
+    cutoff = now - timedelta(seconds=access_token_ttl + clock_skew)
+    result = await db_session.execute(
+        delete(OAuth2SigningKey).where(
+            OAuth2SigningKey.retired_at.is_not(None),
+            OAuth2SigningKey.retired_at < cutoff,
+        )
+    )
+    await db_session.commit()
+    return result.rowcount

--- a/skrift/oauth2_maintenance.py
+++ b/skrift/oauth2_maintenance.py
@@ -1,0 +1,65 @@
+"""Background maintenance for the OAuth2 Authorization Server.
+
+Currently hosts the Dynamic Client Registration pruner: dynamically-registered
+clients that were created but never used are deleted once they age past the
+configured window. The pruning logic itself lives in
+:func:`skrift.db.services.oauth2_service.prune_stale_dynamic_clients` so it can
+be unit-tested directly; this module only supplies the worker handler and its
+process-local database access, mirroring ``skrift.webhooks``.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+import skrift
+from skrift.config import get_settings
+from skrift.db.services import oauth2_service
+
+_session_maker: Any | None = None
+
+PRUNE_DYNAMIC_CLIENTS_JOB = "oauth2.prune_dynamic_clients"
+
+
+class OAuth2MaintenanceConfigurationError(RuntimeError):
+    """Raised when the maintenance job runs without a configured session maker."""
+
+
+def configure_oauth2_maintenance(*, session_maker: Any) -> None:
+    """Configure process-local database access for the maintenance handler."""
+    global _session_maker
+    _session_maker = session_maker
+
+
+def _require_session_maker() -> Any:
+    if _session_maker is None:
+        raise OAuth2MaintenanceConfigurationError(
+            "OAuth2 maintenance jobs have no session maker configured"
+        )
+    return _session_maker
+
+
+class PruneDynamicClients(skrift.Job):
+    """Worker payload for the dynamic-client pruning sweep.
+
+    ``max_age_days`` overrides the configured retention window when set; leave
+    it unset to use ``settings.oauth2_dynamic_client_max_age_days``.
+    """
+
+    max_age_days: int | None = None
+
+
+@skrift.handler(PRUNE_DYNAMIC_CLIENTS_JOB, queue="default", max_attempts=1)
+async def prune_dynamic_clients(job: PruneDynamicClients, context) -> dict[str, Any]:
+    """Delete unused, aged-out dynamically-registered OAuth2 clients."""
+    settings = get_settings()
+    max_age_days = job.max_age_days if job.max_age_days is not None else settings.oauth2_dynamic_client_max_age_days
+    session_maker = _require_session_maker()
+    async with session_maker() as db_session:
+        deleted = await oauth2_service.prune_stale_dynamic_clients(
+            db_session,
+            now=datetime.now(tz=timezone.utc),
+            max_age_days=max_age_days,
+        )
+    return {"deleted": deleted}

--- a/skrift/templates/admin/oauth2/list.html
+++ b/skrift/templates/admin/oauth2/list.html
@@ -34,6 +34,9 @@
                 {% else %}
                     <span class="sk-text-muted">Inactive</span>
                 {% endif %}
+                {% if client.is_dynamically_registered %}
+                    <span class="sk-role-badge">Dynamic</span>
+                {% endif %}
             </td>
             <td>
                 <a href="/admin/oauth-clients/{{ client.id }}/edit" role="button" class="sk-btn-outline sk-btn-small">Edit</a>

--- a/tests/integration/test_notification_backends.py
+++ b/tests/integration/test_notification_backends.py
@@ -132,7 +132,7 @@ class TestNotificationBackends:
         items = await drain_queue(q)
         assert len(items) == 1
         assert items[0].type == "dismissed"
-        assert items[0].id == n.id
+        assert items[0].payload["notification_id"] == str(n.id)
 
         # Notification still in storage but dismissed for subscriber
         queued = await backend_a.get_queued_multi(["session:sess-1"])

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+from typing import Any
 
 import pytest
 from pydantic import BaseModel
@@ -689,6 +690,202 @@ async def test_session_send_rejects_deps_kwarg_when_deps_factory_set():
 
     with pytest.raises(AgentSessionError, match="deps_ref"):
         await session.send("again", deps="not durable")
+
+
+async def test_chat_second_turn_uses_fresh_deps_ref():
+    seen: list[dict[str, Any]] = []
+
+    def deps_factory(ctx):
+        seen.append(dict(ctx.deps_ref))
+        return dict(ctx.deps_ref)
+
+    agent = skrift.Agent(TestModel(), name="demo", deps_type=dict, deps_factory=deps_factory)
+
+    @agent.tool
+    def token(ctx: RunContext[dict]) -> str:
+        return ctx.deps.get("token", "")
+
+    await agent.chat("shared", deps_ref={"token": "first"}).send("hi")
+    await agent.chat("shared", deps_ref={"token": "second"}).send("again")
+
+    assert seen[0] == {"token": "first"}
+    assert seen[-1] == {"token": "second"}
+
+
+async def test_session_send_replaces_deps_ref_on_completed_session():
+    seen: list[dict[str, Any]] = []
+
+    def deps_factory(ctx):
+        seen.append(dict(ctx.deps_ref))
+        return dict(ctx.deps_ref)
+
+    agent = skrift.Agent(TestModel(), name="demo", deps_type=dict, deps_factory=deps_factory)
+    session = await agent.run("hi", deps_ref={"token": "first"})
+    await session.result()
+
+    await session.send("again", deps_ref={"token": "second"})
+    await session.result()
+
+    assert seen[-1] == {"token": "second"}
+    state = await session.state()
+    assert state.deps_ref == {"token": "second"}
+
+
+async def test_queued_turns_each_use_own_deps_ref():
+    runtime = skrift.configure_workers(mode="in_process", queues=("agents",))
+    seen: list[dict[str, Any]] = []
+
+    def deps_factory(ctx):
+        seen.append(dict(ctx.deps_ref))
+        return dict(ctx.deps_ref)
+
+    agent = skrift.Agent(TestModel(), name="demo", deps_type=dict, deps_factory=deps_factory)
+    session = await agent.run("hi", deps_ref={"n": 0})
+    turn_one = await session.send("t1", deps_ref={"n": 1})
+    turn_two = await session.send("t2", deps_ref={"n": 2})
+
+    await runtime.start()
+    try:
+        while await session.status() != "completed":
+            await asyncio.sleep(0.01)
+    finally:
+        await runtime.stop()
+
+    assert seen == [{"n": 0}, {"n": 1}, {"n": 2}]
+
+    events = await skrift.get_runtime().event_log.read(f"agents:run:{session.id}")
+    deps_events = [event for _, event in events if event["type"] == "DepsRefUpdated"]
+    assert [
+        (event["payload"]["turn_id"], event["payload"]["deps_ref"]) for event in deps_events
+    ] == [(turn_one, {"n": 1}), (turn_two, {"n": 2})]
+
+
+async def test_mid_turn_send_does_not_change_in_flight_deps_ref():
+    runtime = skrift.configure_workers(mode="in_process", queues=("agents",))
+    seen: list[dict[str, Any]] = []
+
+    def deps_factory(ctx):
+        seen.append(dict(ctx.deps_ref))
+        return dict(ctx.deps_ref)
+
+    agent = skrift.Agent(TestModel(), name="demo", deps_type=dict, deps_factory=deps_factory)
+
+    @agent.tool_plain(approval=True, policy_description="approval required")
+    def touch() -> str:
+        return "ok"
+
+    session = await agent.run("use the tool", deps_ref={"v": "old"})
+    await runtime.start()
+    try:
+        while await session.status() != "awaiting_approval":
+            await asyncio.sleep(0.01)
+        await session.send("next", deps_ref={"v": "new"})
+        for _ in range(500):
+            if len(seen) >= 3:
+                break
+            await asyncio.sleep(0.01)
+    finally:
+        await runtime.stop()
+
+    assert len(seen) >= 3
+    assert all(entry == {"v": "old"} for entry in seen[:-1])
+    assert seen[-1] == {"v": "new"}
+    state = await session.state()
+    assert state.deps_ref == {"v": "new"}
+
+
+async def test_send_without_deps_ref_preserves_stored_deps_ref():
+    seen: list[dict[str, Any]] = []
+
+    def deps_factory(ctx):
+        seen.append(dict(ctx.deps_ref))
+        return dict(ctx.deps_ref)
+
+    agent = skrift.Agent(TestModel(), name="demo", deps_type=dict, deps_factory=deps_factory)
+    session = await agent.run("hi", deps_ref={"token": "keep"})
+    await session.result()
+
+    await session.send("again")
+    await session.result()
+
+    assert seen == [{"token": "keep"}, {"token": "keep"}]
+    state = await session.state()
+    assert state.deps_ref == {"token": "keep"}
+
+
+async def test_agent_run_rejects_deps_ref_without_deps_factory():
+    agent = skrift.Agent(TestModel(custom_output_text="hello"), name="demo")
+
+    with pytest.raises(AgentSessionError, match="no deps_factory"):
+        await agent.run("hi", deps_ref={"token": "x"})
+
+
+async def test_session_send_rejects_deps_ref_without_deps_factory():
+    agent = skrift.Agent(TestModel(custom_output_text="hello"), name="demo")
+    session = await agent.run("hi")
+    assert await session.result() == "hello"
+
+    with pytest.raises(AgentSessionError, match="no deps_factory"):
+        await session.send("again", deps_ref={"token": "x"})
+
+
+async def test_deps_ref_updated_event_emitted_on_change():
+    agent = skrift.Agent(
+        TestModel(),
+        name="demo",
+        deps_type=dict,
+        deps_factory=lambda ctx: dict(ctx.deps_ref),
+    )
+    session = await agent.run("hi", deps_ref={"token": "first"})
+    await session.result()
+
+    turn_id = await session.send("again", deps_ref={"token": "second"})
+    await session.result()
+
+    events = await skrift.get_runtime().event_log.read(f"agents:run:{session.id}")
+    deps_events = [event for _, event in events if event["type"] == "DepsRefUpdated"]
+    assert len(deps_events) == 1
+    assert deps_events[0]["payload"]["deps_ref"] == {"token": "second"}
+    assert deps_events[0]["payload"]["turn_id"] == turn_id
+
+
+async def test_deps_ref_updated_event_not_emitted_when_unchanged():
+    agent = skrift.Agent(
+        TestModel(),
+        name="demo",
+        deps_type=dict,
+        deps_factory=lambda ctx: dict(ctx.deps_ref),
+    )
+    session = await agent.run("hi", deps_ref={"token": "same"})
+    await session.result()
+
+    await session.send("again", deps_ref={"token": "same"})
+    await session.result()
+
+    events = await skrift.get_runtime().event_log.read(f"agents:run:{session.id}")
+    assert not any(event["type"] == "DepsRefUpdated" for _, event in events)
+
+
+async def test_chat_send_deps_ref_overrides_chat_default():
+    seen: list[dict[str, Any]] = []
+
+    def deps_factory(ctx):
+        seen.append(dict(ctx.deps_ref))
+        return dict(ctx.deps_ref)
+
+    agent = skrift.Agent(TestModel(), name="demo", deps_type=dict, deps_factory=deps_factory)
+
+    await agent.chat("k", deps_ref={"token": "default"}).send(
+        "hi", deps_ref={"token": "override"}
+    )
+
+    assert seen[-1] == {"token": "override"}
+
+    await agent.chat("k", deps_ref={"token": "default"}).send(
+        "again", deps_ref={"token": "override-2"}
+    )
+
+    assert seen[-1] == {"token": "override-2"}
 
 
 async def test_agent_constructor_output_type_is_preserved():

--- a/tests/test_mcp_connector_flow.py
+++ b/tests/test_mcp_connector_flow.py
@@ -1,0 +1,402 @@
+"""End-to-end MCP identity-provider flow — the exact Claude custom-connector sequence.
+
+Drives a real in-process Skrift app (OAuth2 + Sitemap controllers, session
+middleware, SQLite-backed) through discovery → Dynamic Client Registration →
+PKCE authorize/consent → token exchange with an RFC 8707 resource → independent
+JWT verification against the published JWKS → a ``BearerJWTOnly``-guarded
+route → refresh rotation → remembered-consent skip.
+"""
+
+import base64
+import hashlib
+import json
+import secrets
+import time
+from urllib.parse import parse_qs, urlsplit
+
+import pytest
+import yaml
+from advanced_alchemy.extensions.litestar import (
+    AsyncSessionConfig,
+    SQLAlchemyAsyncConfig,
+    SQLAlchemyPlugin,
+)
+from joserfc import jwt as jose_jwt
+from joserfc.jwk import KeySet
+from litestar import Litestar, get
+from litestar.testing import TestClient
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.pool import StaticPool
+
+import skrift.db.models  # noqa: F401 — registers all models on Base.metadata
+from skrift.app_factory import (
+    build_template_engine_callback,
+    create_session_config,
+    create_template_config,
+    get_template_directories_for_theme,
+)
+from skrift.auth.bearer import BearerJWTOnly
+from skrift.auth.guards import auth_guard
+from skrift.auth.session_keys import (
+    SESSION_USER_EMAIL,
+    SESSION_USER_ID,
+    SESSION_USER_NAME,
+    SESSION_USER_PICTURE_URL,
+)
+from skrift.controllers.oauth2 import OAuth2Controller
+from skrift.controllers.sitemap import SitemapController
+from skrift.db.base import Base
+from skrift.db.models.user import User
+from skrift.forms.core import CSRF_FIELD_NAME, CSRF_SESSION_KEY
+
+
+SECRET_KEY = "mcp-connector-flow-secret-key-0000000000000000"
+ISSUER = "http://testserver.local"
+RESOURCE = "https://app.example.com/mcp"
+OTHER_RESOURCE = "https://other.example.com/api"
+REDIRECT_URI = "https://claude.ai/api/mcp/auth_callback"
+REQUESTED_SCOPE = "openid profile email"
+CONSENT_CSRF = "mcp-consent-csrf-token"
+
+
+@get("/mcp/ping", guards=[auth_guard, BearerJWTOnly(audience=RESOURCE)])
+async def mcp_ping() -> dict:
+    return {"ok": True}
+
+
+@pytest.fixture
+def app_yaml(tmp_path, monkeypatch):
+    """Point ``get_settings()`` at a tmp app.yaml with the MCP features on."""
+    monkeypatch.setenv("SECRET_KEY", SECRET_KEY)
+    config: dict = {
+        "domain": "localhost",
+        "auth": {
+            "redirect_base_url": ISSUER,
+            "methods": {"dummy": {"type": "dummy", "label": "Dummy"}},
+        },
+        "db": {"url": "sqlite+aiosqlite:///:memory:"},
+        "session": {"max_age": 3600, "cookie_name": "session"},
+        "rate_limit": {"enabled": False},
+        "oauth2_enabled": True,
+        "oauth2_dynamic_registration_enabled": True,
+    }
+    path = tmp_path / "app.yaml"
+    path.write_text(yaml.safe_dump(config))
+
+    from skrift.config import get_settings, set_config_path
+
+    get_settings.cache_clear()
+    set_config_path(path)
+    yield path
+    get_settings.cache_clear()
+    import skrift.config
+
+    skrift.config._config_path_override = None
+
+
+@pytest.fixture
+def engine():
+    """Shared in-memory SQLite engine (StaticPool keeps the same connection)."""
+    return create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        poolclass=StaticPool,
+        connect_args={"check_same_thread": False},
+    )
+
+
+@pytest.fixture
+def app(app_yaml, engine):
+    """A real Skrift-shaped Litestar app: OAuth2 AS + discovery + a guarded route."""
+    db_config = SQLAlchemyAsyncConfig(
+        engine_instance=engine,
+        metadata=Base.metadata,
+        create_all=True,
+        session_config=AsyncSessionConfig(expire_on_commit=False),
+    )
+    session_config = create_session_config(secret_key=SECRET_KEY, max_age=3600, secure=False)
+    template_config = create_template_config(
+        get_template_directories_for_theme(""),
+        build_template_engine_callback(
+            {
+                "site_name": lambda: "Test Site",
+                "static_url": lambda path: f"/static/{path}",
+                "csrf_field": _csrf_field_global(),
+            },
+            register_for_updates=False,
+        ),
+    )
+
+    app = Litestar(
+        route_handlers=[OAuth2Controller, SitemapController, mcp_ping],
+        plugins=[SQLAlchemyPlugin(config=db_config)],
+        middleware=[session_config.middleware],
+        template_config=template_config,
+        csrf_config=None,
+        debug=True,
+    )
+    app.state.session_config = session_config
+    # auth_guard/resolve_bearer_jwt_permissions read this exact key. Advanced
+    # Alchemy de-dupes ``session_maker_app_state_key`` across a process-wide
+    # registry, so under the full suite the plugin may store its maker under
+    # ``session_maker_class_1`` — pin the canonical key deterministically.
+    app.state.session_maker_class = async_sessionmaker(engine, expire_on_commit=False)
+    return app
+
+
+def _csrf_field_global():
+    from jinja2 import pass_context
+
+    from skrift.forms import csrf_field
+
+    @pass_context
+    def render_csrf_field(context):
+        return csrf_field(context["request"])
+
+    return render_csrf_field
+
+
+@pytest.fixture
+def client(app):
+    with TestClient(app=app, session_config=app.state.session_config) as test_client:
+        yield test_client
+
+
+def _generate_pkce_pair() -> tuple[str, str]:
+    verifier = secrets.token_urlsafe(48)
+    digest = hashlib.sha256(verifier.encode()).digest()
+    challenge = base64.urlsafe_b64encode(digest).decode().rstrip("=")
+    return verifier, challenge
+
+
+def _decode_jwt_segment(segment: str) -> dict:
+    padding = "=" * (-len(segment) % 4)
+    return json.loads(base64.urlsafe_b64decode(segment + padding))
+
+
+def _encode_jwt_segment(payload: dict) -> str:
+    return base64.urlsafe_b64encode(json.dumps(payload).encode()).decode().rstrip("=")
+
+
+async def _seed_user(engine) -> str:
+    async with engine.begin() as connection:
+        await connection.run_sync(Base.metadata.create_all)
+    async with AsyncSession(engine, expire_on_commit=False) as session:
+        user = User(email="connector-user@example.com", name="Connector User")
+        session.add(user)
+        await session.commit()
+        return str(user.id)
+
+
+def _login(client: TestClient, user_id: str) -> None:
+    client.set_session_data(
+        {
+            SESSION_USER_ID: user_id,
+            SESSION_USER_EMAIL: "connector-user@example.com",
+            SESSION_USER_NAME: "Connector User",
+            SESSION_USER_PICTURE_URL: "",
+            CSRF_SESSION_KEY: CONSENT_CSRF,
+        }
+    )
+
+
+def _authorize_params(client_id: str, challenge: str, *, resource: str, state: str) -> dict:
+    return {
+        "response_type": "code",
+        "client_id": client_id,
+        "redirect_uri": REDIRECT_URI,
+        "state": state,
+        "scope": REQUESTED_SCOPE,
+        "code_challenge": challenge,
+        "code_challenge_method": "S256",
+        "resource": resource,
+    }
+
+
+def _code_from_redirect(response, *, expected_state: str) -> str:
+    assert response.status_code in (301, 302, 303, 307), response.text
+    location = response.headers["location"]
+    assert location.startswith(REDIRECT_URI)
+    callback_params = parse_qs(urlsplit(location).query)
+    assert callback_params["state"] == [expected_state]
+    return callback_params["code"][0]
+
+
+def _exchange_code(client: TestClient, *, client_id: str, code: str, verifier: str, resource: str) -> dict:
+    response = client.post(
+        "/oauth/token",
+        data={
+            "grant_type": "authorization_code",
+            "code": code,
+            "redirect_uri": REDIRECT_URI,
+            "client_id": client_id,
+            "code_verifier": verifier,
+            "resource": resource,
+        },
+    )
+    assert response.status_code == 200, response.text
+    return response.json()
+
+
+def test_full_claude_connector_flow(client, engine):
+    # 1. RFC 8414 discovery advertises everything the connector needs.
+    discovery = client.get("/.well-known/oauth-authorization-server")
+    assert discovery.status_code == 200
+    metadata = discovery.json()
+    assert metadata["issuer"] == ISSUER
+    assert metadata["authorization_endpoint"] == f"{ISSUER}/oauth/authorize"
+    assert metadata["token_endpoint"] == f"{ISSUER}/oauth/token"
+    assert metadata["registration_endpoint"] == f"{ISSUER}/oauth/register"
+    assert metadata["jwks_uri"] == f"{ISSUER}/oauth/jwks"
+    assert metadata["code_challenge_methods_supported"] == ["S256"]
+    assert "none" in metadata["token_endpoint_auth_methods_supported"]
+
+    # 2. Dynamic Client Registration mints a public (secretless) client.
+    registration = client.post(
+        "/oauth/register",
+        json={
+            "redirect_uris": [REDIRECT_URI],
+            "client_name": "Claude Custom Connector",
+            "token_endpoint_auth_method": "none",
+            "grant_types": ["authorization_code", "refresh_token"],
+            "response_types": ["code"],
+            "scope": REQUESTED_SCOPE,
+        },
+    )
+    assert registration.status_code == 201, registration.text
+    registered = registration.json()
+    client_id = registered["client_id"]
+    assert client_id
+    assert "client_secret" not in registered
+    assert registered["token_endpoint_auth_method"] == "none"
+
+    # 3. Authorize with PKCE S256 + resource: consent screen, then approval.
+    user_id = _run(_seed_user(engine))
+    _login(client, user_id)
+
+    verifier, challenge = _generate_pkce_pair()
+    consent_page = client.get(
+        "/oauth/authorize",
+        params=_authorize_params(client_id, challenge, resource=RESOURCE, state="first-state"),
+        follow_redirects=False,
+    )
+    assert consent_page.status_code == 200, consent_page.text
+    assert "Claude Custom Connector" in consent_page.text
+
+    approval = client.post(
+        "/oauth/authorize",
+        data={"action": "allow", CSRF_FIELD_NAME: CONSENT_CSRF},
+        follow_redirects=False,
+    )
+    code = _code_from_redirect(approval, expected_state="first-state")
+
+    # 4. Token exchange: code + PKCE verifier + resource → ES256 JWT + refresh.
+    token_body = _exchange_code(
+        client, client_id=client_id, code=code, verifier=verifier, resource=RESOURCE
+    )
+    access_token = token_body["access_token"]
+    refresh_token = token_body["refresh_token"]
+    assert access_token.count(".") == 2
+    assert refresh_token
+    assert token_body["token_type"] == "bearer"
+    assert token_body["scope"] == REQUESTED_SCOPE
+
+    # 5. Verify the access token independently against the published JWKS.
+    jwks_response = client.get("/oauth/jwks")
+    assert jwks_response.status_code == 200
+    jwks = jwks_response.json()["keys"]
+    assert jwks
+
+    header = _decode_jwt_segment(access_token.split(".")[0])
+    assert header["alg"] == "ES256"
+    assert header["kid"] in {key["kid"] for key in jwks}
+
+    key_set = KeySet.import_key_set({"keys": jwks})
+    claims = jose_jwt.decode(access_token, key_set, algorithms=["ES256"]).claims
+    assert claims["iss"] == ISSUER
+    assert claims["aud"] == RESOURCE
+    assert claims["sub"] == user_id
+    assert claims["exp"] > time.time()
+
+    # 6. The Bearer guard admits the token; tampered / wrong-aud tokens get 401.
+    protected = client.get("/mcp/ping", headers={"Authorization": f"Bearer {access_token}"})
+    assert protected.status_code == 200, protected.text
+    assert protected.json() == {"ok": True}
+
+    header_b64, payload_b64, signature_b64 = access_token.split(".")
+    tampered_claims = _decode_jwt_segment(payload_b64)
+    tampered_claims["aud"] = OTHER_RESOURCE
+    tampered_token = f"{header_b64}.{_encode_jwt_segment(tampered_claims)}.{signature_b64}"
+    tampered = client.get("/mcp/ping", headers={"Authorization": f"Bearer {tampered_token}"})
+    assert tampered.status_code == 401
+    assert "invalid_token" in tampered.headers.get("www-authenticate", "")
+
+    other_verifier, other_challenge = _generate_pkce_pair()
+    other_authorize = client.get(
+        "/oauth/authorize",
+        params=_authorize_params(
+            client_id, other_challenge, resource=OTHER_RESOURCE, state="other-state"
+        ),
+        follow_redirects=False,
+    )
+    other_code = _code_from_redirect(other_authorize, expected_state="other-state")
+    wrong_audience_token = _exchange_code(
+        client, client_id=client_id, code=other_code, verifier=other_verifier, resource=OTHER_RESOURCE
+    )["access_token"]
+    assert jose_jwt.decode(wrong_audience_token, key_set, algorithms=["ES256"]).claims["aud"] == OTHER_RESOURCE
+    wrong_audience = client.get(
+        "/mcp/ping", headers={"Authorization": f"Bearer {wrong_audience_token}"}
+    )
+    assert wrong_audience.status_code == 401
+    assert "invalid_token" in wrong_audience.headers.get("www-authenticate", "")
+
+    # 7. Refresh rotation: new tokens issued, the old refresh token is dead.
+    refreshed = client.post(
+        "/oauth/token",
+        data={"grant_type": "refresh_token", "refresh_token": refresh_token, "client_id": client_id},
+    )
+    assert refreshed.status_code == 200, refreshed.text
+    refreshed_body = refreshed.json()
+    assert refreshed_body["access_token"].count(".") == 2
+    assert refreshed_body["refresh_token"] != refresh_token
+    assert jose_jwt.decode(
+        refreshed_body["access_token"], key_set, algorithms=["ES256"]
+    ).claims["aud"] == RESOURCE
+
+    replayed = client.post(
+        "/oauth/token",
+        data={"grant_type": "refresh_token", "refresh_token": refresh_token, "client_id": client_id},
+    )
+    assert replayed.status_code == 400
+    assert replayed.json()["error"] == "invalid_grant"
+
+    # 8. Second authorize with the same client+scopes skips the consent screen.
+    repeat_verifier, repeat_challenge = _generate_pkce_pair()
+    repeat_authorize = client.get(
+        "/oauth/authorize",
+        params=_authorize_params(
+            client_id, repeat_challenge, resource=RESOURCE, state="repeat-state"
+        ),
+        follow_redirects=False,
+    )
+    repeat_code = _code_from_redirect(repeat_authorize, expected_state="repeat-state")
+    repeat_body = _exchange_code(
+        client, client_id=client_id, code=repeat_code, verifier=repeat_verifier, resource=RESOURCE
+    )
+    repeat_protected = client.get(
+        "/mcp/ping", headers={"Authorization": f"Bearer {repeat_body['access_token']}"}
+    )
+    assert repeat_protected.status_code == 200
+
+
+def _run(coro):
+    """Run ``coro`` on a loop that outlives the call — the StaticPool-pinned
+    aiosqlite connection must stay usable for the TestClient afterwards."""
+    import asyncio
+
+    policy = asyncio.get_event_loop_policy()
+    loop = getattr(policy, "_mcp_flow_loop", None)
+    if loop is None or loop.is_closed():
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        policy._mcp_flow_loop = loop
+    return loop.run_until_complete(coro)

--- a/tests/test_oauth2_bearer_guard.py
+++ b/tests/test_oauth2_bearer_guard.py
@@ -1,0 +1,379 @@
+"""Phase 3 MCP identity provider — reusable Bearer JWT route guard.
+
+``BearerJWTAuth``/``BearerJWTOnly`` markers switch ``auth_guard`` into
+accepting ES256 access-token JWTs minted by the OAuth2 Authorization Server.
+The guard must fail closed: bad signature, wrong audience, expiry, revoked
+``jti``, missing scope, or an unknown/inactive subject all yield 401 with an
+RFC 6750 ``WWW-Authenticate`` challenge. API keys (``sk_`` bearers) and JWTs
+share the ``Authorization`` header, so the two schemes must never collide.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from joserfc.jwk import ECKey
+from litestar.exceptions import NotAuthorizedException
+
+from skrift.auth.bearer import BearerJWTAuth, BearerJWTOnly, is_jwt_shaped
+from skrift.auth.guards import APIKeyAuth, APIKeyOnly, Permission, auth_guard
+from skrift.auth.jwt_tokens import create_access_token_jwt
+from skrift.auth.services import UserPermissions
+from skrift.auth.session_keys import SESSION_USER_ID
+from skrift.db.services import oauth2_signing_key_service as signing_keys
+
+
+ISSUER = "http://localhost:8000"
+RESOURCE = "https://app.example.com/mcp"
+OTHER_RESOURCE = "https://other.example.com/api"
+USER_ID = "00000000-0000-0000-0000-000000000042"
+ACCESS_TTL = 900
+
+
+def _signing_key():
+    """A mock OAuth2SigningKey row backed by real EC P-256 key material."""
+    key = ECKey.generate_key("P-256")
+    signing_key = MagicMock()
+    signing_key.kid = key.thumbprint()
+    signing_key.private_key_pem = key.as_pem(private=True).decode("ascii")
+    signing_key.algorithm = "ES256"
+    return signing_key
+
+
+def _jwks_for(*keys) -> list[dict]:
+    return [signing_keys.public_jwk(key) for key in keys]
+
+
+def _mint(signing_key, *, subject=USER_ID, audience=RESOURCE, issuer=ISSUER, scope="openid mcp", expires_in=ACCESS_TTL):
+    return create_access_token_jwt(
+        subject=subject,
+        client_id="abc",
+        scope=scope,
+        audience=audience,
+        issuer=issuer,
+        signing_key=signing_key,
+        expires_in=expires_in,
+    )
+
+
+def _settings():
+    settings = MagicMock()
+    settings.oauth2_issuer = ISSUER
+    return settings
+
+
+def _connection(*, headers=None, session=None):
+    """Build a stand-in ``ASGIConnection`` with just the pieces the guard
+    touches — mirrors tests/test_auth_guards_client_ip.py."""
+    connection = MagicMock()
+    connection.headers = headers or {}
+    connection.session = session if session is not None else {}
+    connection.scope = {"state": {}, "client": ("1.2.3.4", 1234)}
+    connection.base_url = "http://localhost:8000/"
+
+    db_session = AsyncMock()
+    context_manager = AsyncMock()
+    context_manager.__aenter__ = AsyncMock(return_value=db_session)
+    context_manager.__aexit__ = AsyncMock(return_value=None)
+    connection.app.state.session_maker_class = MagicMock(return_value=context_manager)
+    return connection, db_session
+
+
+def _route_handler(*guards):
+    handler = MagicMock()
+    handler.guards = [auth_guard, *guards]
+    return handler
+
+
+async def _run_guard(
+    guards,
+    *,
+    headers=None,
+    session=None,
+    jwks=None,
+    revoked=False,
+    user="active",
+    permissions=None,
+):
+    """Invoke ``auth_guard`` with all bearer-JWT collaborators patched."""
+    connection, db_session = _connection(headers=headers, session=session)
+    if user == "active":
+        user = MagicMock(is_active=True)
+    elif user == "inactive":
+        user = MagicMock(is_active=False)
+    db_session.get = AsyncMock(return_value=user)
+
+    granted = permissions if permissions is not None else UserPermissions(
+        user_id=USER_ID, roles=set(), permissions={"manage-pages"}
+    )
+
+    with patch("skrift.auth.bearer.get_settings", return_value=_settings()), \
+         patch("skrift.auth.bearer.oauth2_signing_key_service") as mock_keys, \
+         patch("skrift.auth.bearer.oauth2_service") as mock_oauth2, \
+         patch("skrift.auth.bearer.get_user_permissions", new=AsyncMock(return_value=granted)), \
+         patch("skrift.auth.services.get_user_permissions", new=AsyncMock(return_value=granted)):
+        mock_keys.list_jwks_keys = AsyncMock(return_value=jwks if jwks is not None else [])
+        mock_oauth2.is_token_revoked = AsyncMock(return_value=revoked)
+        await auth_guard(connection, _route_handler(*guards))
+    return db_session
+
+
+def _www_authenticate(excinfo) -> str:
+    return (excinfo.value.headers or {}).get("WWW-Authenticate", "")
+
+
+class TestJwtShapeDisambiguation:
+    def test_compact_jws_is_jwt_shaped(self):
+        assert is_jwt_shaped("eyJhbGciOi.eyJzdWIiOi.c2ln")
+
+    def test_api_key_prefix_is_never_jwt_shaped(self):
+        assert not is_jwt_shaped("sk_live_abc123")
+        assert not is_jwt_shaped("sk_a.b.c")
+
+    def test_wrong_segment_counts_are_not_jwt_shaped(self):
+        for token in ["", "abc", "a.b", "a.b.c.d"]:
+            assert not is_jwt_shaped(token)
+
+
+class TestBearerJwtHappyPath:
+    @pytest.mark.asyncio
+    async def test_valid_jwt_passes_guard_and_permission_check(self):
+        key = _signing_key()
+        await _run_guard(
+            [BearerJWTAuth(audience=RESOURCE, scopes=["mcp"]), Permission("manage-pages")],
+            headers={"authorization": f"Bearer {_mint(key)}"},
+            jwks=_jwks_for(key),
+        )
+
+    @pytest.mark.asyncio
+    async def test_permission_requirements_still_enforced_for_jwt_identity(self):
+        key = _signing_key()
+        with pytest.raises(NotAuthorizedException):
+            await _run_guard(
+                [BearerJWTAuth(audience=RESOURCE), Permission("manage-users")],
+                headers={"authorization": f"Bearer {_mint(key)}"},
+                jwks=_jwks_for(key),
+                permissions=UserPermissions(user_id=USER_ID, roles=set(), permissions={"manage-pages"}),
+            )
+
+    @pytest.mark.asyncio
+    async def test_jwt_only_route_accepts_valid_jwt(self):
+        key = _signing_key()
+        await _run_guard(
+            [BearerJWTOnly(audience=RESOURCE)],
+            headers={"authorization": f"Bearer {_mint(key)}"},
+            jwks=_jwks_for(key),
+        )
+
+
+class TestBearerJwtRejections:
+    @pytest.mark.asyncio
+    async def test_expired_jwt_rejected_as_invalid_token(self):
+        key = _signing_key()
+        with pytest.raises(NotAuthorizedException) as excinfo:
+            await _run_guard(
+                [BearerJWTAuth(audience=RESOURCE)],
+                headers={"authorization": f"Bearer {_mint(key, expires_in=-10)}"},
+                jwks=_jwks_for(key),
+            )
+        assert 'error="invalid_token"' in _www_authenticate(excinfo)
+
+    @pytest.mark.asyncio
+    async def test_wrong_audience_rejected_as_invalid_token(self):
+        key = _signing_key()
+        with pytest.raises(NotAuthorizedException) as excinfo:
+            await _run_guard(
+                [BearerJWTAuth(audience=RESOURCE)],
+                headers={"authorization": f"Bearer {_mint(key, audience=OTHER_RESOURCE)}"},
+                jwks=_jwks_for(key),
+            )
+        assert 'error="invalid_token"' in _www_authenticate(excinfo)
+
+    @pytest.mark.asyncio
+    async def test_missing_audience_claim_rejected_as_invalid_token(self):
+        key = _signing_key()
+        with pytest.raises(NotAuthorizedException) as excinfo:
+            await _run_guard(
+                [BearerJWTAuth(audience=RESOURCE)],
+                headers={"authorization": f"Bearer {_mint(key, audience=None)}"},
+                jwks=_jwks_for(key),
+            )
+        assert 'error="invalid_token"' in _www_authenticate(excinfo)
+
+    @pytest.mark.asyncio
+    async def test_tampered_jwt_rejected_as_invalid_token(self):
+        import base64
+        import json
+
+        key = _signing_key()
+        token = _mint(key)
+        header_b64, payload_b64, signature_b64 = token.split(".")
+        claims = json.loads(base64.urlsafe_b64decode(payload_b64 + "=="))
+        claims["sub"] = USER_ID.replace("42", "43")
+        tampered_payload = base64.urlsafe_b64encode(json.dumps(claims).encode()).decode().rstrip("=")
+        with pytest.raises(NotAuthorizedException) as excinfo:
+            await _run_guard(
+                [BearerJWTAuth(audience=RESOURCE)],
+                headers={"authorization": f"Bearer {header_b64}.{tampered_payload}.{signature_b64}"},
+                jwks=_jwks_for(key),
+            )
+        assert 'error="invalid_token"' in _www_authenticate(excinfo)
+
+    @pytest.mark.asyncio
+    async def test_wrong_issuer_rejected_as_invalid_token(self):
+        key = _signing_key()
+        with pytest.raises(NotAuthorizedException) as excinfo:
+            await _run_guard(
+                [BearerJWTAuth(audience=RESOURCE)],
+                headers={"authorization": f"Bearer {_mint(key, issuer='https://evil.example.com')}"},
+                jwks=_jwks_for(key),
+            )
+        assert 'error="invalid_token"' in _www_authenticate(excinfo)
+
+    @pytest.mark.asyncio
+    async def test_missing_required_scope_rejected_as_insufficient_scope(self):
+        key = _signing_key()
+        with pytest.raises(NotAuthorizedException) as excinfo:
+            await _run_guard(
+                [BearerJWTAuth(audience=RESOURCE, scopes=["admin"])],
+                headers={"authorization": f"Bearer {_mint(key, scope='openid mcp')}"},
+                jwks=_jwks_for(key),
+            )
+        challenge = _www_authenticate(excinfo)
+        assert 'error="insufficient_scope"' in challenge
+        assert 'scope="admin"' in challenge
+
+    @pytest.mark.asyncio
+    async def test_revoked_jti_rejected_as_invalid_token(self):
+        key = _signing_key()
+        with pytest.raises(NotAuthorizedException) as excinfo:
+            await _run_guard(
+                [BearerJWTAuth(audience=RESOURCE)],
+                headers={"authorization": f"Bearer {_mint(key)}"},
+                jwks=_jwks_for(key),
+                revoked=True,
+            )
+        assert 'error="invalid_token"' in _www_authenticate(excinfo)
+
+    @pytest.mark.asyncio
+    async def test_unknown_subject_rejected_as_invalid_token(self):
+        key = _signing_key()
+        with pytest.raises(NotAuthorizedException) as excinfo:
+            await _run_guard(
+                [BearerJWTAuth(audience=RESOURCE)],
+                headers={"authorization": f"Bearer {_mint(key)}"},
+                jwks=_jwks_for(key),
+                user=None,
+            )
+        assert 'error="invalid_token"' in _www_authenticate(excinfo)
+
+    @pytest.mark.asyncio
+    async def test_inactive_subject_rejected_as_invalid_token(self):
+        key = _signing_key()
+        with pytest.raises(NotAuthorizedException) as excinfo:
+            await _run_guard(
+                [BearerJWTAuth(audience=RESOURCE)],
+                headers={"authorization": f"Bearer {_mint(key)}"},
+                jwks=_jwks_for(key),
+                user="inactive",
+            )
+        assert 'error="invalid_token"' in _www_authenticate(excinfo)
+
+    @pytest.mark.asyncio
+    async def test_malformed_subject_rejected_as_invalid_token(self):
+        key = _signing_key()
+        with pytest.raises(NotAuthorizedException) as excinfo:
+            await _run_guard(
+                [BearerJWTAuth(audience=RESOURCE)],
+                headers={"authorization": f"Bearer {_mint(key, subject='not-a-uuid')}"},
+                jwks=_jwks_for(key),
+            )
+        assert 'error="invalid_token"' in _www_authenticate(excinfo)
+
+    @pytest.mark.asyncio
+    async def test_empty_jwks_rejected_as_invalid_token(self):
+        key = _signing_key()
+        with pytest.raises(NotAuthorizedException) as excinfo:
+            await _run_guard(
+                [BearerJWTAuth(audience=RESOURCE)],
+                headers={"authorization": f"Bearer {_mint(key)}"},
+                jwks=[],
+            )
+        assert 'error="invalid_token"' in _www_authenticate(excinfo)
+
+    @pytest.mark.asyncio
+    async def test_missing_bearer_on_jwt_only_route_gets_bearer_challenge(self):
+        with pytest.raises(NotAuthorizedException) as excinfo:
+            await _run_guard([BearerJWTOnly(audience=RESOURCE)])
+        assert _www_authenticate(excinfo).startswith("Bearer")
+
+
+class TestSchemeCollision:
+    @pytest.mark.asyncio
+    async def test_api_key_bearer_still_routes_to_api_key_path(self):
+        granted = UserPermissions(user_id=USER_ID, roles=set(), permissions={"manage-pages"})
+        connection, _ = _connection(headers={"authorization": "Bearer sk_test_key"})
+        resolve_api_key = AsyncMock(return_value=(USER_ID, granted))
+        with patch("skrift.auth.guards._resolve_api_key_permissions", resolve_api_key):
+            await auth_guard(
+                connection,
+                _route_handler(APIKeyAuth(), Permission("manage-pages")),
+            )
+        resolve_api_key.assert_awaited_once()
+        assert resolve_api_key.await_args.args[1] == "sk_test_key"
+
+    @pytest.mark.asyncio
+    async def test_jwt_does_not_satisfy_api_key_only_route(self):
+        key = _signing_key()
+        connection, _ = _connection(headers={"authorization": f"Bearer {_mint(key)}"})
+        resolve_api_key = AsyncMock(return_value=(None, None))
+        with patch("skrift.auth.guards._resolve_api_key_permissions", resolve_api_key), \
+             pytest.raises(NotAuthorizedException):
+            await auth_guard(connection, _route_handler(APIKeyOnly()))
+        resolve_api_key.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_api_key_does_not_satisfy_jwt_only_route(self):
+        connection, _ = _connection(headers={"authorization": "Bearer sk_test_key"})
+        resolve_api_key = AsyncMock(return_value=(USER_ID, MagicMock()))
+        with patch("skrift.auth.guards._resolve_api_key_permissions", resolve_api_key), \
+             pytest.raises(NotAuthorizedException):
+            await auth_guard(connection, _route_handler(BearerJWTOnly(audience=RESOURCE)))
+        resolve_api_key.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_mixed_route_routes_each_scheme_correctly(self):
+        key = _signing_key()
+        await _run_guard(
+            [BearerJWTAuth(audience=RESOURCE), APIKeyAuth(), Permission("manage-pages")],
+            headers={"authorization": f"Bearer {_mint(key)}"},
+            jwks=_jwks_for(key),
+        )
+
+
+class TestSessionInterplay:
+    @pytest.mark.asyncio
+    async def test_session_user_allowed_on_jwt_compatible_route(self):
+        await _run_guard(
+            [BearerJWTAuth(audience=RESOURCE), Permission("manage-pages")],
+            session={SESSION_USER_ID: USER_ID},
+        )
+
+    @pytest.mark.asyncio
+    async def test_session_user_rejected_on_jwt_only_route(self):
+        with pytest.raises(NotAuthorizedException):
+            await _run_guard(
+                [BearerJWTOnly(audience=RESOURCE)],
+                session={SESSION_USER_ID: USER_ID},
+            )
+
+    @pytest.mark.asyncio
+    async def test_invalid_jwt_does_not_fall_back_to_session(self):
+        key = _signing_key()
+        with pytest.raises(NotAuthorizedException) as excinfo:
+            await _run_guard(
+                [BearerJWTAuth(audience=RESOURCE)],
+                headers={"authorization": f"Bearer {_mint(key, expires_in=-10)}"},
+                session={SESSION_USER_ID: USER_ID},
+                jwks=_jwks_for(key),
+            )
+        assert 'error="invalid_token"' in _www_authenticate(excinfo)

--- a/tests/test_oauth2_code_replay.py
+++ b/tests/test_oauth2_code_replay.py
@@ -28,7 +28,21 @@ def _pkce_pair():
 def _settings():
     settings = MagicMock()
     settings.secret_key = SECRET
+    settings.oauth2_issuer = "http://localhost:8000"
+    settings.oauth2_access_token_ttl = ACCESS_TOKEN_TTL
+    settings.oauth2_allowed_resources = []
     return settings
+
+
+def _signing_key():
+    from joserfc.jwk import ECKey
+
+    key = ECKey.generate_key("P-256")
+    signing_key = MagicMock()
+    signing_key.kid = key.thumbprint()
+    signing_key.private_key_pem = key.as_pem(private=True).decode("ascii")
+    signing_key.algorithm = "ES256"
+    return signing_key
 
 
 def _client(secret="s"):
@@ -84,10 +98,13 @@ async def test_authorization_code_is_revoked_after_successful_exchange():
     db_session = AsyncMock()
 
     with patch("skrift.controllers.oauth2.get_settings", return_value=_settings()), \
-         patch("skrift.controllers.oauth2.oauth2_service") as mock_svc:
+         patch("skrift.controllers.oauth2.oauth2_service") as mock_svc, \
+         patch("skrift.controllers.oauth2.oauth2_signing_key_service") as mock_keys:
         mock_svc.get_client_by_client_id = AsyncMock(return_value=_client())
         mock_svc.is_token_revoked = AsyncMock(return_value=False)
         mock_svc.revoke_token = AsyncMock(return_value=None)
+        mock_svc.mark_client_used = AsyncMock()
+        mock_keys.get_or_create_active_key = AsyncMock(return_value=_signing_key())
 
         result = await OAuth2Controller.token_exchange.fn(controller, request, db_session)
 

--- a/tests/test_oauth2_consent.py
+++ b/tests/test_oauth2_consent.py
@@ -1,0 +1,323 @@
+"""Phase 3 MCP identity provider — remembered OAuth2 consent.
+
+Covers the ConsentGrant service (find/upsert/union/revoke/cascade), the
+``/oauth/authorize`` consent-skip and re-prompt behaviour, that consent
+approval persists a grant, and that deleting or pruning a client removes its
+grants.
+"""
+
+from datetime import datetime, timezone, timedelta
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+import pytest_asyncio
+from litestar.response import Redirect, Template as TemplateResponse
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+from skrift.config import SecurityHeadersConfig
+from skrift.controllers.oauth2 import OAuth2Controller
+from skrift.db.base import Base
+from skrift.db.models import ConsentGrant, OAuth2Client  # noqa: F401  (registers tables)
+from skrift.db.services import oauth2_consent_service, oauth2_service
+
+
+SECRET = "test-secret-key"
+USER_ID = "00000000-0000-0000-0000-000000000042"
+OTHER_USER_ID = "00000000-0000-0000-0000-000000000099"
+REDIRECT_URI = "http://localhost/cb"
+
+
+@pytest_asyncio.fixture
+async def db_session():
+    engine = create_async_engine("sqlite+aiosqlite://")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    maker = async_sessionmaker(engine, expire_on_commit=False)
+    async with maker() as session:
+        yield session
+    await engine.dispose()
+
+
+def _settings():
+    settings = MagicMock()
+    settings.secret_key = SECRET
+    settings.security_headers = SecurityHeadersConfig()
+    settings.oauth2_allowed_resources = []
+    return settings
+
+
+async def _make_client(db_session, scopes=None):
+    return await oauth2_service.create_dynamic_client(
+        db_session,
+        display_name="Consent App",
+        redirect_uris=[REDIRECT_URI],
+        allowed_scopes=scopes or [],
+        registered_by_ip="1.1.1.1",
+        issued_at=datetime.now(tz=timezone.utc),
+    )
+
+
+def _authorize_get_request(client_id, scope, user_id=USER_ID):
+    request = MagicMock()
+    request.query_params = {
+        "response_type": "code",
+        "client_id": client_id,
+        "redirect_uri": REDIRECT_URI,
+        "state": "xyz",
+        "scope": scope,
+        "code_challenge": "challenge",
+        "code_challenge_method": "S256",
+    }
+    request.session = {
+        "user_id": user_id,
+        "user_email": "u@example.com",
+        "user_name": "User",
+        "user_picture_url": "",
+    }
+    return request
+
+
+async def _authorize_get(db_session, request):
+    controller = OAuth2Controller(owner=MagicMock())
+    with patch("skrift.controllers.oauth2.get_settings", return_value=_settings()):
+        return await OAuth2Controller.authorize_get.fn(controller, request, db_session)
+
+
+class TestConsentService:
+    @pytest.mark.asyncio
+    async def test_find_grant_missing_returns_none(self, db_session):
+        assert await oauth2_consent_service.find_grant(db_session, USER_ID, "client-a") is None
+
+    @pytest.mark.asyncio
+    async def test_upsert_creates_grant(self, db_session):
+        grant = await oauth2_consent_service.upsert_grant(
+            db_session,
+            user_id=USER_ID,
+            client_id="client-a",
+            scopes=["openid", "profile"],
+            granted_at=datetime.now(tz=timezone.utc),
+        )
+        assert set(grant.scope_list) == {"openid", "profile"}
+        found = await oauth2_consent_service.find_grant(db_session, USER_ID, "client-a")
+        assert found is not None
+        assert set(found.scope_list) == {"openid", "profile"}
+
+    @pytest.mark.asyncio
+    async def test_upsert_unions_scopes_and_keeps_one_row(self, db_session):
+        now = datetime.now(tz=timezone.utc)
+        await oauth2_consent_service.upsert_grant(
+            db_session, user_id=USER_ID, client_id="client-a", scopes=["openid"], granted_at=now
+        )
+        await oauth2_consent_service.upsert_grant(
+            db_session, user_id=USER_ID, client_id="client-a", scopes=["email"], granted_at=now
+        )
+        found = await oauth2_consent_service.find_grant(db_session, USER_ID, "client-a")
+        assert set(found.scope_list) == {"openid", "email"}
+        rows = (await db_session.execute(select(ConsentGrant))).scalars().all()
+        assert len(rows) == 1
+
+    @pytest.mark.asyncio
+    async def test_grant_is_scoped_per_user(self, db_session):
+        now = datetime.now(tz=timezone.utc)
+        await oauth2_consent_service.upsert_grant(
+            db_session, user_id=USER_ID, client_id="client-a", scopes=["openid"], granted_at=now
+        )
+        assert (
+            await oauth2_consent_service.find_grant(db_session, OTHER_USER_ID, "client-a")
+            is None
+        )
+
+    @pytest.mark.asyncio
+    async def test_revoke_grant_deletes_it(self, db_session):
+        now = datetime.now(tz=timezone.utc)
+        await oauth2_consent_service.upsert_grant(
+            db_session, user_id=USER_ID, client_id="client-a", scopes=["openid"], granted_at=now
+        )
+        await oauth2_consent_service.revoke_grant(db_session, USER_ID, "client-a")
+        assert await oauth2_consent_service.find_grant(db_session, USER_ID, "client-a") is None
+
+    @pytest.mark.asyncio
+    async def test_delete_grants_for_clients_is_bulk(self, db_session):
+        now = datetime.now(tz=timezone.utc)
+        await oauth2_consent_service.upsert_grant(
+            db_session, user_id=USER_ID, client_id="client-a", scopes=["openid"], granted_at=now
+        )
+        await oauth2_consent_service.upsert_grant(
+            db_session, user_id=OTHER_USER_ID, client_id="client-a", scopes=["openid"], granted_at=now
+        )
+        await oauth2_consent_service.upsert_grant(
+            db_session, user_id=USER_ID, client_id="client-b", scopes=["openid"], granted_at=now
+        )
+        deleted = await oauth2_consent_service.delete_grants_for_clients(db_session, ["client-a"])
+        assert deleted == 2
+        remaining = (await db_session.execute(select(ConsentGrant))).scalars().all()
+        assert [g.client_id for g in remaining] == ["client-b"]
+
+
+class TestAuthorizeConsentSkip:
+    @pytest.mark.asyncio
+    async def test_first_authorize_prompts_consent(self, db_session):
+        client = await _make_client(db_session)
+        request = _authorize_get_request(client.client_id, "openid profile")
+        result = await _authorize_get(db_session, request)
+        assert isinstance(result, TemplateResponse)
+        assert result.template_name == "oauth/authorize.html"
+
+    @pytest.mark.asyncio
+    async def test_remembered_consent_skips_and_issues_code(self, db_session):
+        client = await _make_client(db_session)
+        await oauth2_consent_service.upsert_grant(
+            db_session,
+            user_id=USER_ID,
+            client_id=client.client_id,
+            scopes=["openid", "profile"],
+            granted_at=datetime.now(tz=timezone.utc),
+        )
+        request = _authorize_get_request(client.client_id, "openid profile")
+        result = await _authorize_get(db_session, request)
+        assert isinstance(result, Redirect)
+        assert "code=" in result.url
+        assert "state=xyz" in result.url
+        # A skip must not stash consent params in the session.
+        assert "oauth_authorize" not in request.session
+
+    @pytest.mark.asyncio
+    async def test_subset_scopes_skip_consent(self, db_session):
+        client = await _make_client(db_session)
+        await oauth2_consent_service.upsert_grant(
+            db_session,
+            user_id=USER_ID,
+            client_id=client.client_id,
+            scopes=["openid", "profile", "email"],
+            granted_at=datetime.now(tz=timezone.utc),
+        )
+        request = _authorize_get_request(client.client_id, "openid")
+        result = await _authorize_get(db_session, request)
+        assert isinstance(result, Redirect)
+        assert "code=" in result.url
+
+    @pytest.mark.asyncio
+    async def test_broader_scopes_reprompt(self, db_session):
+        client = await _make_client(db_session)
+        await oauth2_consent_service.upsert_grant(
+            db_session,
+            user_id=USER_ID,
+            client_id=client.client_id,
+            scopes=["openid"],
+            granted_at=datetime.now(tz=timezone.utc),
+        )
+        request = _authorize_get_request(client.client_id, "openid profile")
+        result = await _authorize_get(db_session, request)
+        assert isinstance(result, TemplateResponse)
+
+    @pytest.mark.asyncio
+    async def test_grant_for_other_user_does_not_skip(self, db_session):
+        client = await _make_client(db_session)
+        await oauth2_consent_service.upsert_grant(
+            db_session,
+            user_id=OTHER_USER_ID,
+            client_id=client.client_id,
+            scopes=["openid", "profile"],
+            granted_at=datetime.now(tz=timezone.utc),
+        )
+        request = _authorize_get_request(client.client_id, "openid profile")
+        result = await _authorize_get(db_session, request)
+        assert isinstance(result, TemplateResponse)
+
+
+class TestAuthorizePostPersistsGrant:
+    @pytest.mark.asyncio
+    async def test_approval_persists_grant(self, db_session):
+        client = await _make_client(db_session)
+        controller = OAuth2Controller(owner=MagicMock())
+        request = MagicMock()
+        request.session = {
+            "user_id": USER_ID,
+            "user_email": "u@example.com",
+            "user_name": "User",
+            "user_picture_url": "",
+            "oauth_authorize": {
+                "client_id": client.client_id,
+                "redirect_uri": REDIRECT_URI,
+                "state": "xyz",
+                "scope": "openid profile",
+                "code_challenge": "challenge",
+                "resource": "",
+            },
+        }
+        request.form = AsyncMock(return_value={"action": "allow"})
+
+        with patch("skrift.controllers.oauth2.verify_csrf", new_callable=AsyncMock, return_value=True), \
+             patch("skrift.controllers.oauth2.get_settings", return_value=_settings()):
+            result = await OAuth2Controller.authorize_post.fn(controller, request, db_session)
+
+        assert isinstance(result, Redirect)
+        assert "code=" in result.url
+        grant = await oauth2_consent_service.find_grant(db_session, USER_ID, client.client_id)
+        assert grant is not None
+        assert set(grant.scope_list) == {"openid", "profile"}
+
+    @pytest.mark.asyncio
+    async def test_denial_does_not_persist_grant(self, db_session):
+        client = await _make_client(db_session)
+        controller = OAuth2Controller(owner=MagicMock())
+        request = MagicMock()
+        request.session = {
+            "user_id": USER_ID,
+            "oauth_authorize": {
+                "client_id": client.client_id,
+                "redirect_uri": REDIRECT_URI,
+                "state": "xyz",
+                "scope": "openid profile",
+                "code_challenge": "challenge",
+                "resource": "",
+            },
+        }
+        request.form = AsyncMock(return_value={"action": "deny"})
+
+        with patch("skrift.controllers.oauth2.verify_csrf", new_callable=AsyncMock, return_value=True), \
+             patch("skrift.controllers.oauth2.get_settings", return_value=_settings()):
+            result = await OAuth2Controller.authorize_post.fn(controller, request, db_session)
+
+        assert isinstance(result, Redirect)
+        assert "error=access_denied" in result.url
+        assert await oauth2_consent_service.find_grant(db_session, USER_ID, client.client_id) is None
+
+
+class TestClientDeletionCascade:
+    @pytest.mark.asyncio
+    async def test_delete_client_removes_its_grants(self, db_session):
+        client = await _make_client(db_session)
+        await oauth2_consent_service.upsert_grant(
+            db_session,
+            user_id=USER_ID,
+            client_id=client.client_id,
+            scopes=["openid"],
+            granted_at=datetime.now(tz=timezone.utc),
+        )
+        await oauth2_service.delete_client(db_session, client.id)
+        assert await oauth2_consent_service.find_grant(db_session, USER_ID, client.client_id) is None
+
+    @pytest.mark.asyncio
+    async def test_prune_removes_grants_of_pruned_clients(self, db_session):
+        client = await oauth2_service.create_dynamic_client(
+            db_session,
+            display_name="Stale",
+            redirect_uris=[REDIRECT_URI],
+            allowed_scopes=[],
+            registered_by_ip="1.1.1.1",
+            issued_at=datetime.now(tz=timezone.utc) - timedelta(days=30),
+        )
+        await oauth2_consent_service.upsert_grant(
+            db_session,
+            user_id=USER_ID,
+            client_id=client.client_id,
+            scopes=["openid"],
+            granted_at=datetime.now(tz=timezone.utc),
+        )
+        deleted = await oauth2_service.prune_stale_dynamic_clients(
+            db_session, now=datetime.now(tz=timezone.utc), max_age_days=7
+        )
+        assert deleted == 1
+        assert await oauth2_consent_service.find_grant(db_session, USER_ID, client.client_id) is None

--- a/tests/test_oauth2_dcr.py
+++ b/tests/test_oauth2_dcr.py
@@ -1,0 +1,571 @@
+"""Phase 2 MCP identity provider — RFC 7591 Dynamic Client Registration.
+
+Covers POST /oauth/register (public-client creation, gating, redirect-uri
+hardening, per-IP cap, client_name injection safety), last_used_at stamping,
+the dynamic-client pruning service + worker handler, and the discovery
+registration_endpoint.
+"""
+
+import base64
+import hashlib
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+import pytest_asyncio
+from jinja2 import Environment
+from litestar.exceptions import NotFoundException
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+import skrift
+from skrift.auth.tokens import create_signed_token
+from skrift.config import SecurityHeadersConfig
+from skrift.controllers.oauth2 import (
+    AUTH_CODE_TTL,
+    CLIENT_NAME_MAX_LENGTH,
+    OAuth2Controller,
+    _redirect_uri_origin,
+    _validate_registration_redirect_uri,
+)
+from skrift.controllers.sitemap import build_authorization_server_metadata
+from skrift.db.base import Base
+from skrift.db.models import OAuth2Client, OAuth2SigningKey  # noqa: F401  (registers tables)
+from skrift.db.services import oauth2_service
+
+
+SECRET = "test-secret-key"
+ISSUER = "http://localhost:8000"
+USER_ID = "00000000-0000-0000-0000-000000000042"
+
+
+@pytest_asyncio.fixture
+async def db_session():
+    engine = create_async_engine("sqlite+aiosqlite://")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    maker = async_sessionmaker(engine, expire_on_commit=False)
+    async with maker() as session:
+        yield session
+    await engine.dispose()
+
+
+def _settings(*, enabled=True, dcr=True, ip_limit=20, window=3600, max_age_days=7):
+    settings = MagicMock()
+    settings.secret_key = SECRET
+    settings.security_headers = SecurityHeadersConfig()
+    settings.oauth2_enabled = enabled
+    settings.oauth2_dynamic_registration_enabled = dcr
+    settings.oauth2_issuer = ISSUER
+    settings.oauth2_access_token_ttl = 900
+    settings.oauth2_allowed_resources = []
+    settings.oauth2_dynamic_registration_ip_limit = ip_limit
+    settings.oauth2_dynamic_registration_ip_window_seconds = window
+    settings.oauth2_dynamic_client_max_age_days = max_age_days
+    return settings
+
+
+async def _register(db_session, body, *, settings=None, client_ip="1.2.3.4"):
+    controller = OAuth2Controller(owner=MagicMock())
+    request = MagicMock()
+    request.json = AsyncMock(return_value=body)
+    request.scope = {"state": {"client_ip": client_ip}}
+    with patch("skrift.controllers.oauth2.get_settings", return_value=settings or _settings()):
+        return await OAuth2Controller.register.fn(controller, request, db_session)
+
+
+def _pkce_pair():
+    verifier = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"
+    digest = hashlib.sha256(verifier.encode()).digest()
+    challenge = base64.urlsafe_b64encode(digest).decode().rstrip("=")
+    return verifier, challenge
+
+
+class TestRegisterEndpoint:
+    @pytest.mark.asyncio
+    async def test_returns_public_client_without_secret(self, db_session):
+        result = await _register(
+            db_session,
+            {
+                "redirect_uris": ["https://app.example.com/cb"],
+                "client_name": "My Connector",
+                "scope": "openid email",
+            },
+        )
+
+        assert result.status_code == 201
+        body = result.content
+        assert "client_secret" not in body
+        assert body["client_id"]
+        assert body["token_endpoint_auth_method"] == "none"
+        assert isinstance(body["client_id_issued_at"], int)
+        assert body["redirect_uris"] == ["https://app.example.com/cb"]
+        assert body["grant_types"] == ["authorization_code", "refresh_token"]
+        assert body["response_types"] == ["code"]
+
+        client = await oauth2_service.get_client_by_client_id(db_session, body["client_id"])
+        assert client is not None
+        assert client.client_secret == ""
+        assert client.is_dynamically_registered is True
+        assert client.token_endpoint_auth_method == "none"
+        assert client.registered_by_ip == "1.2.3.4"
+        assert client.client_id_issued_at is not None
+        assert client.allowed_scope_list == ["openid", "email"]
+
+    @pytest.mark.asyncio
+    async def test_registered_public_client_completes_pkce_token_flow(self, db_session):
+        register_result = await _register(
+            db_session,
+            {"redirect_uris": ["https://app.example.com/cb"], "scope": "openid"},
+        )
+        client_id = register_result.content["client_id"]
+
+        verifier, challenge = _pkce_pair()
+        code = create_signed_token(
+            {
+                "type": "code",
+                "user_id": USER_ID,
+                "email": "u@example.com",
+                "name": "U User",
+                "picture_url": "",
+                "client_id": client_id,
+                "redirect_uri": "https://app.example.com/cb",
+                "scope": "openid",
+                "code_challenge": challenge,
+            },
+            SECRET,
+            AUTH_CODE_TTL,
+        )
+
+        controller = OAuth2Controller(owner=MagicMock())
+        request = MagicMock()
+        request.base_url = "http://localhost:8000/"
+        # A public client presents NO client_secret — PKCE alone authenticates it.
+        request.form = AsyncMock(return_value={
+            "grant_type": "authorization_code",
+            "code": code,
+            "redirect_uri": "https://app.example.com/cb",
+            "client_id": client_id,
+            "code_verifier": verifier,
+        })
+
+        with patch("skrift.controllers.oauth2.get_settings", return_value=_settings()):
+            token_result = await OAuth2Controller.token_exchange.fn(controller, request, db_session)
+
+        assert token_result.status_code == 200
+        assert token_result.content["access_token"]
+        assert token_result.content["refresh_token"]
+
+        # Token issuance stamps last_used_at so the pruner leaves it alone.
+        client = await oauth2_service.get_client_by_client_id(db_session, client_id)
+        assert client.last_used_at is not None
+
+    @pytest.mark.asyncio
+    async def test_disabled_returns_404(self, db_session):
+        with pytest.raises(NotFoundException):
+            await _register(
+                db_session,
+                {"redirect_uris": ["https://app.example.com/cb"]},
+                settings=_settings(dcr=False),
+            )
+
+    @pytest.mark.asyncio
+    async def test_disabled_when_oauth2_off(self, db_session):
+        with pytest.raises(NotFoundException):
+            await _register(
+                db_session,
+                {"redirect_uris": ["https://app.example.com/cb"]},
+                settings=_settings(enabled=False),
+            )
+
+    @pytest.mark.asyncio
+    async def test_missing_redirect_uris_invalid_client_metadata(self, db_session):
+        result = await _register(db_session, {"client_name": "No URIs"})
+        assert result.status_code == 400
+        assert result.content["error"] == "invalid_client_metadata"
+
+    @pytest.mark.asyncio
+    async def test_empty_redirect_uris_invalid_client_metadata(self, db_session):
+        result = await _register(db_session, {"redirect_uris": []})
+        assert result.status_code == 400
+        assert result.content["error"] == "invalid_client_metadata"
+
+    @pytest.mark.asyncio
+    async def test_non_https_non_loopback_rejected(self, db_session):
+        result = await _register(db_session, {"redirect_uris": ["http://evil.example.com/cb"]})
+        assert result.status_code == 400
+        assert result.content["error"] == "invalid_redirect_uri"
+
+    @pytest.mark.asyncio
+    async def test_loopback_http_allowed(self, db_session):
+        for uri in ["http://127.0.0.1:8765/cb", "http://localhost/cb"]:
+            result = await _register(db_session, {"redirect_uris": [uri]})
+            assert result.status_code == 201, uri
+
+    @pytest.mark.asyncio
+    async def test_fragment_rejected(self, db_session):
+        result = await _register(db_session, {"redirect_uris": ["https://app.example.com/cb#frag"]})
+        assert result.status_code == 400
+        assert result.content["error"] == "invalid_redirect_uri"
+
+    @pytest.mark.asyncio
+    async def test_auth_method_must_be_none(self, db_session):
+        result = await _register(
+            db_session,
+            {
+                "redirect_uris": ["https://app.example.com/cb"],
+                "token_endpoint_auth_method": "client_secret_post",
+            },
+        )
+        assert result.status_code == 400
+        assert result.content["error"] == "invalid_client_metadata"
+
+    @pytest.mark.asyncio
+    async def test_unknown_scope_rejected(self, db_session):
+        result = await _register(
+            db_session,
+            {"redirect_uris": ["https://app.example.com/cb"], "scope": "openid not-a-scope"},
+        )
+        assert result.status_code == 400
+        assert result.content["error"] == "invalid_client_metadata"
+
+    @pytest.mark.asyncio
+    async def test_client_name_length_capped(self, db_session):
+        result = await _register(
+            db_session,
+            {"redirect_uris": ["https://app.example.com/cb"], "client_name": "A" * 5000},
+        )
+        assert result.status_code == 201
+        client = await oauth2_service.get_client_by_client_id(db_session, result.content["client_id"])
+        assert len(client.display_name) <= CLIENT_NAME_MAX_LENGTH
+
+
+class TestPerIpRegistrationCap:
+    @pytest.mark.asyncio
+    async def test_cap_enforced_per_ip(self, db_session):
+        settings = _settings(ip_limit=2)
+        body = {"redirect_uris": ["https://app.example.com/cb"]}
+
+        first = await _register(db_session, body, settings=settings, client_ip="9.9.9.9")
+        second = await _register(db_session, body, settings=settings, client_ip="9.9.9.9")
+        third = await _register(db_session, body, settings=settings, client_ip="9.9.9.9")
+
+        assert first.status_code == 201
+        assert second.status_code == 201
+        assert third.status_code == 429
+
+        # A different IP is unaffected by another IP's usage.
+        other = await _register(db_session, body, settings=settings, client_ip="8.8.8.8")
+        assert other.status_code == 201
+
+    @pytest.mark.asyncio
+    async def test_registrations_outside_window_do_not_count(self, db_session):
+        settings = _settings(ip_limit=1, window=3600)
+        # An old registration for this IP sits before the window and must not
+        # count against the cap.
+        await oauth2_service.create_dynamic_client(
+            db_session,
+            display_name="Old",
+            redirect_uris=["https://old.example.com/cb"],
+            allowed_scopes=[],
+            registered_by_ip="7.7.7.7",
+            issued_at=datetime.now(tz=timezone.utc) - timedelta(hours=5),
+        )
+        result = await _register(
+            db_session,
+            {"redirect_uris": ["https://app.example.com/cb"]},
+            settings=settings,
+            client_ip="7.7.7.7",
+        )
+        assert result.status_code == 201
+
+
+class TestRedirectUriValidation:
+    def test_https_allowed(self):
+        assert _validate_registration_redirect_uri("https://app.example.com/cb") is True
+
+    def test_loopback_ip_http_allowed(self):
+        assert _validate_registration_redirect_uri("http://127.0.0.1:8765/cb") is True
+
+    def test_localhost_http_allowed(self):
+        assert _validate_registration_redirect_uri("http://localhost/cb") is True
+
+    def test_http_non_loopback_rejected(self):
+        assert _validate_registration_redirect_uri("http://example.com/cb") is False
+
+    def test_fragment_rejected(self):
+        assert _validate_registration_redirect_uri("https://app.example.com/cb#x") is False
+
+    def test_relative_rejected(self):
+        assert _validate_registration_redirect_uri("/cb") is False
+
+    def test_empty_rejected(self):
+        assert _validate_registration_redirect_uri("") is False
+
+    def test_non_http_scheme_rejected(self):
+        assert _validate_registration_redirect_uri("ftp://app.example.com/cb") is False
+
+
+class TestRedirectUriAdversarial:
+    """Bypass attempts an attacker would use against the redirect_uri filter."""
+
+    def test_embedded_userinfo_rejected(self):
+        # user:pass@host and host@host phishing/parser-confusion forms.
+        assert _validate_registration_redirect_uri("https://user:pass@evil.com/cb") is False
+        assert _validate_registration_redirect_uri("https://evil.com@good.com/cb") is False
+
+    def test_loopback_userinfo_bypass_rejected(self):
+        # Trying to satisfy the loopback exception with 127.0.0.1 in userinfo
+        # while the real host is attacker-controlled.
+        assert _validate_registration_redirect_uri("http://127.0.0.1@evil.com/cb") is False
+        assert _validate_registration_redirect_uri("http://localhost@evil.com/cb") is False
+
+    def test_newline_smuggling_rejected(self):
+        # A single string carrying a newline: the URL parser strips it (so the
+        # host looks benign) but the newline-delimited storage would later split
+        # it into a second, never-validated redirect_uri.
+        for smuggled in (
+            "https://good.com/cb\nhttp://evil.com/steal",
+            "https://good.com/cb\r\nhttp://evil.com/steal",
+            "https://good.com/cb\thttp://evil.com/steal",
+        ):
+            assert _validate_registration_redirect_uri(smuggled) is False
+
+    def test_csp_token_injection_hosts_rejected(self):
+        # Hosts whose characters would inject extra CSP tokens/directives into
+        # the consent-page form-action allowlist.
+        for hostile in (
+            "https://a b/cb",
+            "https://good.com;form-action */cb",
+            "https://exam ple.com;form-action */cb",
+            "https://*.evil.com/cb",
+        ):
+            assert _validate_registration_redirect_uri(hostile) is False
+
+    def test_origin_safe_for_valid_uris(self):
+        assert _redirect_uri_origin("https://app.example.com/cb") == "https://app.example.com"
+        assert _redirect_uri_origin("http://127.0.0.1:8765/cb") == "http://127.0.0.1:8765"
+
+    def test_origin_none_for_hostile_uris(self):
+        for hostile in (
+            "https://user@evil.com/cb",
+            "https://a b/cb",
+            "https://good.com/cb\nhttp://evil.com",
+            "https://good.com;x */cb",
+        ):
+            assert _redirect_uri_origin(hostile) is None
+
+    @pytest.mark.asyncio
+    async def test_newline_smuggling_registration_rejected_end_to_end(self, db_session):
+        result = await _register(
+            db_session,
+            {"redirect_uris": ["https://good.com/cb\nhttp://evil.com/steal"]},
+        )
+        assert result.status_code == 400
+        assert result.content["error"] == "invalid_redirect_uri"
+        # Nothing must have been persisted for the hostile registration.
+        clients = (await db_session.execute(select(OAuth2Client))).scalars().all()
+        assert clients == []
+
+    @pytest.mark.asyncio
+    async def test_csp_injection_registration_rejected_end_to_end(self, db_session):
+        result = await _register(
+            db_session,
+            {"redirect_uris": ["https://evil.com;form-action */cb"]},
+        )
+        assert result.status_code == 400
+        assert result.content["error"] == "invalid_redirect_uri"
+
+
+class TestConsentCspSink:
+    """The consent-page CSP builder must never emit an attacker-shaped origin."""
+
+    def test_clean_origin_widens_form_action(self):
+        with patch("skrift.controllers.oauth2.get_settings", return_value=_settings()):
+            headers = OAuth2Controller._consent_csp_headers("https://app.example.com/cb")
+        csp = headers["content-security-policy"]
+        assert "form-action 'self' https://app.example.com" in csp
+        assert "https://app.example.com/cb" not in csp
+
+    def test_hostile_origin_fails_closed(self):
+        # A malformed/hostile redirect_uri (which a hardened registrar rejects,
+        # but defense-in-depth still guards) must not inject CSP tokens; the
+        # builder returns no override so the default 'self' policy stands.
+        for hostile in (
+            "https://evil.com;form-action */cb",
+            "https://a b/cb",
+            "https://user@evil.com/cb",
+        ):
+            with patch("skrift.controllers.oauth2.get_settings", return_value=_settings()):
+                headers = OAuth2Controller._consent_csp_headers(hostile)
+            assert headers == {}
+
+
+class TestClientNameInjection:
+    @pytest.mark.asyncio
+    async def test_client_name_html_is_not_executable_on_consent(self, db_session):
+        payload = "<script>alert('xss')</script>Nice App"
+        result = await _register(
+            db_session,
+            {"redirect_uris": ["https://app.example.com/cb"], "client_name": payload},
+        )
+        client = await oauth2_service.get_client_by_client_id(db_session, result.content["client_id"])
+
+        # The raw markup is stored verbatim (no lossy sanitization) — safety
+        # comes from the consent template's autoescape, mirrored here.
+        assert client.display_name == payload
+
+        env = Environment(autoescape=True)
+        rendered = env.from_string("{{ display_name or client_id }}").render(
+            display_name=client.display_name, client_id=client.client_id
+        )
+        assert "<script>" not in rendered
+        assert "&lt;script&gt;" in rendered
+
+        # And the real consent template must never mark that value safe.
+        template_source = (
+            Path(skrift.__file__).parent / "templates" / "oauth" / "authorize.html"
+        ).read_text()
+        assert "display_name or client_id" in template_source
+        assert "display_name | safe" not in template_source
+        assert "display_name|safe" not in template_source
+
+    @pytest.mark.asyncio
+    async def test_client_name_with_json_metacharacters_round_trips(self, db_session):
+        # Quotes/backslashes/braces in client_name must not break the JSON
+        # registration response — Litestar's serializer escapes them and the
+        # echoed value is byte-for-byte what was stored (after the length cap).
+        import json
+
+        payload = 'App", "client_secret": "pwned\\ {}'
+        result = await _register(
+            db_session,
+            {"redirect_uris": ["https://app.example.com/cb"], "client_name": payload},
+        )
+        assert result.status_code == 201
+        assert "client_secret" not in result.content
+        assert result.content["client_name"] == payload
+        # The dict serializes to valid JSON with no smuggled keys.
+        encoded = json.dumps(result.content)
+        assert json.loads(encoded)["client_name"] == payload
+
+
+class TestDiscoveryRegistrationEndpoint:
+    def test_present_when_enabled(self):
+        metadata = build_authorization_server_metadata(ISSUER, registration_enabled=True)
+        assert metadata["registration_endpoint"] == f"{ISSUER}/oauth/register"
+
+    def test_absent_when_disabled(self):
+        metadata = build_authorization_server_metadata(ISSUER, registration_enabled=False)
+        assert "registration_endpoint" not in metadata
+
+    @pytest.mark.asyncio
+    async def test_discovery_route_advertises_registration_when_enabled(self):
+        from skrift.controllers.sitemap import SitemapController
+
+        settings = MagicMock()
+        settings.oauth2_enabled = True
+        settings.oauth2_issuer = ISSUER
+        settings.oauth2_dynamic_registration_enabled = True
+
+        controller = SitemapController(owner=MagicMock())
+        request = MagicMock()
+        request.base_url = "http://localhost:8000/"
+
+        with patch("skrift.config.get_settings", return_value=settings):
+            result = await SitemapController.oauth_authorization_server.fn(controller, request)
+
+        assert result.content["registration_endpoint"] == f"{ISSUER}/oauth/register"
+
+
+class TestPruneStaleDynamicClients:
+    async def _make_dynamic(self, db_session, *, issued_ago_days, last_used=None, ip="1.1.1.1"):
+        client = await oauth2_service.create_dynamic_client(
+            db_session,
+            display_name="Dyn",
+            redirect_uris=["https://app.example.com/cb"],
+            allowed_scopes=[],
+            registered_by_ip=ip,
+            issued_at=datetime.now(tz=timezone.utc) - timedelta(days=issued_ago_days),
+        )
+        if last_used is not None:
+            await oauth2_service.mark_client_used(db_session, client, last_used)
+        return client
+
+    @pytest.mark.asyncio
+    async def test_prunes_unused_old_dynamic_client(self, db_session):
+        await self._make_dynamic(db_session, issued_ago_days=10)
+        deleted = await oauth2_service.prune_stale_dynamic_clients(
+            db_session, now=datetime.now(tz=timezone.utc), max_age_days=7
+        )
+        assert deleted == 1
+        remaining = (await db_session.execute(select(OAuth2Client))).scalars().all()
+        assert remaining == []
+
+    @pytest.mark.asyncio
+    async def test_keeps_recent_dynamic_client(self, db_session):
+        await self._make_dynamic(db_session, issued_ago_days=1)
+        deleted = await oauth2_service.prune_stale_dynamic_clients(
+            db_session, now=datetime.now(tz=timezone.utc), max_age_days=7
+        )
+        assert deleted == 0
+
+    @pytest.mark.asyncio
+    async def test_keeps_used_old_dynamic_client(self, db_session):
+        await self._make_dynamic(
+            db_session, issued_ago_days=30, last_used=datetime.now(tz=timezone.utc)
+        )
+        deleted = await oauth2_service.prune_stale_dynamic_clients(
+            db_session, now=datetime.now(tz=timezone.utc), max_age_days=7
+        )
+        assert deleted == 0
+
+    @pytest.mark.asyncio
+    async def test_keeps_admin_client(self, db_session):
+        await oauth2_service.create_client(
+            db_session,
+            display_name="Confidential",
+            redirect_uris=["https://app.example.com/cb"],
+            allowed_scopes=["openid"],
+        )
+        deleted = await oauth2_service.prune_stale_dynamic_clients(
+            db_session, now=datetime.now(tz=timezone.utc), max_age_days=0
+        )
+        assert deleted == 0
+
+
+class TestPruneWorkerHandler:
+    @pytest.mark.asyncio
+    async def test_handler_prunes_via_configured_session_maker(self):
+        from skrift import oauth2_maintenance
+
+        engine = create_async_engine("sqlite+aiosqlite://")
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.create_all)
+        maker = async_sessionmaker(engine, expire_on_commit=False)
+
+        async with maker() as session:
+            await oauth2_service.create_dynamic_client(
+                session,
+                display_name="Stale",
+                redirect_uris=["https://app.example.com/cb"],
+                allowed_scopes=[],
+                registered_by_ip="1.1.1.1",
+                issued_at=datetime.now(tz=timezone.utc) - timedelta(days=30),
+            )
+
+        oauth2_maintenance.configure_oauth2_maintenance(session_maker=maker)
+        try:
+            with patch(
+                "skrift.oauth2_maintenance.get_settings",
+                return_value=_settings(max_age_days=7),
+            ):
+                result = await oauth2_maintenance.prune_dynamic_clients(
+                    oauth2_maintenance.PruneDynamicClients(), MagicMock()
+                )
+        finally:
+            oauth2_maintenance.configure_oauth2_maintenance(session_maker=None)
+
+        assert result == {"deleted": 1}
+        await engine.dispose()

--- a/tests/test_oauth2_dcr.py
+++ b/tests/test_oauth2_dcr.py
@@ -20,6 +20,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
 import skrift
+from skrift.auth.scopes import SCOPE_DEFINITIONS, register_scope
 from skrift.auth.tokens import create_signed_token
 from skrift.config import SecurityHeadersConfig
 from skrift.controllers.oauth2 import (
@@ -51,7 +52,7 @@ async def db_session():
     await engine.dispose()
 
 
-def _settings(*, enabled=True, dcr=True, ip_limit=20, window=3600, max_age_days=7):
+def _settings(*, enabled=True, dcr=True, ip_limit=20, window=3600, max_age_days=7, total_limit=1000):
     settings = MagicMock()
     settings.secret_key = SECRET
     settings.security_headers = SecurityHeadersConfig()
@@ -62,6 +63,7 @@ def _settings(*, enabled=True, dcr=True, ip_limit=20, window=3600, max_age_days=
     settings.oauth2_allowed_resources = []
     settings.oauth2_dynamic_registration_ip_limit = ip_limit
     settings.oauth2_dynamic_registration_ip_window_seconds = window
+    settings.oauth2_dynamic_registration_total_limit = total_limit
     settings.oauth2_dynamic_client_max_age_days = max_age_days
     return settings
 
@@ -80,6 +82,15 @@ def _pkce_pair():
     digest = hashlib.sha256(verifier.encode()).digest()
     challenge = base64.urlsafe_b64encode(digest).decode().rstrip("=")
     return verifier, challenge
+
+
+async def _authorize_get(db_session, query):
+    controller = OAuth2Controller(owner=MagicMock())
+    request = MagicMock()
+    request.query_params = query
+    request.session = {}
+    with patch("skrift.controllers.oauth2.get_settings", return_value=_settings()):
+        return await OAuth2Controller.authorize_get.fn(controller, request, db_session)
 
 
 class TestRegisterEndpoint:
@@ -241,6 +252,98 @@ class TestRegisterEndpoint:
         assert len(client.display_name) <= CLIENT_NAME_MAX_LENGTH
 
 
+class TestRegisterMetadataValidation:
+    """RFC 7591 — unsupported grant/response types are rejected, not echoed."""
+
+    @pytest.mark.asyncio
+    async def test_unsupported_grant_type_rejected(self, db_session):
+        result = await _register(
+            db_session,
+            {"redirect_uris": ["https://app.example.com/cb"], "grant_types": ["implicit"]},
+        )
+        assert result.status_code == 400
+        assert result.content["error"] == "invalid_client_metadata"
+
+    @pytest.mark.asyncio
+    async def test_unsupported_response_type_rejected(self, db_session):
+        result = await _register(
+            db_session,
+            {"redirect_uris": ["https://app.example.com/cb"], "response_types": ["token"]},
+        )
+        assert result.status_code == 400
+        assert result.content["error"] == "invalid_client_metadata"
+
+    @pytest.mark.asyncio
+    async def test_non_list_grant_types_rejected(self, db_session):
+        result = await _register(
+            db_session,
+            {"redirect_uris": ["https://app.example.com/cb"], "grant_types": "authorization_code"},
+        )
+        assert result.status_code == 400
+        assert result.content["error"] == "invalid_client_metadata"
+
+    @pytest.mark.asyncio
+    async def test_supported_subset_echoed_verbatim(self, db_session):
+        result = await _register(
+            db_session,
+            {
+                "redirect_uris": ["https://app.example.com/cb"],
+                "grant_types": ["authorization_code"],
+                "response_types": ["code"],
+            },
+        )
+        assert result.status_code == 201
+        assert result.content["grant_types"] == ["authorization_code"]
+        assert result.content["response_types"] == ["code"]
+
+
+class TestRegisterScopeDefaults:
+    """Omitting `scope` must cap the client to a minimal identity set — an
+    empty allowed_scopes list would mean 'unrestricted' at /oauth/authorize."""
+
+    @pytest.mark.asyncio
+    async def test_omitted_scope_defaults_to_identity_scopes(self, db_session):
+        result = await _register(db_session, {"redirect_uris": ["https://app.example.com/cb"]})
+        assert result.status_code == 201
+        assert result.content["scope"] == "openid profile email"
+        client = await oauth2_service.get_client_by_client_id(db_session, result.content["client_id"])
+        assert client.allowed_scope_list == ["openid", "profile", "email"]
+
+    @pytest.mark.asyncio
+    async def test_empty_scope_defaults_to_identity_scopes(self, db_session):
+        result = await _register(
+            db_session,
+            {"redirect_uris": ["https://app.example.com/cb"], "scope": ""},
+        )
+        assert result.status_code == 201
+        client = await oauth2_service.get_client_by_client_id(db_session, result.content["client_id"])
+        assert client.allowed_scope_list == ["openid", "profile", "email"]
+
+    @pytest.mark.asyncio
+    async def test_scopeless_registration_cannot_authorize_app_scope(self, db_session):
+        register_scope("mcp-test-scope", "Test-only high-value scope")
+        try:
+            registered = await _register(
+                db_session, {"redirect_uris": ["https://app.example.com/cb"]}
+            )
+            result = await _authorize_get(
+                db_session,
+                {
+                    "client_id": registered.content["client_id"],
+                    "redirect_uri": "https://app.example.com/cb",
+                    "response_type": "code",
+                    "state": "xyz",
+                    "scope": "mcp-test-scope",
+                    "code_challenge": "challenge",
+                    "code_challenge_method": "S256",
+                },
+            )
+            assert result.status_code == 400
+            assert result.content["error"] == "invalid_scope"
+        finally:
+            SCOPE_DEFINITIONS.pop("mcp-test-scope", None)
+
+
 class TestPerIpRegistrationCap:
     @pytest.mark.asyncio
     async def test_cap_enforced_per_ip(self, db_session):
@@ -279,6 +382,45 @@ class TestPerIpRegistrationCap:
             client_ip="7.7.7.7",
         )
         assert result.status_code == 201
+
+
+class TestTotalRegistrationCap:
+    @pytest.mark.asyncio
+    async def test_total_cap_enforced_across_ips(self, db_session):
+        """The per-IP window only bounds the registration rate; the total cap
+        must stop a distributed attacker from growing the table unboundedly."""
+        settings = _settings(total_limit=1)
+        body = {"redirect_uris": ["https://app.example.com/cb"]}
+
+        first = await _register(db_session, body, settings=settings, client_ip="1.1.1.1")
+        second = await _register(db_session, body, settings=settings, client_ip="2.2.2.2")
+
+        assert first.status_code == 201
+        assert second.status_code == 429
+        assert second.content["error"] == "too_many_requests"
+
+    @pytest.mark.asyncio
+    async def test_used_clients_still_count_toward_total_cap(self, db_session):
+        """Marking a client used exempts it from pruning but must not free up
+        registration capacity."""
+        settings = _settings(total_limit=1)
+        client = await oauth2_service.create_dynamic_client(
+            db_session,
+            display_name="Used",
+            redirect_uris=["https://used.example.com/cb"],
+            allowed_scopes=["openid"],
+            registered_by_ip="3.3.3.3",
+            issued_at=datetime.now(tz=timezone.utc),
+        )
+        await oauth2_service.mark_client_used(db_session, client, datetime.now(tz=timezone.utc))
+
+        result = await _register(
+            db_session,
+            {"redirect_uris": ["https://app.example.com/cb"]},
+            settings=settings,
+            client_ip="4.4.4.4",
+        )
+        assert result.status_code == 429
 
 
 class TestRedirectUriValidation:

--- a/tests/test_oauth2_jwt.py
+++ b/tests/test_oauth2_jwt.py
@@ -15,6 +15,7 @@ from urllib.parse import parse_qs, urlsplit
 
 import pytest
 import pytest_asyncio
+from joserfc import jwt as jose_jwt
 from joserfc.jwk import ECKey
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
@@ -161,6 +162,54 @@ class TestJwtRoundTrip:
         key = _signing_key()
         token = _mint(key)
         assert verify_access_token_jwt(token, jwks=[], issuer=ISSUER, audience=RESOURCE) is None
+
+
+def _mint_with_typ(signing_key, typ):
+    """Sign otherwise-valid access-token claims under an arbitrary header typ."""
+    header = {"alg": "ES256", "kid": signing_key.kid}
+    if typ is not None:
+        header["typ"] = typ
+    issued_at = int(time.time())
+    claims = {
+        "iss": ISSUER,
+        "sub": USER_ID,
+        "client_id": "abc",
+        "scope": "openid",
+        "iat": issued_at,
+        "exp": issued_at + ACCESS_TTL,
+        "jti": "typ-test-jti",
+    }
+    private_key = ECKey.import_key(signing_key.private_key_pem)
+    return jose_jwt.encode(header, claims, private_key, algorithms=["ES256"])
+
+
+class TestJwtTypEnforcement:
+    """RFC 9068 §4 — only `at+jwt` tokens may pass as access tokens, so any
+    other JWT kind signed with the same rotating key can never be confused
+    into one."""
+
+    def test_at_jwt_typ_accepted(self):
+        key = _signing_key()
+        for accepted in ("at+jwt", "application/at+jwt", "AT+JWT"):
+            token = _mint_with_typ(key, accepted)
+            assert verify_access_token_jwt(token, jwks=_jwks_for(key), issuer=ISSUER, audience=None) is not None, accepted
+
+    def test_wrong_typ_rejected(self):
+        key = _signing_key()
+        for wrong in ("JWT", "logout+jwt", "id_token+jwt", ""):
+            token = _mint_with_typ(key, wrong)
+            assert verify_access_token_jwt(token, jwks=_jwks_for(key), issuer=ISSUER, audience=None) is None, wrong
+
+    def test_missing_typ_rejected(self):
+        key = _signing_key()
+        token = _mint_with_typ(key, None)
+        assert verify_access_token_jwt(token, jwks=_jwks_for(key), issuer=ISSUER, audience=None) is None
+
+    def test_create_access_token_jwt_sets_at_jwt_typ(self):
+        key = _signing_key()
+        token = _mint(key)
+        header = json.loads(base64.urlsafe_b64decode(token.split(".")[0] + "=="))
+        assert header["typ"] == "at+jwt"
 
 
 @pytest_asyncio.fixture
@@ -579,6 +628,60 @@ class TestUserinfoWithJwt:
         key = _signing_key()
         result = await _userinfo(_mint(key, issuer="https://evil.example.com"), _jwks_for(key))
         assert result.status_code == 401
+
+
+async def _revoke(token, jwks):
+    controller = OAuth2Controller(owner=MagicMock())
+    request = MagicMock()
+    request.form = AsyncMock(return_value={"token": token})
+    request.base_url = "http://localhost:8000/"
+    db_session = AsyncMock()
+
+    with patch("skrift.controllers.oauth2.get_settings", return_value=_settings()), \
+         patch("skrift.controllers.oauth2.oauth2_service") as mock_svc, \
+         patch("skrift.controllers.oauth2.oauth2_signing_key_service") as mock_keys:
+        mock_svc.is_token_revoked = AsyncMock(return_value=False)
+        mock_svc.revoke_token = AsyncMock()
+        mock_keys.list_jwks_keys = AsyncMock(return_value=jwks)
+        result = await OAuth2Controller.revoke.fn(controller, request, db_session)
+    return result, mock_svc
+
+
+class TestRevokeWithJwt:
+    @pytest.mark.asyncio
+    async def test_jwt_access_token_revocation_stores_its_jti(self):
+        key = _signing_key()
+        token = _mint(key)
+        claims = verify_access_token_jwt(token, jwks=_jwks_for(key), issuer=ISSUER, audience=None)
+
+        result, mock_svc = await _revoke(token, _jwks_for(key))
+
+        assert result.status_code == 200
+        mock_svc.revoke_token.assert_awaited_once()
+        _, stored_jti, stored_type, stored_expiry = mock_svc.revoke_token.await_args.args
+        assert stored_jti == claims["jti"]
+        assert stored_type == "access"
+        assert stored_expiry == datetime.fromtimestamp(claims["exp"], tz=timezone.utc)
+
+    @pytest.mark.asyncio
+    async def test_revoked_jwt_no_longer_passes_userinfo(self):
+        """End-to-end shape of the connector 'disconnect' path: once the JWT's
+        jti is on the revocation list, the token stops working."""
+        key = _signing_key()
+        token = _mint(key)
+
+        result = await _userinfo(token, _jwks_for(key), revoked=True)
+        assert result.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_foreign_issuer_jwt_returns_200_without_storing_revocation(self):
+        key = _signing_key()
+        token = _mint(key, issuer="https://evil.example.com")
+
+        result, mock_svc = await _revoke(token, _jwks_for(key))
+
+        assert result.status_code == 200
+        mock_svc.revoke_token.assert_not_awaited()
 
 
 async def _introspect(token, jwks, *, client=None, revoked=False):

--- a/tests/test_oauth2_jwt.py
+++ b/tests/test_oauth2_jwt.py
@@ -243,8 +243,10 @@ async def _authorize_get(query, *, session=None, settings=None):
     request.session = session if session is not None else {}
     db_session = AsyncMock()
     with patch("skrift.controllers.oauth2.get_settings", return_value=settings or _settings()), \
+         patch("skrift.controllers.oauth2.oauth2_consent_service") as mock_consent, \
          patch("skrift.controllers.oauth2.oauth2_service") as mock_svc:
         mock_svc.get_client_by_client_id = AsyncMock(return_value=_client())
+        mock_consent.find_grant = AsyncMock(return_value=None)
         return await OAuth2Controller.authorize_get.fn(controller, request, db_session), request
 
 
@@ -332,7 +334,9 @@ class TestAuthorizePostCarriesResource:
         db_session = AsyncMock()
 
         with patch("skrift.controllers.oauth2.verify_csrf", new_callable=AsyncMock, return_value=True), \
+             patch("skrift.controllers.oauth2.oauth2_consent_service") as mock_consent, \
              patch("skrift.controllers.oauth2.get_settings", return_value=_settings()):
+            mock_consent.upsert_grant = AsyncMock()
             result = await OAuth2Controller.authorize_post.fn(controller, request, db_session)
 
         code = parse_qs(urlsplit(result.url).query)["code"][0]
@@ -373,6 +377,7 @@ async def _exchange(form_data, *, settings=None, signing_key=None):
         mock_svc.is_family_revoked = AsyncMock(return_value=False)
         mock_svc.revoke_token = AsyncMock()
         mock_svc.revoke_family = AsyncMock()
+        mock_svc.mark_client_used = AsyncMock()
         mock_keys.get_or_create_active_key = AsyncMock(return_value=signing_key or _signing_key())
         return await OAuth2Controller.token_exchange.fn(controller, request, db_session)
 
@@ -653,6 +658,7 @@ class TestDiscoveryDocuments:
         settings = MagicMock()
         settings.oauth2_enabled = True
         settings.oauth2_issuer = ""
+        settings.oauth2_dynamic_registration_enabled = False
 
         controller = SitemapController(owner=MagicMock())
         request = MagicMock()
@@ -690,6 +696,7 @@ class TestDiscoveryDocuments:
         settings = MagicMock()
         settings.oauth2_enabled = True
         settings.oauth2_issuer = "https://id.example.com"
+        settings.oauth2_dynamic_registration_enabled = False
 
         controller = SitemapController(owner=MagicMock())
         request = MagicMock()

--- a/tests/test_oauth2_jwt.py
+++ b/tests/test_oauth2_jwt.py
@@ -1,0 +1,702 @@
+"""Phase 1 MCP identity provider — ES256 JWT access tokens, JWKS publication,
+RFC 8707 resource→aud propagation, and RFC 8414 discovery.
+
+Auth codes and refresh tokens stay HMAC (`skrift.auth.tokens`); only the
+access-token format changes to an asymmetric JWT verifiable via /oauth/jwks.
+"""
+
+import base64
+import hashlib
+import json
+import time
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+from urllib.parse import parse_qs, urlsplit
+
+import pytest
+import pytest_asyncio
+from joserfc.jwk import ECKey
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+from skrift.auth.jwt_tokens import create_access_token_jwt, verify_access_token_jwt
+from skrift.auth.tokens import create_signed_token, verify_signed_token
+from skrift.config import SecurityHeadersConfig
+from skrift.controllers.oauth2 import (
+    AUTH_CODE_TTL,
+    REFRESH_TOKEN_TTL,
+    OAuth2Controller,
+)
+from skrift.db.base import Base
+from skrift.db.models import OAuth2SigningKey  # noqa: F401  (registers table)
+from skrift.db.services import oauth2_signing_key_service as signing_keys
+
+
+SECRET = "test-secret-key"
+ISSUER = "http://localhost:8000"
+RESOURCE = "https://mcp.example.com/sse"
+OTHER_RESOURCE = "https://other.example.com/api"
+USER_ID = "00000000-0000-0000-0000-000000000042"
+ACCESS_TTL = 900
+
+
+def _signing_key():
+    """A mock OAuth2SigningKey row backed by real EC P-256 key material."""
+    key = ECKey.generate_key("P-256")
+    signing_key = MagicMock()
+    signing_key.kid = key.thumbprint()
+    signing_key.private_key_pem = key.as_pem(private=True).decode("ascii")
+    signing_key.algorithm = "ES256"
+    return signing_key
+
+
+def _jwks_for(*keys) -> list[dict]:
+    return [signing_keys.public_jwk(key) for key in keys]
+
+
+def _settings(allowed_resources: list[str] | None = None):
+    settings = MagicMock()
+    settings.secret_key = SECRET
+    settings.security_headers = SecurityHeadersConfig()
+    settings.oauth2_issuer = ISSUER
+    settings.oauth2_access_token_ttl = ACCESS_TTL
+    settings.oauth2_allowed_resources = allowed_resources or []
+    return settings
+
+
+def _client(client_id="abc", client_secret="secret", allowed_scopes=None):
+    from skrift.auth.client_secret import hash_client_secret
+
+    client = MagicMock()
+    client.client_id = client_id
+    client.client_secret = hash_client_secret(client_secret) if client_secret else ""
+    client.display_name = "Test App"
+    client.is_active = True
+    client.redirect_uri_list = ["http://localhost/cb"]
+    client.allowed_scope_list = allowed_scopes or []
+    return client
+
+
+def _pkce_pair():
+    verifier = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"
+    digest = hashlib.sha256(verifier.encode()).digest()
+    challenge = base64.urlsafe_b64encode(digest).decode().rstrip("=")
+    return verifier, challenge
+
+
+def _mint(signing_key, *, audience=RESOURCE, issuer=ISSUER, scope="openid email profile", expires_in=ACCESS_TTL):
+    return create_access_token_jwt(
+        subject=USER_ID,
+        client_id="abc",
+        scope=scope,
+        audience=audience,
+        issuer=issuer,
+        signing_key=signing_key,
+        expires_in=expires_in,
+    )
+
+
+class TestJwtRoundTrip:
+    def test_create_verify_round_trip(self):
+        key = _signing_key()
+        token = _mint(key)
+        claims = verify_access_token_jwt(token, jwks=_jwks_for(key), issuer=ISSUER, audience=RESOURCE)
+        assert claims is not None
+        assert claims["sub"] == USER_ID
+        assert claims["client_id"] == "abc"
+        assert claims["scope"] == "openid email profile"
+        assert claims["aud"] == RESOURCE
+        assert claims["iss"] == ISSUER
+        assert claims["jti"]
+        assert claims["exp"] > claims["iat"]
+
+    def test_wrong_audience_rejected(self):
+        key = _signing_key()
+        token = _mint(key)
+        assert verify_access_token_jwt(token, jwks=_jwks_for(key), issuer=ISSUER, audience=OTHER_RESOURCE) is None
+
+    def test_missing_audience_claim_rejected_when_audience_expected(self):
+        key = _signing_key()
+        token = _mint(key, audience=None)
+        assert verify_access_token_jwt(token, jwks=_jwks_for(key), issuer=ISSUER, audience=RESOURCE) is None
+
+    def test_audience_none_skips_audience_check(self):
+        key = _signing_key()
+        token = _mint(key, audience=None)
+        claims = verify_access_token_jwt(token, jwks=_jwks_for(key), issuer=ISSUER, audience=None)
+        assert claims is not None
+        assert "aud" not in claims
+
+    def test_expired_rejected(self):
+        key = _signing_key()
+        token = _mint(key, expires_in=-10)
+        assert verify_access_token_jwt(token, jwks=_jwks_for(key), issuer=ISSUER, audience=RESOURCE) is None
+
+    def test_wrong_issuer_rejected(self):
+        key = _signing_key()
+        token = _mint(key, issuer="https://evil.example.com")
+        assert verify_access_token_jwt(token, jwks=_jwks_for(key), issuer=ISSUER, audience=RESOURCE) is None
+
+    def test_tampered_payload_rejected(self):
+        key = _signing_key()
+        token = _mint(key)
+        header_b64, payload_b64, signature_b64 = token.split(".")
+        claims = json.loads(base64.urlsafe_b64decode(payload_b64 + "=="))
+        claims["sub"] = "attacker"
+        tampered_payload = base64.urlsafe_b64encode(json.dumps(claims).encode()).decode().rstrip("=")
+        tampered = f"{header_b64}.{tampered_payload}.{signature_b64}"
+        assert verify_access_token_jwt(tampered, jwks=_jwks_for(key), issuer=ISSUER, audience=RESOURCE) is None
+
+    def test_wrong_key_rejected(self):
+        signer = _signing_key()
+        other = _signing_key()
+        token = _mint(signer)
+        assert verify_access_token_jwt(token, jwks=_jwks_for(other), issuer=ISSUER, audience=RESOURCE) is None
+
+    def test_garbage_token_rejected(self):
+        key = _signing_key()
+        for garbage in ["", "abc", "a.b", "a.b.c", "a.b.c.d"]:
+            assert verify_access_token_jwt(garbage, jwks=_jwks_for(key), issuer=ISSUER, audience=RESOURCE) is None
+
+    def test_empty_jwks_rejected(self):
+        key = _signing_key()
+        token = _mint(key)
+        assert verify_access_token_jwt(token, jwks=[], issuer=ISSUER, audience=RESOURCE) is None
+
+
+@pytest_asyncio.fixture
+async def db_session():
+    engine = create_async_engine("sqlite+aiosqlite://")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    maker = async_sessionmaker(engine, expire_on_commit=False)
+    async with maker() as session:
+        yield session
+    await engine.dispose()
+
+
+class TestSigningKeyRotation:
+    @pytest.mark.asyncio
+    async def test_token_signed_by_retired_key_verifies_until_pruned(self, db_session):
+        original = await signing_keys.get_or_create_active_key(db_session)
+        token = _mint(original)
+
+        await signing_keys.rotate(db_session)
+        jwks = await signing_keys.list_jwks_keys(db_session)
+        assert verify_access_token_jwt(token, jwks=jwks, issuer=ISSUER, audience=RESOURCE) is not None
+
+        future = datetime.now(tz=timezone.utc) + timedelta(seconds=ACCESS_TTL + 120)
+        await signing_keys.prune_expired(db_session, now=future, access_token_ttl=ACCESS_TTL, clock_skew=60)
+        jwks = await signing_keys.list_jwks_keys(db_session)
+        assert verify_access_token_jwt(token, jwks=jwks, issuer=ISSUER, audience=RESOURCE) is None
+
+
+class TestJwksRoute:
+    @pytest.mark.asyncio
+    async def test_jwks_route_returns_active_key(self, db_session):
+        controller = OAuth2Controller(owner=MagicMock())
+        result = await OAuth2Controller.jwks.fn(controller, db_session)
+
+        assert result.status_code == 200
+        keys = result.content["keys"]
+        assert len(keys) == 1
+        active = await signing_keys.get_or_create_active_key(db_session)
+        assert keys[0]["kid"] == active.kid
+        assert keys[0]["kty"] == "EC"
+        assert keys[0]["alg"] == "ES256"
+        assert "d" not in keys[0]
+
+
+class _MultiValueParams(dict):
+    """Query/form params stub exposing Litestar's multi-dict ``getall``."""
+
+    def __init__(self, base: dict, resources: list[str]):
+        super().__init__(base)
+        self._resources = resources
+
+    def getall(self, key, default=None):
+        if key == "resource":
+            return list(self._resources)
+        value = super().get(key)
+        if value is None:
+            return default if default is not None else []
+        return [value]
+
+
+def _authorize_params(**overrides):
+    params = {
+        "client_id": "abc",
+        "redirect_uri": "http://localhost/cb",
+        "response_type": "code",
+        "state": "xyz",
+        "scope": "openid",
+        "code_challenge": "challenge",
+        "code_challenge_method": "S256",
+    }
+    params.update(overrides)
+    return params
+
+
+async def _authorize_get(query, *, session=None, settings=None):
+    controller = OAuth2Controller(owner=MagicMock())
+    request = MagicMock()
+    request.query_params = query
+    request.session = session if session is not None else {}
+    db_session = AsyncMock()
+    with patch("skrift.controllers.oauth2.get_settings", return_value=settings or _settings()), \
+         patch("skrift.controllers.oauth2.oauth2_service") as mock_svc:
+        mock_svc.get_client_by_client_id = AsyncMock(return_value=_client())
+        return await OAuth2Controller.authorize_get.fn(controller, request, db_session), request
+
+
+class TestAuthorizeResourceValidation:
+    @pytest.mark.asyncio
+    async def test_missing_resource_is_allowed(self):
+        result, _ = await _authorize_get(_authorize_params())
+        from litestar.response import Redirect
+
+        assert isinstance(result, Redirect)
+
+    @pytest.mark.asyncio
+    async def test_relative_resource_rejected_as_invalid_target(self):
+        result, _ = await _authorize_get(_authorize_params(resource="not-a-uri"))
+        assert result.status_code == 400
+        assert result.content["error"] == "invalid_target"
+
+    @pytest.mark.asyncio
+    async def test_resource_with_fragment_rejected(self):
+        result, _ = await _authorize_get(_authorize_params(resource="https://mcp.example.com/sse#frag"))
+        assert result.status_code == 400
+        assert result.content["error"] == "invalid_target"
+
+    @pytest.mark.asyncio
+    async def test_multiple_resources_rejected(self):
+        query = _MultiValueParams(_authorize_params(resource=RESOURCE), [RESOURCE, OTHER_RESOURCE])
+        result, _ = await _authorize_get(query)
+        assert result.status_code == 400
+        assert result.content["error"] == "invalid_target"
+
+    @pytest.mark.asyncio
+    async def test_resource_outside_allowlist_rejected(self):
+        result, _ = await _authorize_get(
+            _authorize_params(resource=OTHER_RESOURCE),
+            settings=_settings(allowed_resources=[RESOURCE]),
+        )
+        assert result.status_code == 400
+        assert result.content["error"] == "invalid_target"
+
+    @pytest.mark.asyncio
+    async def test_allowlisted_resource_accepted_and_stored_in_session(self):
+        session = {"user_id": USER_ID}
+        result, _ = await _authorize_get(
+            _authorize_params(resource=RESOURCE),
+            session=session,
+            settings=_settings(allowed_resources=[RESOURCE]),
+        )
+        from litestar.response import Template as TemplateResponse
+
+        assert isinstance(result, TemplateResponse)
+        assert session["oauth_authorize"]["resource"] == RESOURCE
+
+    @pytest.mark.asyncio
+    async def test_resource_survives_login_redirect(self):
+        result, _ = await _authorize_get(_authorize_params(resource=RESOURCE))
+        from litestar.response import Redirect
+
+        assert isinstance(result, Redirect)
+        login = urlsplit(result.url)
+        next_url = parse_qs(login.query)["next"][0]
+        authorize_params = parse_qs(urlsplit(next_url).query)
+        assert authorize_params["resource"] == [RESOURCE]
+
+
+class TestAuthorizePostCarriesResource:
+    @pytest.mark.asyncio
+    async def test_approved_code_embeds_resource(self):
+        controller = OAuth2Controller(owner=MagicMock())
+        request = MagicMock()
+        request.session = {
+            "user_id": USER_ID,
+            "user_email": "u@example.com",
+            "user_name": "U User",
+            "user_picture_url": "",
+            "oauth_authorize": {
+                "client_id": "abc",
+                "redirect_uri": "http://localhost/cb",
+                "state": "xyz",
+                "scope": "openid",
+                "code_challenge": "challenge",
+                "resource": RESOURCE,
+            },
+        }
+        request.form = AsyncMock(return_value={"action": "allow"})
+        db_session = AsyncMock()
+
+        with patch("skrift.controllers.oauth2.verify_csrf", new_callable=AsyncMock, return_value=True), \
+             patch("skrift.controllers.oauth2.get_settings", return_value=_settings()):
+            result = await OAuth2Controller.authorize_post.fn(controller, request, db_session)
+
+        code = parse_qs(urlsplit(result.url).query)["code"][0]
+        payload = verify_signed_token(code, SECRET)
+        assert payload["resource"] == RESOURCE
+
+
+def _auth_code(*, resource="", challenge=None):
+    _, default_challenge = _pkce_pair()
+    payload = {
+        "type": "code",
+        "user_id": USER_ID,
+        "email": "u@example.com",
+        "name": "U User",
+        "picture_url": "",
+        "client_id": "abc",
+        "redirect_uri": "http://localhost/cb",
+        "scope": "openid",
+        "code_challenge": challenge if challenge is not None else default_challenge,
+    }
+    if resource:
+        payload["resource"] = resource
+    return create_signed_token(payload, SECRET, AUTH_CODE_TTL)
+
+
+async def _exchange(form_data, *, settings=None, signing_key=None):
+    controller = OAuth2Controller(owner=MagicMock())
+    request = MagicMock()
+    request.form = AsyncMock(return_value=form_data)
+    request.base_url = "http://localhost:8000/"
+    db_session = AsyncMock()
+
+    with patch("skrift.controllers.oauth2.get_settings", return_value=settings or _settings()), \
+         patch("skrift.controllers.oauth2.oauth2_service") as mock_svc, \
+         patch("skrift.controllers.oauth2.oauth2_signing_key_service") as mock_keys:
+        mock_svc.get_client_by_client_id = AsyncMock(return_value=_client())
+        mock_svc.is_token_revoked = AsyncMock(return_value=False)
+        mock_svc.is_family_revoked = AsyncMock(return_value=False)
+        mock_svc.revoke_token = AsyncMock()
+        mock_svc.revoke_family = AsyncMock()
+        mock_keys.get_or_create_active_key = AsyncMock(return_value=signing_key or _signing_key())
+        return await OAuth2Controller.token_exchange.fn(controller, request, db_session)
+
+
+def _code_grant_form(code, **overrides):
+    verifier, _ = _pkce_pair()
+    form = {
+        "grant_type": "authorization_code",
+        "code": code,
+        "redirect_uri": "http://localhost/cb",
+        "client_id": "abc",
+        "client_secret": "secret",
+        "code_verifier": verifier,
+    }
+    form.update(overrides)
+    return form
+
+
+class TestTokenEndpointIssuesJwt:
+    @pytest.mark.asyncio
+    async def test_code_resource_becomes_audience(self):
+        key = _signing_key()
+        result = await _exchange(_code_grant_form(_auth_code(resource=RESOURCE)), signing_key=key)
+
+        assert result.status_code == 200
+        body = result.content
+        assert body["expires_in"] == ACCESS_TTL
+        claims = verify_access_token_jwt(
+            body["access_token"], jwks=_jwks_for(key), issuer=ISSUER, audience=RESOURCE
+        )
+        assert claims is not None
+        assert claims["sub"] == USER_ID
+        assert claims["client_id"] == "abc"
+        assert claims["scope"] == "openid"
+        assert claims["aud"] == RESOURCE
+        refresh_payload = verify_signed_token(body["refresh_token"], SECRET)
+        assert refresh_payload["resource"] == RESOURCE
+
+    @pytest.mark.asyncio
+    async def test_no_resource_yields_jwt_without_audience(self):
+        key = _signing_key()
+        result = await _exchange(_code_grant_form(_auth_code()), signing_key=key)
+
+        assert result.status_code == 200
+        claims = verify_access_token_jwt(
+            result.content["access_token"], jwks=_jwks_for(key), issuer=ISSUER, audience=None
+        )
+        assert claims is not None
+        assert "aud" not in claims
+
+    @pytest.mark.asyncio
+    async def test_token_endpoint_resource_narrows_unrestricted_grant(self):
+        key = _signing_key()
+        result = await _exchange(
+            _code_grant_form(_auth_code(), resource=RESOURCE), signing_key=key
+        )
+
+        assert result.status_code == 200
+        claims = verify_access_token_jwt(
+            result.content["access_token"], jwks=_jwks_for(key), issuer=ISSUER, audience=RESOURCE
+        )
+        assert claims is not None
+
+    @pytest.mark.asyncio
+    async def test_token_endpoint_resource_mismatch_rejected(self):
+        result = await _exchange(
+            _code_grant_form(_auth_code(resource=RESOURCE), resource=OTHER_RESOURCE)
+        )
+        assert result.status_code == 400
+        assert result.content["error"] == "invalid_target"
+
+    @pytest.mark.asyncio
+    async def test_token_endpoint_invalid_resource_rejected(self):
+        result = await _exchange(_code_grant_form(_auth_code(), resource="not-a-uri"))
+        assert result.status_code == 400
+        assert result.content["error"] == "invalid_target"
+
+    @pytest.mark.asyncio
+    async def test_token_endpoint_enforces_allowlist(self):
+        result = await _exchange(
+            _code_grant_form(_auth_code(), resource=OTHER_RESOURCE),
+            settings=_settings(allowed_resources=[RESOURCE]),
+        )
+        assert result.status_code == 400
+        assert result.content["error"] == "invalid_target"
+
+
+class TestRefreshKeepsAudience:
+    def _refresh_token(self, *, resource=""):
+        payload = {
+            "type": "refresh",
+            "user_id": USER_ID,
+            "client_id": "abc",
+            "scope": "openid",
+            "family_id": "fam-aud",
+        }
+        if resource:
+            payload["resource"] = resource
+        return create_signed_token(payload, SECRET, REFRESH_TOKEN_TTL)
+
+    def _refresh_form(self, refresh, **overrides):
+        form = {
+            "grant_type": "refresh_token",
+            "refresh_token": refresh,
+            "client_id": "abc",
+            "client_secret": "secret",
+        }
+        form.update(overrides)
+        return form
+
+    @pytest.mark.asyncio
+    async def test_refreshed_access_token_keeps_audience(self):
+        key = _signing_key()
+        result = await _exchange(
+            self._refresh_form(self._refresh_token(resource=RESOURCE)), signing_key=key
+        )
+
+        assert result.status_code == 200
+        body = result.content
+        claims = verify_access_token_jwt(
+            body["access_token"], jwks=_jwks_for(key), issuer=ISSUER, audience=RESOURCE
+        )
+        assert claims is not None
+        assert claims["aud"] == RESOURCE
+        new_refresh_payload = verify_signed_token(body["refresh_token"], SECRET)
+        assert new_refresh_payload["resource"] == RESOURCE
+
+    @pytest.mark.asyncio
+    async def test_refresh_resource_mismatch_rejected(self):
+        result = await _exchange(
+            self._refresh_form(self._refresh_token(resource=RESOURCE), resource=OTHER_RESOURCE)
+        )
+        assert result.status_code == 400
+        assert result.content["error"] == "invalid_target"
+
+    @pytest.mark.asyncio
+    async def test_legacy_refresh_without_resource_still_works(self):
+        key = _signing_key()
+        result = await _exchange(self._refresh_form(self._refresh_token()), signing_key=key)
+
+        assert result.status_code == 200
+        claims = verify_access_token_jwt(
+            result.content["access_token"], jwks=_jwks_for(key), issuer=ISSUER, audience=None
+        )
+        assert claims is not None
+        assert "aud" not in claims
+
+
+async def _userinfo(token, jwks, *, user="default", revoked=False, email_verified=True):
+    if user == "default":
+        user = MagicMock(email="u@example.com", picture_url="https://x/p.png")
+        user.name = "U User"
+    controller = OAuth2Controller(owner=MagicMock())
+    request = MagicMock()
+    request.headers = {"authorization": f"Bearer {token}"}
+    request.base_url = "http://localhost:8000/"
+    db_session = AsyncMock()
+    db_session.get = AsyncMock(return_value=user)
+
+    with patch("skrift.controllers.oauth2.get_settings", return_value=_settings()), \
+         patch("skrift.controllers.oauth2.oauth2_service") as mock_svc, \
+         patch("skrift.controllers.oauth2.oauth_service") as mock_oauth_svc, \
+         patch("skrift.controllers.oauth2.oauth2_signing_key_service") as mock_keys:
+        mock_svc.is_token_revoked = AsyncMock(return_value=revoked)
+        mock_oauth_svc.is_email_verified_for_user = AsyncMock(return_value=email_verified)
+        mock_keys.list_jwks_keys = AsyncMock(return_value=jwks)
+        return await OAuth2Controller.userinfo.fn(controller, request, db_session)
+
+
+class TestUserinfoWithJwt:
+    @pytest.mark.asyncio
+    async def test_full_scopes_return_profile_from_database(self):
+        key = _signing_key()
+        result = await _userinfo(_mint(key), _jwks_for(key))
+
+        assert result.status_code == 200
+        assert result.content == {
+            "sub": USER_ID,
+            "email": "u@example.com",
+            "email_verified": True,
+            "name": "U User",
+            "picture": "https://x/p.png",
+        }
+
+    @pytest.mark.asyncio
+    async def test_openid_only_returns_sub(self):
+        key = _signing_key()
+        result = await _userinfo(_mint(key, scope="openid"), _jwks_for(key))
+        assert result.content == {"sub": USER_ID}
+
+    @pytest.mark.asyncio
+    async def test_revoked_jwt_rejected(self):
+        key = _signing_key()
+        result = await _userinfo(_mint(key), _jwks_for(key), revoked=True)
+        assert result.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_jwt_from_other_issuer_rejected(self):
+        key = _signing_key()
+        result = await _userinfo(_mint(key, issuer="https://evil.example.com"), _jwks_for(key))
+        assert result.status_code == 401
+
+
+async def _introspect(token, jwks, *, client=None, revoked=False):
+    controller = OAuth2Controller(owner=MagicMock())
+    request = MagicMock()
+    request.form = AsyncMock(return_value={
+        "token": token,
+        "client_id": (client or _client()).client_id,
+        "client_secret": "secret",
+    })
+    request.base_url = "http://localhost:8000/"
+    db_session = AsyncMock()
+
+    with patch("skrift.controllers.oauth2.get_settings", return_value=_settings()), \
+         patch("skrift.controllers.oauth2.oauth2_service") as mock_svc, \
+         patch("skrift.controllers.oauth2.oauth2_signing_key_service") as mock_keys:
+        mock_svc.get_client_by_client_id = AsyncMock(return_value=client or _client())
+        mock_svc.is_token_revoked = AsyncMock(return_value=revoked)
+        mock_keys.list_jwks_keys = AsyncMock(return_value=jwks)
+        return await OAuth2Controller.introspect.fn(controller, request, db_session)
+
+
+class TestIntrospectWithJwt:
+    @pytest.mark.asyncio
+    async def test_issuing_client_sees_full_jwt_details(self):
+        key = _signing_key()
+        result = await _introspect(_mint(key), _jwks_for(key))
+
+        assert result.status_code == 200
+        body = result.content
+        assert body["active"] is True
+        assert body["token_type"] == "access"
+        assert body["sub"] == USER_ID
+        assert body["scope"] == "openid email profile"
+        assert body["client_id"] == "abc"
+        assert body["aud"] == RESOURCE
+        assert body["exp"] > time.time()
+
+    @pytest.mark.asyncio
+    async def test_other_client_sees_minimal_jwt_details(self):
+        key = _signing_key()
+        result = await _introspect(_mint(key), _jwks_for(key), client=_client(client_id="nosy"))
+
+        body = result.content
+        assert body["active"] is True
+        assert "sub" not in body
+        assert "scope" not in body
+        assert "aud" not in body
+
+    @pytest.mark.asyncio
+    async def test_revoked_jwt_is_inactive(self):
+        key = _signing_key()
+        result = await _introspect(_mint(key), _jwks_for(key), revoked=True)
+        assert result.content["active"] is False
+
+    @pytest.mark.asyncio
+    async def test_hmac_refresh_token_still_introspects(self):
+        refresh = create_signed_token({
+            "type": "refresh",
+            "user_id": USER_ID,
+            "client_id": "abc",
+            "scope": "openid",
+            "family_id": "fam-x",
+        }, SECRET, REFRESH_TOKEN_TTL)
+        result = await _introspect(refresh, [])
+
+        body = result.content
+        assert body["active"] is True
+        assert body["token_type"] == "refresh"
+        assert body["sub"] == USER_ID
+
+
+class TestDiscoveryDocuments:
+    async def _fetch(self, route_name):
+        from skrift.controllers.sitemap import SitemapController
+
+        settings = MagicMock()
+        settings.oauth2_enabled = True
+        settings.oauth2_issuer = ""
+
+        controller = SitemapController(owner=MagicMock())
+        request = MagicMock()
+        request.base_url = "http://localhost:8000/"
+
+        with patch("skrift.config.get_settings", return_value=settings):
+            handler = getattr(SitemapController, route_name)
+            return await handler.fn(controller, request)
+
+    @pytest.mark.asyncio
+    async def test_both_documents_served_and_equal(self):
+        openid = await self._fetch("openid_configuration")
+        rfc8414 = await self._fetch("oauth_authorization_server")
+
+        assert openid.status_code == 200
+        assert rfc8414.status_code == 200
+        assert openid.content == rfc8414.content
+
+    @pytest.mark.asyncio
+    async def test_metadata_contains_jwks_uri_and_registry_scopes(self):
+        result = await self._fetch("oauth_authorization_server")
+        body = result.content
+
+        assert body["issuer"] == ISSUER
+        assert body["jwks_uri"] == f"{ISSUER}/oauth/jwks"
+        assert set(body["scopes_supported"]) >= {"openid", "profile", "email"}
+        assert body["code_challenge_methods_supported"] == ["S256"]
+        assert "token_endpoint_auth_methods_supported" in body
+        assert "registration_endpoint" not in body
+
+    @pytest.mark.asyncio
+    async def test_configured_issuer_overrides_request_base_url(self):
+        from skrift.controllers.sitemap import SitemapController
+
+        settings = MagicMock()
+        settings.oauth2_enabled = True
+        settings.oauth2_issuer = "https://id.example.com"
+
+        controller = SitemapController(owner=MagicMock())
+        request = MagicMock()
+        request.base_url = "http://localhost:8000/"
+
+        with patch("skrift.config.get_settings", return_value=settings):
+            result = await SitemapController.oauth_authorization_server.fn(controller, request)
+
+        assert result.content["issuer"] == "https://id.example.com"
+        assert result.content["jwks_uri"] == "https://id.example.com/oauth/jwks"

--- a/tests/test_oauth2_refresh_scope.py
+++ b/tests/test_oauth2_refresh_scope.py
@@ -21,7 +21,21 @@ SECRET = "test-secret-key"
 def _settings():
     settings = MagicMock()
     settings.secret_key = SECRET
+    settings.oauth2_issuer = "http://localhost:8000"
+    settings.oauth2_access_token_ttl = 900
+    settings.oauth2_allowed_resources = []
     return settings
+
+
+def _signing_key():
+    from joserfc.jwk import ECKey
+
+    key = ECKey.generate_key("P-256")
+    signing_key = MagicMock()
+    signing_key.kid = key.thumbprint()
+    signing_key.private_key_pem = key.as_pem(private=True).decode("ascii")
+    signing_key.algorithm = "ES256"
+    return signing_key
 
 
 def _client():
@@ -64,12 +78,15 @@ def _request(refresh: str, *, scope: str | None = None):
 
 async def _exchange(controller, request, db_session, *, client):
     with patch("skrift.controllers.oauth2.get_settings", return_value=_settings()), \
-         patch("skrift.controllers.oauth2.oauth2_service") as mock_svc:
+         patch("skrift.controllers.oauth2.oauth2_service") as mock_svc, \
+         patch("skrift.controllers.oauth2.oauth2_signing_key_service") as mock_keys:
         mock_svc.is_token_revoked = AsyncMock(return_value=False)
         mock_svc.is_family_revoked = AsyncMock(return_value=False)
         mock_svc.get_client_by_client_id = AsyncMock(return_value=client)
         mock_svc.revoke_token = AsyncMock()
         mock_svc.revoke_family = AsyncMock()
+        mock_svc.mark_client_used = AsyncMock()
+        mock_keys.get_or_create_active_key = AsyncMock(return_value=_signing_key())
         return await OAuth2Controller.token_exchange.fn(controller, request, db_session)
 
 

--- a/tests/test_oauth2_server.py
+++ b/tests/test_oauth2_server.py
@@ -29,7 +29,22 @@ def _make_settings():
     settings = MagicMock()
     settings.secret_key = SECRET
     settings.security_headers = SecurityHeadersConfig()
+    settings.oauth2_issuer = "http://localhost:8000"
+    settings.oauth2_access_token_ttl = ACCESS_TOKEN_TTL
+    settings.oauth2_allowed_resources = []
     return settings
+
+
+def _make_signing_key():
+    """A mock OAuth2SigningKey row backed by real EC P-256 key material."""
+    from joserfc.jwk import ECKey
+
+    key = ECKey.generate_key("P-256")
+    signing_key = MagicMock()
+    signing_key.kid = key.thumbprint()
+    signing_key.private_key_pem = key.as_pem(private=True).decode("ascii")
+    signing_key.algorithm = "ES256"
+    return signing_key
 
 
 def _mock_client(
@@ -333,8 +348,10 @@ class TestAuthorizeGet:
         client = _mock_client(redirect_uris=["http://localhost/cb"])
 
         with patch("skrift.controllers.oauth2.oauth2_service") as mock_svc, \
+             patch("skrift.controllers.oauth2.oauth2_consent_service") as mock_consent, \
              patch("skrift.controllers.oauth2.get_settings", return_value=_make_settings()):
             mock_svc.get_client_by_client_id = AsyncMock(return_value=client)
+            mock_consent.find_grant = AsyncMock(return_value=None)
             result = await OAuth2Controller.authorize_get.fn(controller, request, db_session)
 
         assert isinstance(result, TemplateResponse)
@@ -360,8 +377,10 @@ class TestAuthorizeGet:
         client = _mock_client(redirect_uris=["https://runhacks.sh/auth/callback"])
 
         with patch("skrift.controllers.oauth2.oauth2_service") as mock_svc, \
+             patch("skrift.controllers.oauth2.oauth2_consent_service") as mock_consent, \
              patch("skrift.controllers.oauth2.get_settings", return_value=_make_settings()):
             mock_svc.get_client_by_client_id = AsyncMock(return_value=client)
+            mock_consent.find_grant = AsyncMock(return_value=None)
             result = await OAuth2Controller.authorize_get.fn(controller, request, db_session)
 
         csp = dict(result.headers)["content-security-policy"]
@@ -418,7 +437,9 @@ class TestAuthorizePost:
         db_session = AsyncMock()
 
         with patch("skrift.controllers.oauth2.verify_csrf", new_callable=AsyncMock, return_value=True), \
+             patch("skrift.controllers.oauth2.oauth2_consent_service") as mock_consent, \
              patch("skrift.controllers.oauth2.get_settings", return_value=settings):
+            mock_consent.upsert_grant = AsyncMock()
             result = await OAuth2Controller.authorize_post.fn(controller, request, db_session)
 
         assert isinstance(result, Redirect)
@@ -457,10 +478,13 @@ class TestTokenExchange:
         db_session = AsyncMock()
 
         with patch("skrift.controllers.oauth2.get_settings", return_value=settings), \
-             patch("skrift.controllers.oauth2.oauth2_service") as mock_svc:
+             patch("skrift.controllers.oauth2.oauth2_service") as mock_svc, \
+             patch("skrift.controllers.oauth2.oauth2_signing_key_service") as mock_keys:
             mock_svc.get_client_by_client_id = AsyncMock(return_value=client)
             mock_svc.is_token_revoked = AsyncMock(return_value=False)
             mock_svc.revoke_token = AsyncMock(return_value=None)
+            mock_svc.mark_client_used = AsyncMock()
+            mock_keys.get_or_create_active_key = AsyncMock(return_value=_make_signing_key())
             result = await OAuth2Controller.token_exchange.fn(controller, request, db_session)
 
         assert result.status_code == 200
@@ -521,10 +545,13 @@ class TestTokenExchange:
         db_session = AsyncMock()
 
         with patch("skrift.controllers.oauth2.get_settings", return_value=settings), \
-             patch("skrift.controllers.oauth2.oauth2_service") as mock_svc:
+             patch("skrift.controllers.oauth2.oauth2_service") as mock_svc, \
+             patch("skrift.controllers.oauth2.oauth2_signing_key_service") as mock_keys:
             mock_svc.get_client_by_client_id = AsyncMock(return_value=client)
             mock_svc.is_token_revoked = AsyncMock(return_value=False)
             mock_svc.revoke_token = AsyncMock(return_value=None)
+            mock_svc.mark_client_used = AsyncMock()
+            mock_keys.get_or_create_active_key = AsyncMock(return_value=_make_signing_key())
             result = await OAuth2Controller.token_exchange.fn(controller, request, db_session)
 
         assert result.status_code == 200
@@ -555,12 +582,15 @@ class TestRefreshTokenGrant:
         db_session = AsyncMock()
 
         with patch("skrift.controllers.oauth2.get_settings", return_value=settings), \
-             patch("skrift.controllers.oauth2.oauth2_service") as mock_svc:
+             patch("skrift.controllers.oauth2.oauth2_service") as mock_svc, \
+             patch("skrift.controllers.oauth2.oauth2_signing_key_service") as mock_keys:
             mock_svc.is_token_revoked = AsyncMock(return_value=False)
             mock_svc.is_family_revoked = AsyncMock(return_value=False)
             mock_svc.get_client_by_client_id = AsyncMock(return_value=client)
             mock_svc.revoke_token = AsyncMock()
             mock_svc.revoke_family = AsyncMock()
+            mock_svc.mark_client_used = AsyncMock()
+            mock_keys.get_or_create_active_key = AsyncMock(return_value=_make_signing_key())
             result = await OAuth2Controller.token_exchange.fn(controller, request, db_session)
 
         assert result.status_code == 200
@@ -969,6 +999,7 @@ class TestDiscovery:
 
         settings = MagicMock()
         settings.oauth2_enabled = True
+        settings.oauth2_issuer = ""
 
         controller = SitemapController(owner=MagicMock())
         request = MagicMock()

--- a/tests/test_oauth2_server.py
+++ b/tests/test_oauth2_server.py
@@ -959,6 +959,64 @@ class TestIntrospect:
         assert result.status_code == 400
         assert result.content["error"] == "invalid_client"
 
+    @pytest.mark.asyncio
+    async def test_public_client_cannot_introspect(self):
+        """RFC 7662 §2.1 — a secretless (dynamically-registered) client has no
+        way to authenticate here, so it must be refused outright. Anything
+        else turns introspection into an unauthenticated validity oracle for
+        any captured token string."""
+        settings = _make_settings()
+        public_client = _mock_client(client_id="dyn-public", client_secret="")
+        token = create_signed_token({
+            "type": "access",
+            "user_id": "user-123",
+            "client_id": "some-other-client",
+            "scope": "openid",
+        }, SECRET, ACCESS_TOKEN_TTL)
+
+        controller = OAuth2Controller(owner=MagicMock())
+        request = MagicMock()
+        request.form = AsyncMock(return_value={
+            "token": token,
+            "client_id": "dyn-public",
+            "client_secret": "",
+        })
+        db_session = AsyncMock()
+
+        with patch("skrift.controllers.oauth2.get_settings", return_value=settings), \
+             patch("skrift.controllers.oauth2.oauth2_service") as mock_svc:
+            mock_svc.get_client_by_client_id = AsyncMock(return_value=public_client)
+            mock_svc.is_token_revoked = AsyncMock(return_value=False)
+            result = await OAuth2Controller.introspect.fn(controller, request, db_session)
+
+        assert result.status_code == 401
+        assert result.content["error"] == "invalid_client"
+        assert "active" not in result.content
+
+    @pytest.mark.asyncio
+    async def test_public_client_with_guessed_secret_still_refused(self):
+        """Presenting an arbitrary secret for a secretless client must not
+        sneak past the authentication gate either."""
+        settings = _make_settings()
+        public_client = _mock_client(client_id="dyn-public", client_secret="")
+
+        controller = OAuth2Controller(owner=MagicMock())
+        request = MagicMock()
+        request.form = AsyncMock(return_value={
+            "token": "any-token",
+            "client_id": "dyn-public",
+            "client_secret": "guessed",
+        })
+        db_session = AsyncMock()
+
+        with patch("skrift.controllers.oauth2.get_settings", return_value=settings), \
+             patch("skrift.controllers.oauth2.oauth2_service") as mock_svc:
+            mock_svc.get_client_by_client_id = AsyncMock(return_value=public_client)
+            result = await OAuth2Controller.introspect.fn(controller, request, db_session)
+
+        assert result.status_code == 401
+        assert result.content["error"] == "invalid_client"
+
 
 class TestScopeRegistry:
     def test_builtin_scopes_registered(self):

--- a/tests/test_oauth2_signing_keys.py
+++ b/tests/test_oauth2_signing_keys.py
@@ -1,0 +1,135 @@
+"""Integration tests for the OAuth2 signing-key service against SQLite."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+import pytest_asyncio
+from joserfc.jwk import ECKey
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+from skrift.db.base import Base
+from skrift.db.models import OAuth2SigningKey  # noqa: F401  (registers table)
+from skrift.db.services import oauth2_signing_key_service as signing_keys
+
+
+@pytest_asyncio.fixture
+async def db_session():
+    engine = create_async_engine("sqlite+aiosqlite://")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    maker = async_sessionmaker(engine, expire_on_commit=False)
+    async with maker() as session:
+        yield session
+    await engine.dispose()
+
+
+async def _all_keys(db_session) -> list[OAuth2SigningKey]:
+    result = await db_session.execute(select(OAuth2SigningKey))
+    return list(result.scalars().all())
+
+
+class TestGetOrCreateActiveKey:
+    @pytest.mark.asyncio
+    async def test_generates_key_on_first_use(self, db_session):
+        key = await signing_keys.get_or_create_active_key(db_session)
+        assert key.is_active is True
+        assert key.algorithm == "ES256"
+        assert key.retired_at is None
+        assert "BEGIN PRIVATE KEY" in key.private_key_pem
+        assert key.kid
+
+    @pytest.mark.asyncio
+    async def test_returns_same_key_when_already_active(self, db_session):
+        first = await signing_keys.get_or_create_active_key(db_session)
+        second = await signing_keys.get_or_create_active_key(db_session)
+        assert first.kid == second.kid
+        assert len(await _all_keys(db_session)) == 1
+
+    @pytest.mark.asyncio
+    async def test_private_key_pem_is_importable(self, db_session):
+        key = await signing_keys.get_or_create_active_key(db_session)
+        imported = ECKey.import_key(key.private_key_pem)
+        assert imported.thumbprint() == key.kid
+
+
+class TestRotate:
+    @pytest.mark.asyncio
+    async def test_rotate_retires_previous_and_activates_new(self, db_session):
+        original = await signing_keys.get_or_create_active_key(db_session)
+        rotated = await signing_keys.rotate(db_session)
+
+        assert rotated.kid != original.kid
+        assert rotated.is_active is True
+        assert rotated.retired_at is None
+
+        keys_by_kid = {key.kid: key for key in await _all_keys(db_session)}
+        assert keys_by_kid[original.kid].is_active is False
+        assert keys_by_kid[original.kid].retired_at is not None
+
+    @pytest.mark.asyncio
+    async def test_only_one_active_key_after_rotation(self, db_session):
+        await signing_keys.get_or_create_active_key(db_session)
+        await signing_keys.rotate(db_session)
+        active = [key for key in await _all_keys(db_session) if key.is_active]
+        assert len(active) == 1
+
+
+class TestListJwksKeys:
+    @pytest.mark.asyncio
+    async def test_lists_active_key_as_public_jwk(self, db_session):
+        key = await signing_keys.get_or_create_active_key(db_session)
+        jwks = await signing_keys.list_jwks_keys(db_session)
+        assert len(jwks) == 1
+        jwk = jwks[0]
+        assert jwk["kid"] == key.kid
+        assert jwk["kty"] == "EC"
+        assert jwk["crv"] == "P-256"
+        assert jwk["alg"] == "ES256"
+        assert jwk["use"] == "sig"
+        assert "d" not in jwk  # private component must not leak
+
+    @pytest.mark.asyncio
+    async def test_retired_key_still_listed_until_pruned(self, db_session):
+        original = await signing_keys.get_or_create_active_key(db_session)
+        rotated = await signing_keys.rotate(db_session)
+        listed_kids = {jwk["kid"] for jwk in await signing_keys.list_jwks_keys(db_session)}
+        assert listed_kids == {original.kid, rotated.kid}
+
+
+class TestPruneExpired:
+    @pytest.mark.asyncio
+    async def test_keeps_recently_retired_key(self, db_session):
+        await signing_keys.get_or_create_active_key(db_session)
+        await signing_keys.rotate(db_session)
+        now = datetime.now(tz=timezone.utc)
+        deleted = await signing_keys.prune_expired(
+            db_session, now=now, access_token_ttl=900, clock_skew=60
+        )
+        assert deleted == 0
+        assert len(await _all_keys(db_session)) == 2
+
+    @pytest.mark.asyncio
+    async def test_prunes_key_retired_past_ttl_and_skew(self, db_session):
+        original = await signing_keys.get_or_create_active_key(db_session)
+        rotated = await signing_keys.rotate(db_session)
+        future = datetime.now(tz=timezone.utc) + timedelta(seconds=901 + 61)
+        deleted = await signing_keys.prune_expired(
+            db_session, now=future, access_token_ttl=900, clock_skew=60
+        )
+        assert deleted == 1
+        remaining = {key.kid for key in await _all_keys(db_session)}
+        assert remaining == {rotated.kid}
+        assert original.kid not in remaining
+
+    @pytest.mark.asyncio
+    async def test_never_prunes_active_key(self, db_session):
+        active = await signing_keys.get_or_create_active_key(db_session)
+        far_future = datetime.now(tz=timezone.utc) + timedelta(days=3650)
+        deleted = await signing_keys.prune_expired(
+            db_session, now=far_future, access_token_ttl=900, clock_skew=60
+        )
+        assert deleted == 0
+        assert [key.kid for key in await _all_keys(db_session)] == [active.kid]

--- a/uv.lock
+++ b/uv.lock
@@ -969,6 +969,18 @@ wheels = [
 ]
 
 [[package]]
+name = "joserfc"
+version = "1.7.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d4/c6/b1cac0280f8efc57626ea8804866b37099f23cae11b1485a42b213245e31/joserfc-1.7.3.tar.gz", hash = "sha256:116955c2587139dba20621fd0bd7fc9255fa960c9fe7f43c43ebef2e801dcfcf", size = 233821, upload-time = "2026-07-08T12:41:42.66Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7d/f5/650b59d1b74f5befb7a7a7e7d7c92a26b94256df3541e2b4914152cd177a/joserfc-1.7.3-py3-none-any.whl", hash = "sha256:7c39f3f2c943dbc03122747fa8ebbd8e156e54904cf25651b452f4d2634a6075", size = 70982, upload-time = "2026-07-08T12:41:41.521Z" },
+]
+
+[[package]]
 name = "litestar"
 version = "2.19.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2148,6 +2160,7 @@ dependencies = [
     { name = "fast-query-parsers" },
     { name = "httpx" },
     { name = "hypercorn" },
+    { name = "joserfc" },
     { name = "litestar", extra = ["cryptography", "jinja"] },
     { name = "markdown-it-py" },
     { name = "mdit-py-plugins" },
@@ -2214,6 +2227,7 @@ requires-dist = [
     { name = "fast-query-parsers", specifier = ">=1.0.2" },
     { name = "httpx", specifier = ">=0.28.0" },
     { name = "hypercorn", specifier = ">=0.17.0" },
+    { name = "joserfc", specifier = ">=1.0.0" },
     { name = "litestar", extras = ["jinja", "cryptography"], specifier = ">=2.14.0" },
     { name = "logfire", extras = ["asgi", "sqlalchemy", "httpx"], marker = "extra == 'logfire'", specifier = ">=3.0.0" },
     { name = "markdown-it-py", specifier = ">=3.0.0" },

--- a/uv.lock
+++ b/uv.lock
@@ -2137,7 +2137,7 @@ wheels = [
 
 [[package]]
 name = "skrift"
-version = "0.2.0a11"
+version = "0.2.0a12"
 source = { editable = "." }
 dependencies = [
     { name = "advanced-alchemy" },


### PR DESCRIPTION
## Summary

Adds an MCP-ready OAuth 2.1 authorization-server layer so Skrift apps can serve authenticated remote MCP connectors (Claude custom connectors) and act as identity providers for external OAuth clients (#165), and fixes a correctness bug where agent `deps_ref` was frozen at the first turn (#164).

## Changes

### New Features
- **OAuth2 identity provider for MCP (#165):** ES256 JWT access tokens signed by rotating keys published at `/oauth/jwks`, RFC 8707 `resource` → token `aud`, RFC 8414 authorization-server metadata at `/.well-known/oauth-authorization-server`, Dynamic Client Registration (RFC 7591) for per-install public clients, a reusable Bearer-JWT route guard, and remembered per-user/client consent. Includes a full end-to-end Claude-connector integration test.

### Bug Fixes
- **Per-turn `deps_ref` (#164):** `Chat`/`Session` now propagate a fresh `deps_ref` on every turn instead of freezing it at session creation. Queued turns carry their own `deps_ref` and it is applied at turn activation, so rapid sends and mid-turn sends no longer corrupt each other's dependencies. Adds a `DepsRefUpdated` audit event and fails fast when `deps_ref` is passed to an agent without a `deps_factory`.
- Fix a stale assertion in the cross-replica dismiss test.

### Improvements
- DCR hardening: https/loopback-only redirect URIs, per-IP and global registration caps, rate limiting, and a prune job for unused dynamically-registered clients.
- Introspection restricted to authenticated confidential clients (public clients rejected) to avoid an unauthenticated token-validity oracle.

## Release version
`0.2.0a12` -> `0.2.0a13`

Closes #164, #165