### PR TITLE
Release v0.2.0a14 — memory fixes + partial-scope OAuth consent

### DIFF
--- a/demo/basic-site/.env.example
+++ b/demo/basic-site/.env.example
@@ -1,0 +1,14 @@
+# Copy to .env before running the demo — the app will not start without SECRET_KEY.
+# Generate a real key with: skrift secret generate
+
+SECRET_KEY=your-secret-key-here-change-in-production
+DEBUG=true
+
+# The demo's app.yaml configures sqlite at ./app.db; override here if needed.
+# DATABASE_URL=sqlite+aiosqlite:///./app.db
+
+# OAuth login (optional for local browsing; required to sign in)
+# Get credentials from: https://console.cloud.google.com/apis/credentials
+GOOGLE_CLIENT_ID=your-client-id
+GOOGLE_CLIENT_SECRET=your-client-secret
+OAUTH_REDIRECT_BASE_URL=http://localhost:8080

--- a/docs/deployment/index.md
+++ b/docs/deployment/index.md
@@ -48,10 +48,14 @@ Deploy your Skrift site to production.
 
 | Resource | Recommendation |
 |----------|----------------|
-| RAM | 512MB+ |
+| RAM | 512MB minimum (1 worker), 1GB+ recommended (2 workers) |
 | CPU | 1 core+ |
 | Storage | 1GB+ (plus database) |
 | Python | 3.13+ |
+
+Each Skrift worker is a separate process using ~150MB of RSS, so RAM — not CPU
+cores — sets the worker count. See
+[Worker Count and Memory](production.md#worker-count-and-memory).
 
 ## Configuration Differences
 

--- a/docs/deployment/production.md
+++ b/docs/deployment/production.md
@@ -314,6 +314,41 @@ development-only and always runs a single worker.
       in every worker process; moving it to the edge substantially lowers per-process
       memory.
 
+### Response Compression
+
+In-app gzip is on by default and bounded so that traffic spikes cannot ratchet
+process memory: each in-flight compressed response holds ~153KB of zlib state,
+so Skrift compresses lazily, releases the compressor as soon as the response is
+written, and caps the number of simultaneously live compressors process-wide.
+When the cap is reached a response is sent uncompressed rather than queued.
+
+```yaml
+# app.yaml
+compression:
+  enabled: true       # set false when the proxy/CDN compresses (recommended)
+  minimum_size: 2048  # bytes; smaller responses are sent uncompressed
+  max_concurrent: 20  # live compressors per process; excess falls back to identity
+```
+
+Responses smaller than `minimum_size` (default 2048 bytes, up from Litestar's
+500) are never compressed — they fit in one or two TCP packets either way. The
+`/notifications/stream` SSE endpoint is always excluded from compression.
+
+### Request Body Limit
+
+Requests larger than `max_request_body_size` (default 10MB) are refused with
+`413` at the transport layer, before the body is buffered into memory:
+
+```yaml
+# app.yaml
+max_request_body_size: 10485760  # bytes (10MB)
+```
+
+The effective cap is automatically lifted to the largest configured storage
+store's `max_upload_size` plus 1MB of multipart framing, so legitimate uploads
+are never refused by the transport while a runaway or malicious POST cannot
+buffer past the limit.
+
 ### PostgreSQL Tuning
 
 Edit `/etc/postgresql/14/main/postgresql.conf`:

--- a/docs/deployment/production.md
+++ b/docs/deployment/production.md
@@ -122,8 +122,10 @@ Environment="SECRET_KEY=your-secure-secret-key"
 Environment="DATABASE_URL=postgresql+asyncpg://skrift:your-secure-password@localhost:5432/skrift"
 Environment="GOOGLE_CLIENT_ID=your-production-client-id"
 Environment="GOOGLE_CLIENT_SECRET=your-production-client-secret"
+# glibc Linux: cap per-thread malloc arenas so freed memory is returned to the OS
+Environment="MALLOC_ARENA_MAX=2"
 ExecStart=/home/skrift/app/venv/bin/hypercorn skrift.asgi:app \
-    --workers 4 \
+    --workers 2 \
     --bind 127.0.0.1:8000 \
     --access-logfile /var/log/skrift/access.log \
     --error-logfile /var/log/skrift/error.log
@@ -133,6 +135,12 @@ RestartSec=5
 [Install]
 WantedBy=multi-user.target
 ```
+
+!!! warning "Workers cost memory"
+    Each worker is a full Python process using roughly **150MB of RSS** with nothing
+    shared between them. Two workers is ~300MB before serving a single request. Size
+    the worker count against available RAM first (see
+    [Worker Count and Memory](#worker-count-and-memory)), not against CPU cores.
 
 Generate a secure secret key:
 
@@ -267,15 +275,44 @@ psql -U skrift skrift < backup_20240101.sql
 
 ## Performance Tuning
 
-### Gunicorn Workers
+### Worker Count and Memory
 
-Adjust workers based on CPU cores:
+Workers are **separate processes**, not threads: nothing is shared between them, so
+memory scales linearly with the worker count. A single Skrift worker measures
+**~135-155MB RSS** once warm, so budget ~150MB per worker plus headroom for the OS
+and any background worker processes.
+
+| Available RAM | Recommended `--workers` |
+|---------------|-------------------------|
+| 512MB | 1 (2 only if nothing else runs on the box) |
+| 1GB | 2 |
+| 2GB | 3-4 |
+
+Skrift is async, so one worker already handles many concurrent connections. Add
+workers to use additional CPU cores, staying within both the RAM budget above and
+the CPU core count.
+
+Each worker also opens **its own database connection pool** (`db.pool_size` 5 plus
+`db.pool_overflow` 10, so up to 15 connections per process). Four workers can therefore
+demand 60 PostgreSQL connections; keep the total below `max_connections` or put
+PgBouncer in front.
 
 ```bash
-# Rule: 2-4 workers per core
-# For 2 cores: 4-8 workers
-gunicorn ... -w 4
+# 1GB server, 2 cores
+skrift serve --workers 2 --host 127.0.0.1 --port 8000
 ```
+
+`skrift serve --workers N` spawns N real worker processes. `--reload` is
+development-only and always runs a single worker.
+
+!!! tip "Reduce per-process memory"
+    - **Set `MALLOC_ARENA_MAX=2`** in the systemd unit or container environment on
+      glibc Linux. Without it glibc creates up to 8 arenas per core per process,
+      which inflates RSS considerably and rarely returns freed memory to the OS.
+    - **Terminate response compression at the reverse proxy or CDN** (nginx `gzip on;`)
+      rather than in the application. In-app gzip buffers response bodies per request
+      in every worker process; moving it to the edge substantially lowers per-process
+      memory.
 
 ### PostgreSQL Tuning
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "skrift"
-version = "0.2.0a13"
+version = "0.2.0a14"
 description = "A lightweight async Python CMS for crafting modern websites"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/skrift/admin/media.py
+++ b/skrift/admin/media.py
@@ -32,6 +32,19 @@ from skrift.storage import StorageManager
 logger = logging.getLogger(__name__)
 
 
+async def read_and_release(upload: UploadFile) -> bytes:
+    """Read an upload into memory and immediately free its spooled buffer.
+
+    Litestar's multipart parser writes each part to a ``SpooledTemporaryFile``
+    that lives until the request object is garbage collected. Reading copies
+    those bytes, so without this the payload is held twice for the whole
+    storage write and database commit.
+    """
+    content = await upload.read()
+    await upload.close()
+    return content
+
+
 class MediaAdminController(Controller):
     """Controller for the admin media library."""
 
@@ -94,14 +107,19 @@ class MediaAdminController(Controller):
         db_session: AsyncSession,
         data: Annotated[UploadFile, Body(media_type=RequestEncodingType.MULTI_PART)],
     ) -> Redirect:
-        """Handle file upload from the media library form."""
+        """Handle file upload from the media library form.
+
+        Bodies larger than the app's ``request_max_body_size`` are rejected by
+        Litestar before this handler runs; ``upload_asset`` re-checks the
+        per-store limit as defense in depth.
+        """
         storage: StorageManager = request.app.state.storage_manager
         user = getattr(request, "user", None)
         user_id = user.id if user else None
 
-        content = await data.read()
         filename = data.filename or "untitled"
         content_type = data.content_type or "application/octet-stream"
+        content = await read_and_release(data)
 
         try:
             await upload_asset(
@@ -131,14 +149,19 @@ class MediaAdminController(Controller):
         db_session: AsyncSession,
         data: Annotated[UploadFile, Body(media_type=RequestEncodingType.MULTI_PART)],
     ) -> Response:
-        """Handle file upload and return JSON (used by page editor fetch)."""
+        """Handle file upload and return JSON (used by page editor fetch).
+
+        Bodies larger than the app's ``request_max_body_size`` are rejected by
+        Litestar before this handler runs; ``upload_asset`` re-checks the
+        per-store limit as defense in depth.
+        """
         storage: StorageManager = request.app.state.storage_manager
         uid = request.session.get(SESSION_USER_ID)
         user_id = UUID(uid) if uid else None
 
-        content = await data.read()
         filename = data.filename or "untitled"
         content_type = data.content_type or "application/octet-stream"
+        content = await read_and_release(data)
 
         try:
             asset = await upload_asset(

--- a/skrift/asgi.py
+++ b/skrift/asgi.py
@@ -27,9 +27,8 @@ from advanced_alchemy.extensions.litestar import (
 
 from skrift.db.session import SessionCleanupMiddleware
 from litestar import Litestar
-from litestar.config.compression import CompressionConfig
 
-from skrift.middleware.compression import SafeGzipCompression
+from skrift.middleware.compression import build_compression_middleware
 from litestar.middleware import DefineMiddleware
 from litestar.types import ASGIApp, Receive, Scope, Send
 
@@ -42,7 +41,15 @@ from skrift.app_factory import (
     get_template_directories,
     update_template_directories,
 )
-from skrift.config import DatabaseConfig, get_config_path, get_settings, is_config_valid
+from skrift.config import (
+    CompressionConfig,
+    DEFAULT_MAX_REQUEST_BODY_SIZE,
+    DatabaseConfig,
+    get_config_path,
+    get_settings,
+    is_config_valid,
+    resolve_request_max_body_size,
+)
 from skrift.db.services.asset_service import internal_asset_url
 from skrift.ratelimit import RateLimiter, set_limiter
 from skrift.lib.trusted_proxy import TrustedProxyManager
@@ -649,6 +656,7 @@ def _build_site_app(
         route_handlers=controllers,
         plugins=[SQLAlchemyPlugin(config=db_config)],
         middleware=[
+            *build_compression_middleware(settings.compression),
             DefineMiddleware(SessionCleanupMiddleware),
             *client_ip_middleware,
             *security_middleware,
@@ -657,8 +665,8 @@ def _build_site_app(
             *user_middleware,
         ],
         template_config=template_config,
-        compression_config=CompressionConfig(backend="gzip", compression_facade=SafeGzipCompression),
         exception_handlers=EXCEPTION_HANDLERS,
+        request_max_body_size=resolve_request_max_body_size(settings),
         debug=settings.debug,
     )
     site_app.state.storage_manager = storage_manager
@@ -1186,10 +1194,10 @@ def create_app() -> ASGIApp:
         on_shutdown=[on_shutdown],
         route_handlers=[NotificationsController, SitemapController, AccountController, *oauth2_handlers, *api_auth_handlers, *republish_handlers, *webhook_handlers, *bot_detection_handlers, *controllers],
         plugins=[SQLAlchemyPlugin(config=db_config)],
-        middleware=[DefineMiddleware(SessionCleanupMiddleware), *client_ip_middleware, *security_middleware, *rate_limit_middleware, *bot_detection_middleware, session_config.middleware, *session_idle_middleware, *user_middleware],
+        middleware=[*build_compression_middleware(settings.compression), DefineMiddleware(SessionCleanupMiddleware), *client_ip_middleware, *security_middleware, *rate_limit_middleware, *bot_detection_middleware, session_config.middleware, *session_idle_middleware, *user_middleware],
         template_config=template_config,
-        compression_config=CompressionConfig(backend="gzip", exclude="/notifications/stream", compression_facade=SafeGzipCompression),
         exception_handlers=EXCEPTION_HANDLERS,
+        request_max_body_size=resolve_request_max_body_size(settings),
         debug=settings.debug,
     )
     app.state.webhook_secret = settings.notifications.webhook_secret
@@ -1314,6 +1322,9 @@ def create_setup_app() -> Litestar:
     class MinimalSettings(BaseSettings):
         debug: bool = True
         secret_key: str = "setup-wizard-temporary-secret-key-change-me"
+        compression: CompressionConfig = CompressionConfig()
+        # The setup wizard has no upload routes, so the plain floor applies.
+        max_request_body_size: int = DEFAULT_MAX_REQUEST_BODY_SIZE
 
     settings = MinimalSettings()
 
@@ -1439,10 +1450,10 @@ def create_setup_app() -> Litestar:
         on_startup=[on_startup],
         route_handlers=route_handlers,
         plugins=plugins,
-        middleware=[DefineMiddleware(SessionCleanupMiddleware), session_config.middleware],
+        middleware=[*build_compression_middleware(settings.compression), DefineMiddleware(SessionCleanupMiddleware), session_config.middleware],
         template_config=template_config,
-        compression_config=CompressionConfig(backend="gzip", compression_facade=SafeGzipCompression),
         exception_handlers=EXCEPTION_HANDLERS,
+        request_max_body_size=settings.max_request_body_size,
         debug=settings.debug,
     )
     return StaticFilesMiddleware(

--- a/skrift/asgi.py
+++ b/skrift/asgi.py
@@ -1139,6 +1139,7 @@ def create_app() -> ASGIApp:
                 visibility_timeout=settings.workers.visibility_timeout,
                 reaper_interval=settings.workers.reaper_interval,
                 max_reclaims=settings.workers.max_reclaims,
+                terminal_job_state_ttl=settings.workers.retention.terminal_job_state_ttl,
                 backend_imports=settings.workers.backends,
                 settings=settings,
                 session_maker=db_config.get_session,

--- a/skrift/auth/services.py
+++ b/skrift/auth/services.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections import OrderedDict
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta
 from typing import TYPE_CHECKING
@@ -17,9 +18,12 @@ if TYPE_CHECKING:
     from sqlalchemy.ext.asyncio import AsyncSession
 
 
-# Cache for user permissions with TTL
-_permission_cache: dict[str, tuple[datetime, "UserPermissions"]] = {}
+# Cache for user permissions: TTL for freshness, LRU cap for memory. The TTL
+# alone can't bound it — a user who never comes back is never read again, so
+# their entry would sit there forever. Least-recently-used entries sit first.
+_permission_cache: OrderedDict[str, tuple[datetime, "UserPermissions"]] = OrderedDict()
 CACHE_TTL = timedelta(minutes=5)
+MAX_PERMISSION_CACHE_ENTRIES = 10_000
 
 
 @dataclass
@@ -31,12 +35,34 @@ class UserPermissions:
     permissions: set[str] = field(default_factory=set)
 
 
+def _purge_expired_permissions(now: datetime) -> None:
+    """Drop lapsed entries from the front, stopping at the first live one.
+
+    Opportunistic: entries that were pushed to the back by a recent read may
+    outlive their TTL until the LRU cap reaches them. That's fine — the TTL is
+    still checked on every read, so a stale entry is never served.
+    """
+    while _permission_cache:
+        oldest_user_id = next(iter(_permission_cache))
+        cached_time, _ = _permission_cache[oldest_user_id]
+        if now - cached_time < CACHE_TTL:
+            return
+        del _permission_cache[oldest_user_id]
+
+
+def _evict_permissions_over_capacity() -> None:
+    """Drop least-recently-used entries until the cache fits its cap."""
+    while len(_permission_cache) > MAX_PERMISSION_CACHE_ENTRIES:
+        _permission_cache.popitem(last=False)
+
+
 async def get_user_permissions(
     session: "AsyncSession", user_id: str | UUID
 ) -> UserPermissions:
     """Get all permissions and roles for a user.
 
-    Results are cached with a TTL for performance.
+    Results are cached with a TTL for performance; the cache is capped at
+    ``MAX_PERMISSION_CACHE_ENTRIES`` and evicts least-recently-used entries.
     """
     user_id_str = str(user_id)
     user_id_uuid = user_id if isinstance(user_id, UUID) else UUID(user_id)
@@ -45,6 +71,7 @@ async def get_user_permissions(
     if user_id_str in _permission_cache:
         cached_time, cached_perms = _permission_cache[user_id_str]
         if datetime.now() - cached_time < CACHE_TTL:
+            _permission_cache.move_to_end(user_id_str)
             return cached_perms
 
     # Query user with roles and permissions
@@ -66,7 +93,11 @@ async def get_user_permissions(
                 permissions.permissions.add(role_perm.permission)
 
     # Update cache
-    _permission_cache[user_id_str] = (datetime.now(), permissions)
+    cached_at = datetime.now()
+    _purge_expired_permissions(cached_at)
+    _permission_cache[user_id_str] = (cached_at, permissions)
+    _permission_cache.move_to_end(user_id_str)
+    _evict_permissions_over_capacity()
 
     return permissions
 

--- a/skrift/bot_detection/store.py
+++ b/skrift/bot_detection/store.py
@@ -7,7 +7,9 @@ a process-local dict (for single-process deployments and tests) or
 Redis (for multi-process / multi-replica deployments).
 
 The store carries opaque string values keyed by ``(namespace, key)``
-tuples. Time-to-live is enforced lazily for the in-memory backend.
+tuples. Time-to-live is enforced lazily for the in-memory backend, which
+also sweeps expired entries and caps its size so abandoned client state
+can't accumulate.
 """
 
 from __future__ import annotations
@@ -28,15 +30,34 @@ class BotStateStore(Protocol):
     async def delete(self, namespace: str, key: str) -> None: ...
 
 
+DEFAULT_SWEEP_EVERY = 256
+DEFAULT_MAX_ENTRIES = 50_000
+
+
 class InMemoryBotStateStore:
     """Process-local store backed by a dict. Not safe across replicas.
 
     TTLs are enforced lazily on read; expired entries are dropped on
-    access.
+    access. Keys are client identities (usually IPs), and a client that
+    trips one metric and never comes back is never read again — so
+    reads alone can't keep the dict bounded. Two guards do:
+
+    * every ``sweep_every`` writes, expired entries are dropped in one
+      amortized pass;
+    * past ``max_entries`` live entries, the oldest writes are evicted.
+      Evicting live state only means that client is measured afresh.
     """
 
-    def __init__(self) -> None:
+    def __init__(
+        self,
+        *,
+        sweep_every: int = DEFAULT_SWEEP_EVERY,
+        max_entries: int = DEFAULT_MAX_ENTRIES,
+    ) -> None:
         self._data: dict[tuple[str, str], tuple[str, float]] = {}
+        self._sweep_every = sweep_every
+        self._max_entries = max_entries
+        self._writes_since_sweep = 0
 
     async def get(self, namespace: str, key: str) -> str | None:
         entry = self._data.get((namespace, key))
@@ -51,10 +72,31 @@ class InMemoryBotStateStore:
     async def set(
         self, namespace: str, key: str, value: str, *, ttl: int
     ) -> None:
+        # Re-inserting rather than overwriting keeps dict order by write
+        # time, which is the order eviction walks.
+        self._data.pop((namespace, key), None)
         self._data[(namespace, key)] = (value, time.monotonic() + ttl)
+
+        self._writes_since_sweep += 1
+        if self._writes_since_sweep >= self._sweep_every:
+            self._sweep_expired()
+        self._evict_oldest_over_capacity()
 
     async def delete(self, namespace: str, key: str) -> None:
         self._data.pop((namespace, key), None)
+
+    def _sweep_expired(self) -> None:
+        now = time.monotonic()
+        self._writes_since_sweep = 0
+        self._data = {
+            entry_key: entry
+            for entry_key, entry in self._data.items()
+            if entry[1] > now
+        }
+
+    def _evict_oldest_over_capacity(self) -> None:
+        while len(self._data) > self._max_entries:
+            self._data.pop(next(iter(self._data)))
 
 
 class RedisBotStateStore:

--- a/skrift/claude_skill/skrift-auth/SKILL.md
+++ b/skrift/claude_skill/skrift-auth/SKILL.md
@@ -234,7 +234,7 @@ Access tokens are **ES256 JWTs** (RFC 9068) verifiable offline against `GET /oau
 
 ### Remembered Consent
 
-`ConsentGrant` (unique per user + client) records approved scopes. `/oauth/authorize` skips the consent screen and issues a code directly when a stored grant covers all requested scopes; broader scopes re-prompt and widen the grant on approval. Grants cascade-delete when the client is deleted or pruned. Service: `skrift/db/services/oauth2_consent_service.py` (`find_grant`, `upsert_grant`, `revoke_grant`, `delete_grants_for_clients`).
+`ConsentGrant` (unique per user + client) records approved scopes. `/oauth/authorize` skips the consent screen and issues a code directly when a stored grant covers all requested scopes; broader scopes re-prompt and widen the grant on approval. The consent screen renders each requested scope as a checkbox (checked by default), so users can grant a subset: the granted set must be a subset of the request (a submitted superset is a 400 `invalid_scope`), unchecking everything is a denial, and scopes unchecked on the screen are removed from the stored grant via `upsert_grant(..., declined_scopes=...)` — so a declined scope re-prompts on the next authorize instead of silently returning. Scopes granted earlier but absent from the current request survive. Grants cascade-delete when the client is deleted or pruned. Service: `skrift/db/services/oauth2_consent_service.py` (`find_grant`, `upsert_grant`, `revoke_grant`, `delete_grants_for_clients`).
 
 ### PKCE
 

--- a/skrift/cli.py
+++ b/skrift/cli.py
@@ -186,6 +186,7 @@ def _configure_worker_runtime(settings, *, session_maker, queues, concurrency, m
         visibility_timeout=settings.workers.visibility_timeout,
         reaper_interval=settings.workers.reaper_interval,
         max_reclaims=settings.workers.max_reclaims,
+        terminal_job_state_ttl=settings.workers.retention.terminal_job_state_ttl,
         backend_imports=settings.workers.backends,
         settings=settings,
         session_maker=session_maker,

--- a/skrift/cli.py
+++ b/skrift/cli.py
@@ -33,7 +33,12 @@ def cli(config_file):
 @click.option("--host", default="127.0.0.1", help="Host to bind to")
 @click.option("--port", default=8080, type=int, help="Port to bind to")
 @click.option("--reload", is_flag=True, help="Enable auto-reload for development")
-@click.option("--workers", default=1, type=int, help="Number of worker processes")
+@click.option(
+    "--workers",
+    default=1,
+    type=int,
+    help="Number of worker processes (each is a full process using ~150MB RSS)",
+)
 @click.option(
     "--log-level",
     default="info",
@@ -47,11 +52,10 @@ def cli(config_file):
 )
 def serve(host, port, reload, workers, log_level, subdomain):
     """Run the Skrift server."""
-    import asyncio
-    import signal
-
-    from hypercorn.asyncio import serve as hypercorn_serve
     from hypercorn.config import Config
+
+    if workers < 1:
+        raise click.ClickException(f"--workers must be at least 1, got {workers}")
 
     if subdomain:
         os.environ["SKRIFT_SUBDOMAIN"] = subdomain
@@ -66,9 +70,30 @@ def serve(host, port, reload, workers, log_level, subdomain):
 
     if reload:
         config.use_reloader = True
-        from hypercorn.run import run
-        run(config)
+
+    # Hypercorn only spawns worker processes when it owns the application
+    # import (config.application_path); serving an already-built app object
+    # runs a single worker in the current process.
+    if reload or config.workers > 1:
+        _serve_with_worker_processes(config)
         return
+
+    _serve_in_current_process(config)
+
+
+def _serve_with_worker_processes(config) -> None:
+    """Run the server through hypercorn's process manager (reloader/multi-worker)."""
+    from hypercorn.run import run
+
+    run(config)
+
+
+def _serve_in_current_process(config) -> None:
+    """Run a single worker inside this process with graceful signal shutdown."""
+    import asyncio
+    import signal
+
+    from hypercorn.asyncio import serve as hypercorn_serve
 
     from skrift.asgi import app
 

--- a/skrift/config.py
+++ b/skrift/config.py
@@ -499,6 +499,23 @@ class SessionConfig(BaseModel):
     idle_timeout: int = 0
 
 
+class CompressionConfig(BaseModel):
+    """Response gzip compression configuration.
+
+    Every in-flight compressed response holds a zlib deflate state costing
+    ~153 KB of RSS that the allocator never returns, so both the size floor and
+    the concurrency cap exist to bound memory. Deployments that compress at the
+    reverse proxy should set ``enabled: false``.
+
+    Defaults mirror ``skrift.middleware.compression`` (kept literal here so
+    config loading stays free of Litestar imports).
+    """
+
+    enabled: bool = True
+    minimum_size: int = Field(default=2048, gt=0)  # bytes; Litestar's default is 500
+    max_concurrent: int = Field(default=20, gt=0)  # live compressors, process-wide
+
+
 # Friendly window-period names → seconds, for rate-limit windows.
 _RATE_LIMIT_PERIODS: dict[str, float] = {
     "second": 1.0,
@@ -1157,6 +1174,14 @@ class StorageConfig(BaseModel):
     stores: dict[str, StoreConfig] = {"default": StoreConfig()}
 
 
+DEFAULT_MAX_REQUEST_BODY_SIZE = 10_485_760  # 10 MB
+"""Body size accepted on routes that do not receive file uploads."""
+
+MULTIPART_FRAMING_OVERHEAD = 1_048_576  # 1 MB
+"""Headroom over the raw file size for multipart boundaries, part headers, and
+any form fields sent alongside the file."""
+
+
 class Settings(BaseSettings):
     model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8", extra="ignore")
 
@@ -1222,6 +1247,9 @@ class Settings(BaseSettings):
     # Security headers config (loaded from app.yaml)
     security_headers: SecurityHeadersConfig = SecurityHeadersConfig()
 
+    # Response compression config (loaded from app.yaml)
+    compression: CompressionConfig = CompressionConfig()
+
     # Rate limit config (loaded from app.yaml)
     rate_limit: RateLimitConfig = RateLimitConfig()
 
@@ -1261,6 +1289,30 @@ class Settings(BaseSettings):
     # Security contact for /.well-known/security.txt (RFC 9116)
     security_contact: str = ""
 
+    # Floor for the request body cap enforced before Litestar buffers a body.
+    # The effective cap is resolve_request_max_body_size(), which also has to
+    # accommodate the largest upload the configured stores accept.
+    max_request_body_size: int = Field(default=DEFAULT_MAX_REQUEST_BODY_SIZE, gt=0)
+
+
+def resolve_request_max_body_size(settings: Settings) -> int:
+    """Largest request body, in bytes, that an app will buffer before a 413.
+
+    Enforced at the transport layer, so an oversized POST is refused before the
+    body is read into memory. Upload routes share this cap with everything else,
+    so it is lifted to fit the biggest upload any configured store accepts plus
+    multipart framing — otherwise the transport would reject uploads that
+    ``max_upload_size`` allows.
+    """
+    largest_configured_upload = max(
+        (store.max_upload_size for store in settings.storage.stores.values()),
+        default=0,
+    )
+    return max(
+        settings.max_request_body_size,
+        largest_configured_upload + MULTIPART_FRAMING_OVERHEAD,
+    )
+
 
 def _register_builtin_sections() -> None:
     """Built-in sections parse through the same registry extensions use."""
@@ -1269,6 +1321,7 @@ def _register_builtin_sections() -> None:
         "auth": AuthConfig,
         "session": SessionConfig,
         "security_headers": SecurityHeadersConfig,
+        "compression": CompressionConfig,
         "rate_limit": RateLimitConfig,
         "bot_detection": BotDetectionConfig,
         "trusted_proxy": TrustedProxyConfig,
@@ -1412,6 +1465,9 @@ def get_settings() -> Settings:
 
     if "security_contact" in app_config:
         kwargs["security_contact"] = app_config["security_contact"]
+
+    if "max_request_body_size" in app_config:
+        kwargs["max_request_body_size"] = app_config["max_request_body_size"]
 
     if "sites" in app_config:
         kwargs["sites"] = {

--- a/skrift/controllers/oauth2.py
+++ b/skrift/controllers/oauth2.py
@@ -92,6 +92,26 @@ def _extract_resource_values(params) -> list[str]:
     return [value for value in getall("resource", []) if value]
 
 
+def _extract_granted_scopes(form_data) -> list[str]:
+    """Collect the scopes a user left checked on the consent form.
+
+    Browsers submit one ``scope`` field per checked checkbox — and nothing at
+    all when every box is cleared — so this reads every value. A single
+    space-delimited value is accepted too, matching how ``scope`` travels
+    everywhere else in OAuth2. Duplicates and ordering are left to the caller,
+    which intersects the result with the requested scopes.
+    """
+    getall = getattr(form_data, "getall", None)
+    values = getall("scope", []) if getall is not None else [form_data.get("scope", "")]
+    return [scope for value in values for scope in value.split()]
+
+
+def _consent_denied_redirect(redirect_uri: str, state: str) -> Redirect:
+    """Send the user-agent back to the client with an ``access_denied`` error."""
+    sep = "&" if "?" in redirect_uri else "?"
+    return Redirect(path=f"{redirect_uri}{sep}" + urlencode({"error": "access_denied", "state": state}))
+
+
 def _validate_resource_indicator(resource: str, allowed_resources: list[str]) -> bool:
     """Validate an RFC 8707 resource indicator.
 
@@ -407,12 +427,40 @@ class OAuth2Controller(Controller):
         scope = authorize_data.get("scope", "")
         code_challenge = authorize_data.get("code_challenge", "")
         resource = authorize_data.get("resource", "")
+        requested_scopes = scope.split() if scope else []
 
-        # User denied
+        # User denied — the button wins over any still-checked checkbox the
+        # browser submitted alongside it.
         if action == "deny":
-            sep = "&" if "?" in redirect_uri else "?"
-            deny_url = f"{redirect_uri}{sep}" + urlencode({"error": "access_denied", "state": state})
-            return Redirect(path=deny_url)
+            return _consent_denied_redirect(redirect_uri, state)
+
+        # RFC 6749 §3.3: the user may approve a subset of the request, never a
+        # superset. The stored authorization request is the ceiling, so a
+        # submitted scope outside it is a tampered form — rejected outright
+        # rather than quietly dropped, matching the refresh grant's handling of
+        # an out-of-grant scope.
+        granted_scopes = set(_extract_granted_scopes(form_data))
+        if not granted_scopes.issubset(requested_scopes):
+            return _json_error("invalid_scope", "Granted scope exceeds the requested scope")
+
+        # Approving while keeping nothing grants nothing, which is the same
+        # answer as denying — never an empty-scope token. A request that asked
+        # for no scopes at all has nothing to decline and still approves.
+        if requested_scopes and not granted_scopes:
+            return _consent_denied_redirect(redirect_uri, state)
+
+        # Keep the requested ordering so the granted scope string reads the way
+        # the consent screen did.
+        granted_scope = " ".join(
+            requested_scope
+            for requested_scope in requested_scopes
+            if requested_scope in granted_scopes
+        )
+        declined_scopes = [
+            requested_scope
+            for requested_scope in requested_scopes
+            if requested_scope not in granted_scopes
+        ]
 
         # User approved — remember this consent, then issue the auth code.
         settings = get_settings()
@@ -424,7 +472,8 @@ class OAuth2Controller(Controller):
             db_session,
             user_id=user_id,
             client_id=client_id,
-            scopes=scope.split() if scope else [],
+            scopes=granted_scope.split(),
+            declined_scopes=declined_scopes,
             granted_at=datetime.now(tz=timezone.utc),
         )
 
@@ -434,7 +483,7 @@ class OAuth2Controller(Controller):
             client_id=client_id,
             redirect_uri=redirect_uri,
             state=state,
-            scope=scope,
+            scope=granted_scope,
             code_challenge=code_challenge,
             resource=resource,
         )

--- a/skrift/controllers/sitemap.py
+++ b/skrift/controllers/sitemap.py
@@ -70,24 +70,26 @@ class SitemapController(Controller):
         """Generate sitemap.xml with published pages."""
         base_url = _get_base_url(request)
 
-        # Get all published pages (respects scheduling)
-        pages = await page_service.list_pages(db_session, published_only=True)
+        # Published pages (respects scheduling), projected down to the columns
+        # used below — this route is public and crawled, so it must never pull
+        # page bodies or asset relationships into memory.
+        page_rows = await page_service.list_page_sitemap_entries(db_session)
 
         entries: list[SitemapEntry] = []
 
-        for page in pages:
-            slug = page.slug.strip("/")
+        for page_row in page_rows:
+            slug = page_row.slug.strip("/")
             loc = f"{base_url}/{slug}" if slug else base_url
 
             entry = SitemapEntry(
                 loc=loc,
-                lastmod=page.updated_at or page.created_at,
+                lastmod=page_row.updated_at or page_row.created_at,
                 changefreq="weekly",
                 priority=0.8 if slug else 1.0,  # Home page gets higher priority
             )
 
             # Apply sitemap_page filter (can return None to exclude)
-            entry = await hooks.apply_filters(SITEMAP_PAGE, entry, page)
+            entry = await hooks.apply_filters(SITEMAP_PAGE, entry, page_row)
             if entry is not None:
                 entries.append(entry)
 

--- a/skrift/db/services/oauth2_consent_service.py
+++ b/skrift/db/services/oauth2_consent_service.py
@@ -35,16 +35,24 @@ async def upsert_grant(
     client_id: str,
     scopes: list[str],
     granted_at: datetime,
+    declined_scopes: list[str] | None = None,
 ) -> ConsentGrant:
-    """Create or widen a user's remembered consent for a client.
+    """Create or update a user's remembered consent for a client.
 
     Newly approved scopes are unioned with any previously granted scopes so a
     remembered grant only ever grows — a narrower later request never silently
     drops a scope the user already consented to.
+
+    ``declined_scopes`` is the exception: scopes the user was shown and
+    actively unchecked are removed from the grant. Without that, the union
+    would restore a scope the user just refused and the next authorization
+    request would skip the consent screen and hand it back.
     """
     grant = await find_grant(db_session, user_id, client_id)
     existing_scopes = set(grant.scope_list) if grant is not None else set()
-    merged_scopes = "\n".join(sorted(existing_scopes | set(scopes)))
+    merged_scopes = "\n".join(
+        sorted((existing_scopes | set(scopes)) - set(declined_scopes or []))
+    )
     if grant is None:
         grant = ConsentGrant(
             user_id=user_id,

--- a/skrift/db/services/page_service.py
+++ b/skrift/db/services/page_service.py
@@ -1,5 +1,6 @@
 """Page service for CRUD operations on pages."""
 
+from dataclasses import dataclass
 from datetime import datetime, UTC
 from typing import Literal
 from uuid import UUID
@@ -14,6 +15,24 @@ from skrift.hooks import hooks, BEFORE_PAGE_SAVE, AFTER_PAGE_SAVE, BEFORE_PAGE_D
 
 
 OrderBy = Literal["order", "created", "published", "title"]
+
+SITEMAP_MAX_URLS = 50_000
+"""Sitemap protocol maximum URLs per file; also bounds the query's memory."""
+
+
+@dataclass(frozen=True, slots=True)
+class PageSitemapEntry:
+    """The only page columns ``/sitemap.xml`` reads.
+
+    Deliberately not a :class:`~skrift.db.models.Page`: loading mapped entities
+    would pull every page body (``Page.content`` is a ``Text`` column) and fan
+    out the ``selectin`` relationships into memory for a publicly reachable,
+    crawler-hammered route.
+    """
+
+    slug: str
+    updated_at: datetime | None
+    created_at: datetime | None
 
 
 def _published_filters() -> list:
@@ -79,6 +98,44 @@ async def list_pages(
 
     result = await db_session.execute(query)
     return list(result.scalars().all())
+
+
+async def list_page_sitemap_entries(
+    db_session: AsyncSession,
+    limit: int = SITEMAP_MAX_URLS,
+) -> list[PageSitemapEntry]:
+    """List published pages as projected sitemap rows.
+
+    Selects columns rather than the mapped entity, so neither page bodies nor
+    the ``selectin`` relationships are ever materialized. Ordering matches
+    :func:`list_pages` with its default ``order_by`` so sitemap output is
+    unchanged.
+
+    Args:
+        db_session: Database session
+        limit: Maximum number of rows to return
+
+    Returns:
+        List of PageSitemapEntry rows, at most ``limit`` of them
+
+    Raises:
+        ValueError: If ``limit`` is not positive
+    """
+    if limit <= 0:
+        raise ValueError(f"Sitemap entry limit must be positive, got {limit}")
+
+    query = (
+        select(Page.slug, Page.updated_at, Page.created_at)
+        .where(and_(*_published_filters()))
+        .order_by(Page.order.asc(), Page.created_at.desc())
+        .limit(limit)
+    )
+
+    result = await db_session.execute(query)
+    return [
+        PageSitemapEntry(slug=slug, updated_at=updated_at, created_at=created_at)
+        for slug, updated_at, created_at in result
+    ]
 
 
 async def get_page_by_slug(

--- a/skrift/lib/notification_backends.py
+++ b/skrift/lib/notification_backends.py
@@ -12,6 +12,7 @@ import asyncio
 import importlib
 import json
 import logging
+import time
 from collections.abc import Collection
 from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING, Any, Callable, Protocol, runtime_checkable
@@ -26,6 +27,7 @@ logger = logging.getLogger(__name__)
 
 QUEUED_TTL_HOURS = 24
 TIMESERIES_TTL_DAYS = 7
+CLEANUP_INTERVAL_SECONDS = 600
 
 
 def load_backend(spec: str) -> type:
@@ -77,7 +79,48 @@ class NotificationBackend(Protocol):
     def on_remote_message(self, callback: Callable[[dict], Any]) -> None: ...
 
 
-class InMemoryBackend:
+class _PeriodicCleanupMixin:
+    """Background sweep that expires stored notifications and stale dismissals.
+
+    Subclasses provide the storage-specific ``_delete_old_notifications`` and
+    ``cleanup_dismissed``; the loop itself is shared by every backend so no
+    storage grows without bound.
+    """
+
+    _cleanup_interval_seconds: float = CLEANUP_INTERVAL_SECONDS
+    _cleanup_task: asyncio.Task | None = None
+
+    async def _start_cleanup(self) -> None:
+        self._cleanup_task = asyncio.create_task(self._cleanup_loop())
+
+    async def _stop_cleanup(self) -> None:
+        if self._cleanup_task:
+            self._cleanup_task.cancel()
+            try:
+                await self._cleanup_task
+            except asyncio.CancelledError:
+                pass
+            self._cleanup_task = None
+
+    async def _cleanup_loop(self) -> None:
+        while True:
+            try:
+                await asyncio.sleep(self._cleanup_interval_seconds)
+                await self._delete_old_notifications()
+                await self.cleanup_dismissed()
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                logger.warning("Notification cleanup error", exc_info=True)
+
+    async def _delete_old_notifications(self) -> None:
+        raise NotImplementedError
+
+    async def cleanup_dismissed(self) -> None:
+        raise NotImplementedError
+
+
+class InMemoryBackend(_PeriodicCleanupMixin):
     """Dict-based storage with no cross-replica fanout. Default backend."""
 
     def __init__(self, **kwargs: Any) -> None:
@@ -85,12 +128,45 @@ class InMemoryBackend:
         self._subscriptions: dict[str, set[str]] = {}  # subscriber_key → {source_keys}
         self._dismissed: dict[str, set[UUID]] = {}  # subscriber_key → {notification_ids}
         self._callback: Callable[[dict], Any] | None = None
+        self._cleanup_task = None
 
     async def start(self) -> None:
-        pass
+        await self._start_cleanup()
 
     async def stop(self) -> None:
-        pass
+        await self._stop_cleanup()
+
+    async def _delete_old_notifications(self) -> None:
+        """Drop notifications past their TTL and forget emptied source keys."""
+        now = time.time()
+        queued_cutoff = now - QUEUED_TTL_HOURS * 3600
+        timeseries_cutoff = now - TIMESERIES_TTL_DAYS * 86400
+        for source_key in list(self._queues):
+            queue = self._queues[source_key]
+            expired_ids = [
+                notification_id
+                for notification_id, notification in queue.items()
+                if self._is_expired(
+                    notification,
+                    queued_cutoff=queued_cutoff,
+                    timeseries_cutoff=timeseries_cutoff,
+                )
+            ]
+            for notification_id in expired_ids:
+                del queue[notification_id]
+            if not queue:
+                del self._queues[source_key]
+
+    @staticmethod
+    def _is_expired(
+        notification: Notification, *, queued_cutoff: float, timeseries_cutoff: float
+    ) -> bool:
+        cutoff = (
+            timeseries_cutoff
+            if notification.mode == NotificationMode.TIMESERIES
+            else queued_cutoff
+        )
+        return notification.created_at < cutoff
 
     async def store(self, source_key: str, notification: Notification) -> UUID | None:
         old_id: UUID | None = None
@@ -195,37 +271,14 @@ class InMemoryBackend:
         return None
 
 
-class _DatabaseStorageMixin:
+class _DatabaseStorageMixin(_PeriodicCleanupMixin):
     """Shared DB operations for Redis and PgNotify backends."""
 
     _session_maker: Any
-    _cleanup_task: asyncio.Task | None
 
     def _init_db(self, session_maker: Any) -> None:
         self._session_maker = session_maker
         self._cleanup_task = None
-
-    async def _start_cleanup(self) -> None:
-        self._cleanup_task = asyncio.create_task(self._cleanup_loop())
-
-    async def _stop_cleanup(self) -> None:
-        if self._cleanup_task:
-            self._cleanup_task.cancel()
-            try:
-                await self._cleanup_task
-            except asyncio.CancelledError:
-                pass
-
-    async def _cleanup_loop(self) -> None:
-        while True:
-            try:
-                await asyncio.sleep(600)  # 10 minutes
-                await self._delete_old_notifications()
-                await self.cleanup_dismissed()
-            except asyncio.CancelledError:
-                raise
-            except Exception:
-                logger.warning("Notification cleanup error", exc_info=True)
 
     async def _delete_old_notifications(self) -> None:
         from skrift.db.models.notification import StoredNotification

--- a/skrift/lib/sliding_window.py
+++ b/skrift/lib/sliding_window.py
@@ -33,6 +33,153 @@ class SlidingWindowCounter(Protocol):
     async def count(self, key: str) -> int: ...
 
 
+# Multi-window histories keep one timestamp per hit for windows up to this
+# length and fall back to counters over fixed-width buckets beyond it. Long
+# windows (hour, day) are where per-hit timestamps pile up, and they are also
+# where a bucket's worth of imprecision is proportionally negligible.
+COARSE_WINDOW_THRESHOLD = 900.0
+COARSE_BUCKET_SECONDS = 60.0
+
+
+class _MultiWindowHistory:
+    """Hit history for one key on the multi-window path.
+
+    Windows up to :data:`COARSE_WINDOW_THRESHOLD` are counted from exact
+    per-hit timestamps. Longer windows are counted from
+    :data:`COARSE_BUCKET_SECONDS`-wide buckets that hold a hit *count*
+    instead of a timestamp per hit, so a key's long-window footprint grows
+    with elapsed time (bounded by the limit itself, since hits stop being
+    recorded once a limit is reached) rather than with request volume.
+
+    The tradeoff: the bucket straddling a long window's trailing edge is
+    counted in full even though part of it has aged out, so long windows may
+    over-count by up to one bucket's worth of hits — at most a minute of
+    traffic against an hour or a day. They never under-count, so a configured
+    limit is never silently exceeded.
+
+    Retention is per key: history is dropped once it falls outside the
+    longest window *this* key has been checked against, so a day-long rule on
+    one route can't pin the history of keys that only ever hit a minute-long
+    rule.
+    """
+
+    __slots__ = (
+        "_coarse_buckets",
+        "_fine_horizon",
+        "_hits",
+        "_last_untracked_hit",
+        "_retention",
+    )
+
+    def __init__(self) -> None:
+        self._hits: list[float] = []
+        self._coarse_buckets: list[tuple[float, int]] = []
+        self._fine_horizon = 0.0
+        self._retention = 0.0
+        # Hits recorded before any short window was seen never reached _hits,
+        # so an exact count over a window covering them would come up short.
+        self._last_untracked_hit = float("-inf")
+
+    @property
+    def entry_count(self) -> int:
+        """Retained entries — one per hit when fine, one per bucket when coarse."""
+        return len(self._hits) + len(self._coarse_buckets)
+
+    @property
+    def hit_count(self) -> int:
+        """Hits still retained. The two views overlap, so take the larger."""
+        return max(len(self._hits), sum(count for _, count in self._coarse_buckets))
+
+    @property
+    def is_empty(self) -> bool:
+        return not self._hits and not self._coarse_buckets
+
+    def observe(self, windows: list[float]) -> None:
+        """Widen retention to cover every window this key is checked against."""
+        for window in windows:
+            self._retention = max(self._retention, window)
+            if window <= COARSE_WINDOW_THRESHOLD:
+                self._fine_horizon = max(self._fine_horizon, window)
+
+    def prune(self, now: float) -> None:
+        """Drop history that no window of this key can still see."""
+        fine_cutoff = now - self._fine_horizon
+        if self._hits and self._hits[0] <= fine_cutoff:
+            self._hits = [hit for hit in self._hits if hit > fine_cutoff]
+
+        coarse_cutoff = now - self._retention
+        buckets = self._coarse_buckets
+        if buckets and buckets[0][0] + COARSE_BUCKET_SECONDS <= coarse_cutoff:
+            self._coarse_buckets = [
+                bucket
+                for bucket in buckets
+                if bucket[0] + COARSE_BUCKET_SECONDS > coarse_cutoff
+            ]
+
+    def record(self, now: float) -> None:
+        """Record one hit at *now*."""
+        if self._fine_horizon > 0:
+            self._hits.append(now)
+        else:
+            self._last_untracked_hit = now
+
+        if self._retention <= COARSE_WINDOW_THRESHOLD and self._fine_horizon > 0:
+            # Every window this key uses is counted exactly; buckets would be
+            # dead weight. A key whose windows later grow past the threshold
+            # starts bucketing from that point on.
+            return
+
+        bucket_start = now - (now % COARSE_BUCKET_SECONDS)
+        if self._coarse_buckets and self._coarse_buckets[-1][0] == bucket_start:
+            start, count = self._coarse_buckets[-1]
+            self._coarse_buckets[-1] = (start, count + 1)
+        else:
+            self._coarse_buckets.append((bucket_start, 1))
+
+    def retry_after_for(self, limit: int, window: float, now: float) -> int:
+        """Seconds until this key fits under *limit* for *window*; 0 if it does."""
+        cutoff = now - window
+        if limit <= 0:
+            # A zero limit denies everything; no amount of aging out helps.
+            return max(int(window) + 1, 1)
+
+        if self._counts_exactly(window, now):
+            in_window = [hit for hit in self._hits if hit > cutoff]
+            if len(in_window) < limit:
+                return 0
+            # The (count - limit + 1)-th oldest hit must age out before a new
+            # one fits; that hit sits at index (count - limit).
+            deadline = in_window[len(in_window) - limit]
+        else:
+            in_window = [
+                bucket
+                for bucket in self._coarse_buckets
+                if bucket[0] + COARSE_BUCKET_SECONDS > cutoff
+            ]
+            total = sum(count for _, count in in_window)
+            if total < limit:
+                return 0
+            # Buckets age out whole, so wait for the bucket holding the
+            # (total - limit + 1)-th oldest hit to leave the window entirely.
+            excess = total - limit + 1
+            shed = 0
+            deadline = in_window[-1][0] + COARSE_BUCKET_SECONDS
+            for start, count in in_window:
+                shed += count
+                if shed >= excess:
+                    deadline = start + COARSE_BUCKET_SECONDS
+                    break
+
+        return max(int(deadline - cutoff) + 1, 1)
+
+    def _counts_exactly(self, window: float, now: float) -> bool:
+        """Whether ``_hits`` holds every hit *window* can see."""
+        return (
+            window <= COARSE_WINDOW_THRESHOLD
+            and self._last_untracked_hit <= now - window
+        )
+
+
 class InMemorySlidingWindowCounter:
     """Process-local sliding window counter.
 
@@ -43,11 +190,10 @@ class InMemorySlidingWindowCounter:
     def __init__(self, window: float = 60.0, cleanup_interval: float = 60.0) -> None:
         self.window = window
         self._buckets: dict[str, list[float]] = {}
-        # Multi-window keys hold all hit timestamps in a single list; each
-        # window is evaluated as a count over a different sub-range, so they
-        # can't share the single-window cleanup (which prunes by self.window).
-        self._multi_buckets: dict[str, list[float]] = {}
-        self._max_multi_window = 0.0
+        # Multi-window keys evaluate several windows over one history, so they
+        # can't share the single-window cleanup (which prunes by self.window);
+        # each history prunes itself against the windows its key uses.
+        self._multi_buckets: dict[str, _MultiWindowHistory] = {}
         self._last_cleanup = time.monotonic()
         self._cleanup_interval = cleanup_interval
 
@@ -64,11 +210,10 @@ class InMemorySlidingWindowCounter:
         for key in stale_keys:
             del self._buckets[key]
 
-        multi_cutoff = now - self._max_multi_window
         stale_multi = []
-        for key, timestamps in self._multi_buckets.items():
-            self._multi_buckets[key] = [t for t in timestamps if t > multi_cutoff]
-            if not self._multi_buckets[key]:
+        for key, history in self._multi_buckets.items():
+            history.prune(now)
+            if history.is_empty:
                 stale_multi.append(key)
         for key in stale_multi:
             del self._multi_buckets[key]
@@ -122,32 +267,33 @@ class InMemorySlidingWindowCounter:
         Returns ``(allowed, retry_after_seconds)`` where retry_after reflects
         the binding (longest-blocking) window. Atomic by virtue of running to
         completion without awaiting between the check and the record.
+
+        Windows longer than :data:`COARSE_WINDOW_THRESHOLD` are counted from
+        coarse buckets rather than per-hit timestamps; see
+        :class:`_MultiWindowHistory` for the memory/precision tradeoff.
         """
         if not limits:
             return True, 0
 
         now = time.monotonic()
-        max_window = max(window for _, window in limits)
-        if max_window > self._max_multi_window:
-            self._max_multi_window = max_window
         self._cleanup_stale(now)
 
-        timestamps = [t for t in self._multi_buckets.get(key, []) if t > now - max_window]
-        self._multi_buckets[key] = timestamps
+        history = self._multi_buckets.get(key)
+        if history is None:
+            history = self._multi_buckets[key] = _MultiWindowHistory()
+        history.observe([window for _, window in limits])
+        history.prune(now)
 
         retry_after = 0
         for limit, window in limits:
-            cutoff = now - window
-            in_window = [t for t in timestamps if t > cutoff]
-            if len(in_window) >= limit:
-                # The (count - limit + 1)-th oldest entry must age out before a
-                # new hit fits; that entry sits at index (count - limit).
-                target = in_window[len(in_window) - limit]
-                window_retry = int(target - cutoff) + 1
-                retry_after = max(retry_after, window_retry)
+            retry_after = max(retry_after, history.retry_after_for(limit, window, now))
 
         if retry_after:
+            if history.is_empty:
+                # Nothing was ever recorded for this key (a zero limit denies
+                # on sight); don't leave an empty history behind.
+                del self._multi_buckets[key]
             return False, max(retry_after, 1)
 
-        timestamps.append(now)
+        history.record(now)
         return True, 0

--- a/skrift/middleware/compression.py
+++ b/skrift/middleware/compression.py
@@ -1,37 +1,151 @@
-"""Safe gzip compression facade for Litestar.
+"""Memory-bounded gzip compression for Litestar.
 
-Python 3.13 introduced a regression where GzipFile.__del__ tries to flush
-to an already-closed BytesIO buffer, raising ``ValueError: I/O operation
-on closed file``.  This happens when the client disconnects before the
-response is fully written — the middleware closes the buffer, but the
-GzipFile finalizer still tries to write.
+Litestar's stock compression middleware allocates a zlib deflate state for
+every in-flight request that advertises ``accept-encoding: gzip`` — roughly
+256 KB of address space and ~153 KB of touched RSS each, regardless of the
+compression level.  Those blocks are never returned to the OS, so a burst of
+concurrent requests permanently ratchets process RSS.  Two behaviours here
+keep that bounded:
 
-This module provides a drop-in replacement that catches the harmless error.
+* :class:`ConcurrentCompressionLimiter` caps how many deflate states may be
+  alive process-wide.  Requests arriving past the cap are answered
+  *uncompressed* — never queued — so a slow client can never head-of-line
+  block anyone else.
+* The compressor is created lazily, only once the response is known to be
+  compressible (streaming, or a buffered body of at least ``minimum_size``
+  bytes), so short responses cost nothing at all.
+
+:class:`SafeGzipCompression` additionally works around a Python 3.13
+regression where ``GzipFile``'s finalizer flushes into an already-closed
+``BytesIO`` — which happens when a client disconnects before the response is
+fully written — raising ``ValueError: I/O operation on closed file``.  It also
+flushes the deflate stream only when a streamed chunk has to reach the client
+immediately; Litestar's facade flushes on every write, which forces the whole
+pending window to be materialized even for buffered responses.
 """
 
 from __future__ import annotations
 
+import threading
+from dataclasses import dataclass, field
 from gzip import GzipFile
+from io import BytesIO
 from typing import TYPE_CHECKING, Literal
 
+from litestar.config.compression import CompressionConfig as LitestarCompressionConfig
+from litestar.datastructures import Headers, MutableScopeHeaders
 from litestar.enums import CompressionEncoding
+from litestar.middleware import DefineMiddleware
+from litestar.middleware.compression import CompressionMiddleware
 from litestar.middleware.compression.facade import CompressionFacade
+from litestar.utils.empty import value_or_default
+from litestar.utils.scope.state import ScopeState
 
 if TYPE_CHECKING:
-    from io import BytesIO
+    from litestar.types import (
+        ASGIApp,
+        HTTPResponseStartEvent,
+        Message,
+        Receive,
+        Scope,
+        Send,
+    )
 
-    from litestar.config.compression import CompressionConfig
+    from skrift.config import CompressionConfig
+
+__all__ = (
+    "DEFAULT_MAX_CONCURRENT_COMPRESSIONS",
+    "DEFAULT_MINIMUM_COMPRESSED_SIZE",
+    "STREAMING_EXCLUDE_PATTERN",
+    "BoundedCompressionConfig",
+    "BoundedCompressionMiddleware",
+    "BoundedCompressionSend",
+    "ConcurrentCompressionLimiter",
+    "SafeGzipCompression",
+    "build_compression_config",
+    "build_compression_middleware",
+    "process_compression_limiter",
+)
+
+DEFAULT_MAX_CONCURRENT_COMPRESSIONS = 20
+"""Live deflate states allowed at once (~153 KB each, so ~3 MB worst case)."""
+
+DEFAULT_MINIMUM_COMPRESSED_SIZE = 2048
+"""Bodies smaller than this are not worth a compressor; Litestar defaults to 500."""
+
+STREAMING_EXCLUDE_PATTERN = "/notifications/stream"
+"""Server-sent events endpoint; the compression middleware must not buffer it."""
+
+
+class ConcurrentCompressionLimiter:
+    """Process-wide bound on simultaneously live compressor states.
+
+    Acquisition never blocks: callers that cannot get a slot send their
+    response uncompressed instead of waiting, which keeps slow readers from
+    holding compressor memory hostage or head-of-line blocking other responses.
+    """
+
+    __slots__ = ("_active_compressors", "_lock")
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._active_compressors = 0
+
+    @property
+    def active_compressors(self) -> int:
+        """How many compressor states are currently checked out."""
+        with self._lock:
+            return self._active_compressors
+
+    def try_acquire(self, max_concurrent_compressions: int) -> bool:
+        """Claim a slot if one is free, returning whether it was claimed."""
+        with self._lock:
+            if self._active_compressors >= max_concurrent_compressions:
+                return False
+
+            self._active_compressors += 1
+            return True
+
+    def release(self) -> None:
+        """Return a previously claimed slot."""
+        with self._lock:
+            if self._active_compressors == 0:
+                raise RuntimeError("Released a compression slot that was never acquired")
+
+            self._active_compressors -= 1
+
+
+process_compression_limiter = ConcurrentCompressionLimiter()
+"""The limiter shared by every app in this process (primary, sites, setup)."""
+
+
+@dataclass
+class BoundedCompressionConfig(LitestarCompressionConfig):
+    """Litestar compression config extended with the concurrency bound."""
+
+    max_concurrent_compressions: int = DEFAULT_MAX_CONCURRENT_COMPRESSIONS
+    """Maximum number of compressor states alive at once, process-wide."""
+
+    compression_limiter: ConcurrentCompressionLimiter = field(
+        default=process_compression_limiter
+    )
+    """Limiter enforcing :attr:`max_concurrent_compressions`."""
 
 
 class SafeGzipCompression(CompressionFacade):
-    """GzipCompression that suppresses ValueError on close.
+    """Gzip facade that owns a compression slot and defers flushing.
 
-    Drop-in replacement for ``litestar.middleware.compression.gzip_facade.GzipCompression``
-    that catches the ``ValueError: I/O operation on closed file`` error
-    raised by Python 3.13's ``GzipFile`` finalizer.
+    Differences from ``litestar.middleware.compression.gzip_facade.GzipCompression``:
+
+    * :meth:`acquire` refuses to build a compressor once the configured
+      concurrency cap is reached, and :meth:`close` always returns the slot.
+    * :meth:`write` accumulates instead of flushing; callers that stream ask
+      for the pending bytes explicitly through :meth:`flush`.
+    * :meth:`close` swallows the ``ValueError`` raised by Python 3.13's
+      ``GzipFile`` finalizer when the output buffer is already closed.
     """
 
-    __slots__ = ("buffer", "compression_encoding", "compressor")
+    __slots__ = ("buffer", "closed", "compression_encoding", "compressor", "limiter")
 
     encoding = CompressionEncoding.GZIP
 
@@ -39,20 +153,308 @@ class SafeGzipCompression(CompressionFacade):
         self,
         buffer: BytesIO,
         compression_encoding: Literal[CompressionEncoding.GZIP] | str,
-        config: CompressionConfig,
+        config: LitestarCompressionConfig,
+        limiter: ConcurrentCompressionLimiter | None = None,
     ) -> None:
+        self.limiter = limiter
+        self.closed = False
         self.buffer = buffer
         self.compression_encoding = compression_encoding
         self.compressor = GzipFile(
             mode="wb", fileobj=buffer, compresslevel=config.gzip_compress_level
         )
 
+    @classmethod
+    def acquire(
+        cls,
+        buffer: BytesIO,
+        compression_encoding: Literal[CompressionEncoding.GZIP] | str,
+        config: BoundedCompressionConfig,
+    ) -> SafeGzipCompression | None:
+        """Build a facade holding a compression slot, or ``None`` past the cap."""
+        limiter = config.compression_limiter
+        if not limiter.try_acquire(config.max_concurrent_compressions):
+            return None
+
+        try:
+            return cls(buffer, compression_encoding, config, limiter=limiter)
+        except BaseException:
+            limiter.release()
+            raise
+
     def write(self, body: bytes) -> None:
+        """Feed bytes to the compressor without forcing a flush."""
         self.compressor.write(body)
+
+    def flush(self) -> None:
+        """Push everything written so far into the output buffer."""
         self.compressor.flush()
 
     def close(self) -> None:
+        """Finish the gzip stream and release the compression slot.
+
+        Safe to call more than once; the slot is released exactly once, even
+        when the buffer was closed underneath the compressor.
+        """
+        if self.closed:
+            return
+
+        self.closed = True
         try:
             self.compressor.close()
         except ValueError:
+            # Python 3.13: the GzipFile finalizer writes into a buffer the
+            # middleware already closed after a client disconnect.
             pass
+        finally:
+            if self.limiter is not None:
+                limiter = self.limiter
+                self.limiter = None
+                limiter.release()
+
+
+class BoundedCompressionSend:
+    """Per-response ASGI ``send`` wrapper that compresses within the slot budget.
+
+    Mirrors Litestar's compression send wrapper with three changes: the
+    compressor is created lazily and only when a slot is available, responses
+    that cannot get a slot are sent as-is, and the deflate stream is flushed
+    only for streamed chunks.
+    """
+
+    __slots__ = (
+        "_buffer",
+        "_compression_encoding",
+        "_config",
+        "_connection_state",
+        "_facade",
+        "_initial_message",
+        "_send",
+        "_started",
+    )
+
+    def __init__(
+        self,
+        send: Send,
+        compression_encoding: CompressionEncoding | str,
+        scope: Scope,
+        config: BoundedCompressionConfig,
+    ) -> None:
+        self._send = send
+        self._compression_encoding = compression_encoding
+        self._config = config
+        self._buffer = BytesIO()
+        self._facade: SafeGzipCompression | None = None
+        self._initial_message: HTTPResponseStartEvent | None = None
+        self._started = False
+        self._connection_state = ScopeState.from_scope(scope)
+
+    async def __call__(self, message: Message) -> None:
+        """Handle one outgoing ASGI message."""
+        if message["type"] == "http.response.start":
+            self._initial_message = message
+            return
+
+        if self._initial_message is None:
+            await self._send(message)
+            return
+
+        if value_or_default(self._connection_state.is_cached, False):
+            await self._send(self._initial_message)
+            await self._send(message)
+            self.close()
+            return
+
+        if message["type"] == "http.disconnect":
+            self.close()
+            return
+
+        if message["type"] != "http.response.body":
+            await self._send(message)
+            return
+
+        if self._started:
+            await self._send_streamed_chunk(message)
+            return
+
+        self._started = True
+        if message.get("more_body"):
+            await self._start_streaming_response(message)
+        elif len(message["body"]) >= self._config.minimum_size:
+            await self._send_compressed_response(message)
+        else:
+            await self._send_uncompressed_response(message)
+
+    def close(self) -> None:
+        """Close the compressor, if one was ever created, releasing its slot."""
+        if self._facade is not None:
+            self._facade.close()
+
+    async def _start_streaming_response(self, message: Message) -> None:
+        """Send the first chunk of a streamed response, compressed when possible."""
+        self._facade = self._config.compression_facade.acquire(
+            self._buffer, self._compression_encoding, self._config
+        )
+        if self._facade is None:
+            await self._send_uncompressed_response(message)
+            return
+
+        headers = MutableScopeHeaders(self._initial_message)
+        headers["Content-Encoding"] = self._compression_encoding
+        headers.extend_header_value("vary", "Accept-Encoding")
+        del headers["Content-Length"]
+        self._connection_state.response_compressed = True
+
+        self._facade.write(message["body"])
+        self._facade.flush()
+        await self._send(self._initial_message)
+        await self._send({**message, "body": self._drain_buffer()})
+
+    async def _send_compressed_response(self, message: Message) -> None:
+        """Compress and send a complete buffered body."""
+        self._facade = self._config.compression_facade.acquire(
+            self._buffer, self._compression_encoding, self._config
+        )
+        if self._facade is None:
+            await self._send_uncompressed_response(message)
+            return
+
+        self._facade.write(message["body"])
+        self._facade.close()
+        body = self._drain_buffer()
+
+        headers = MutableScopeHeaders(self._initial_message)
+        headers["Content-Encoding"] = self._compression_encoding
+        headers["Content-Length"] = str(len(body))
+        headers.extend_header_value("vary", "Accept-Encoding")
+        self._connection_state.response_compressed = True
+
+        await self._send(self._initial_message)
+        await self._send({**message, "body": body})
+
+    async def _send_uncompressed_response(self, message: Message) -> None:
+        """Pass a response through untouched (too small, or no slot available)."""
+        await self._send(self._initial_message)
+        await self._send(message)
+
+    async def _send_streamed_chunk(self, message: Message) -> None:
+        """Send a follow-up chunk of an already-started response."""
+        if self._facade is None:
+            await self._send(message)
+            return
+
+        more_body = message.get("more_body")
+        self._facade.write(message["body"])
+        if more_body:
+            self._facade.flush()
+        else:
+            self._facade.close()
+
+        body = self._drain_buffer()
+        if not more_body:
+            self._buffer.close()
+
+        await self._send({**message, "body": body})
+
+    def _drain_buffer(self) -> bytes:
+        """Take everything written to the output buffer so far."""
+        compressed = self._buffer.getvalue()
+        self._buffer.seek(0)
+        self._buffer.truncate()
+        return compressed
+
+
+class BoundedCompressionMiddleware(CompressionMiddleware):
+    """Compression middleware that bounds live compressor memory.
+
+    Litestar's middleware hardcodes its own gzip facade and builds it for every
+    request that accepts gzip; this one always uses the configured facade and
+    guarantees the compressor is closed — and its slot released — even when the
+    application raises mid-response.
+    """
+
+    def __init__(self, app: ASGIApp, config: BoundedCompressionConfig) -> None:
+        super().__init__(app=app, config=config)
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        """Wrap ``send`` so compressible responses are compressed within budget."""
+        accept_encoding = Headers.from_scope(scope).get("accept-encoding", "")
+        facade_encoding = self.config.compression_facade.encoding
+
+        if facade_encoding in accept_encoding:
+            compression_encoding: CompressionEncoding | str = facade_encoding
+        elif self.config.gzip_fallback and CompressionEncoding.GZIP in accept_encoding:
+            compression_encoding = CompressionEncoding.GZIP
+        else:
+            await self.app(scope, receive, send)
+            return
+
+        compressing_send = self.create_compression_send_wrapper(
+            send=send, compression_encoding=compression_encoding, scope=scope
+        )
+        try:
+            await self.app(scope, receive, compressing_send)
+        finally:
+            compressing_send.close()
+
+    def create_compression_send_wrapper(
+        self,
+        send: Send,
+        compression_encoding: CompressionEncoding | str,
+        scope: Scope,
+    ) -> BoundedCompressionSend:
+        """Build the per-response send wrapper."""
+        return BoundedCompressionSend(
+            send=send,
+            compression_encoding=compression_encoding,
+            scope=scope,
+            config=self.config,
+        )
+
+
+def build_compression_config(
+    compression_settings: CompressionConfig,
+    exclude: str | list[str] | None = None,
+) -> BoundedCompressionConfig | None:
+    """Build an app's Litestar compression config, or ``None`` when disabled.
+
+    ``exclude`` is added on top of :data:`STREAMING_EXCLUDE_PATTERN`, which is
+    always excluded so server-sent event streams are never buffered by the
+    compression middleware.
+    """
+    if not compression_settings.enabled:
+        return None
+
+    excluded_paths = [STREAMING_EXCLUDE_PATTERN]
+    if isinstance(exclude, str):
+        excluded_paths.append(exclude)
+    elif exclude:
+        excluded_paths.extend(exclude)
+
+    return BoundedCompressionConfig(
+        backend="gzip",
+        compression_facade=SafeGzipCompression,
+        middleware_class=BoundedCompressionMiddleware,
+        minimum_size=compression_settings.minimum_size,
+        max_concurrent_compressions=compression_settings.max_concurrent,
+        exclude=excluded_paths,
+    )
+
+
+def build_compression_middleware(
+    compression_settings: CompressionConfig,
+    exclude: str | list[str] | None = None,
+) -> list[DefineMiddleware]:
+    """Build an app's compression middleware, empty when compression is disabled.
+
+    Compression is installed as application middleware rather than through
+    Litestar's ``compression_config``: Litestar hardcodes its own middleware and
+    gzip facade for the ``gzip`` backend, so a configured facade is never used.
+    Place this first in the middleware list so it wraps ``send`` outermost and
+    sees the final response bytes.
+    """
+    config = build_compression_config(compression_settings, exclude)
+    if config is None:
+        return []
+
+    return [DefineMiddleware(BoundedCompressionMiddleware, config=config)]

--- a/skrift/notifications.py
+++ b/skrift/notifications.py
@@ -17,6 +17,7 @@ Usage:
 from __future__ import annotations
 
 import asyncio
+import logging
 import time
 from collections import deque
 from dataclasses import dataclass, field
@@ -28,6 +29,13 @@ from skrift.hooks import hooks, NOTIFICATION_PRE_SEND, NOTIFICATION_SENT, NOTIFI
 
 if TYPE_CHECKING:
     from skrift.lib.notification_backends import NotificationBackend
+
+logger = logging.getLogger(__name__)
+
+# Upper bound on undelivered notifications held for a single SSE connection.
+# A stalled client drops its oldest pending notifications instead of growing
+# memory; stored notifications are re-flushed when the client reconnects.
+SSE_QUEUE_MAXSIZE = 100
 
 
 class NotificationMode(str, Enum):
@@ -92,6 +100,23 @@ def _parse_source_key(source_key: str) -> tuple[str, str | None]:
     return (source_key, None)
 
 
+def _put_dropping_oldest(queue: asyncio.Queue, notification: Notification) -> None:
+    """Enqueue *notification*, discarding the oldest entry when the queue is full.
+
+    Bounded listener queues give slow SSE clients backpressure: the newest
+    notification always wins, so a stalled connection costs a fixed amount of
+    memory rather than one entry per broadcast.
+    """
+    if queue.full():
+        dropped = queue.get_nowait()
+        logger.warning(
+            "SSE listener queue full — dropped notification %s (type=%s)",
+            dropped.id,
+            dropped.type,
+        )
+    queue.put_nowait(notification)
+
+
 class SourceRegistry:
     """In-memory subscription DAG and listener registry.
 
@@ -122,6 +147,10 @@ class SourceRegistry:
 
     def has_listeners(self, source_key: str) -> bool:
         return bool(self._listeners.get(source_key))
+
+    def has_subscribers(self, source_key: str) -> bool:
+        """True while any child still subscribes to *source_key*."""
+        return bool(self._subscribers.get(source_key))
 
     def subscribe(self, child: str, parent: str) -> None:
         """Add an edge: child subscribes to parent (idempotent)."""
@@ -184,7 +213,7 @@ class SourceRegistry:
         targets = self.resolve_downstream(source_key)
         for target in targets:
             for q in self._listeners.get(target, ()):
-                q.put_nowait(notification)
+                _put_dropping_oldest(q, notification)
 
 
 class NotificationService:
@@ -199,6 +228,7 @@ class NotificationService:
         self._backend: NotificationBackend | None = None
         self._publisher_id: str = str(uuid4())
         self._loaded_user_subs: set[str] = set()
+        self._session_users: dict[str, str] = {}  # session_key -> user_key
 
     def set_backend(self, backend: NotificationBackend) -> None:
         self._backend = backend
@@ -388,16 +418,17 @@ class NotificationService:
         Sets up ephemeral graph edges and loads persistent subscriptions.
         """
         session_key = f"session:{nid}"
-        q: asyncio.Queue = asyncio.Queue()
+        q: asyncio.Queue = asyncio.Queue(maxsize=SSE_QUEUE_MAXSIZE)
 
         # Ephemeral edges: session -> global, session -> user, user -> global
         self._registry.subscribe(session_key, "global")
         if user_id:
             user_key = f"user:{user_id}"
+            self._session_users[session_key] = user_key
             self._registry.subscribe(session_key, user_key)
             self._registry.subscribe(user_key, "global")
 
-            # Load persistent subscriptions for this user (once per process)
+            # Load persistent subscriptions while the user has a live connection
             if user_key not in self._loaded_user_subs:
                 self._loaded_user_subs.add(user_key)
                 backend = self._get_backend()
@@ -409,13 +440,23 @@ class NotificationService:
         return q
 
     def unregister_connection(self, nid: str, q: asyncio.Queue) -> None:
-        """Remove a connection on disconnect."""
+        """Remove a connection on disconnect and tear down its ephemeral edges."""
         session_key = f"session:{nid}"
         self._registry.remove_listener(session_key, q)
 
-        # If no more listeners on this session, tear down ephemeral edges
-        if not self._registry.has_listeners(session_key):
-            self._registry.unsubscribe_all(session_key)
+        # Other connections for this session keep the edges alive
+        if self._registry.has_listeners(session_key):
+            return
+
+        self._registry.unsubscribe_all(session_key)
+
+        # When the user's last session goes away, drop the ``user:{id}`` edges
+        # (global + persistent subscriptions) so they don't accumulate. They are
+        # reloaded from the backend on the user's next connection.
+        user_key = self._session_users.pop(session_key, None)
+        if user_key and not self._registry.has_subscribers(user_key):
+            self._registry.unsubscribe_all(user_key)
+            self._loaded_user_subs.discard(user_key)
 
     async def subscribe(self, subscriber_key: str, source_key: str) -> None:
         """Add a persistent subscription (DB + local graph)."""

--- a/skrift/templates/oauth/authorize.html
+++ b/skrift/templates/oauth/authorize.html
@@ -18,15 +18,18 @@
     .scope-list li {
         padding: 0.5rem 0;
         border-bottom: 1px solid var(--sk-color-border, #eee);
+    }
+
+    .scope-option {
         display: flex;
         align-items: center;
         gap: 0.5rem;
+        cursor: pointer;
     }
 
-    .scope-list li::before {
-        content: "\2713";
-        color: #16a34a;
-        font-weight: bold;
+    .scope-option input {
+        flex: none;
+        accent-color: #16a34a;
     }
 
     .client-name {
@@ -82,24 +85,35 @@
             wants to access your account.
         </p>
 
-        {% if scope_descriptions %}
-        <p>This will allow the application to:</p>
-        <ul class="scope-list">
-            {% for scope in scope_descriptions %}
-            <li>{{ scope.description }}</li>
-            {% endfor %}
-        </ul>
-        {% elif scopes %}
-        <p>This will allow the application to:</p>
-        <ul class="scope-list">
-            {% for scope in scopes %}
-            <li>{{ scope }}</li>
-            {% endfor %}
-        </ul>
-        {% endif %}
-
         <form method="post" action="/oauth/authorize">
             {{ csrf_field() }}
+
+            {% if scope_descriptions %}
+            <p>Choose what to allow:</p>
+            <ul class="scope-list">
+                {% for scope in scope_descriptions %}
+                <li>
+                    <label class="scope-option">
+                        <input type="checkbox" name="scope" value="{{ scope.name }}" checked>
+                        <span>{{ scope.description }}</span>
+                    </label>
+                </li>
+                {% endfor %}
+            </ul>
+            {% elif scopes %}
+            <p>Choose what to allow:</p>
+            <ul class="scope-list">
+                {% for scope in scopes %}
+                <li>
+                    <label class="scope-option">
+                        <input type="checkbox" name="scope" value="{{ scope }}" checked>
+                        <span>{{ scope }}</span>
+                    </label>
+                </li>
+                {% endfor %}
+            </ul>
+            {% endif %}
+
             <div class="consent-buttons">
                 <button type="submit" name="action" value="deny" class="btn-deny">Deny</button>
                 <button type="submit" name="action" value="allow" class="btn-allow">Allow</button>

--- a/skrift/workers/memory.py
+++ b/skrift/workers/memory.py
@@ -4,10 +4,11 @@ from __future__ import annotations
 
 import asyncio
 import inspect
-from collections import defaultdict
+from collections import defaultdict, deque
 from collections.abc import AsyncIterator
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
+from itertools import islice
 from typing import Any
 from uuid import uuid4
 
@@ -18,8 +19,17 @@ from skrift.workers.models import (
     EventIdConflict,
     JobEnvelope,
     JobIdConflict,
+    JobState,
+    JobStatus,
     QueueStats,
 )
+
+# Streams live entirely in process memory, so they are capped the way the Redis
+# event log is capped by `retention.redis_event_max_entries`: newest events win
+# and the oldest are dropped once the cap is reached.
+DEFAULT_EVENT_STREAM_MAX_EVENTS = 10_000
+
+WORKER_JOB_STATE_PREFIX = "workers:jobs:"
 
 
 def _now() -> datetime:
@@ -87,29 +97,141 @@ class InMemoryStateStore:
                     del self._values[key]
             return sorted(key for key in self._values if key.startswith(prefix))
 
+    async def sweep_expired(self) -> int:
+        """Drop every expired entry and report how many were removed.
+
+        Reads skip expired entries without necessarily reclaiming them, so this
+        dedicated sweep — driven by the runtime's reaper timer — is what actually
+        frees the memory they hold.
+        """
+        async with self._lock:
+            expired = [key for key, stored in self._values.items() if self._is_expired(stored)]
+            for key in expired:
+                del self._values[key]
+            return len(expired)
+
+    async def worker_job_states(self, *, limit: int | None = None) -> tuple[list[JobState], int]:
+        """Return recent worker job states plus the total, in one pass."""
+        async with self._lock:
+            states = [
+                stored.value
+                for key, stored in self._values.items()
+                if key.startswith(WORKER_JOB_STATE_PREFIX)
+                and not self._is_expired(stored)
+                and isinstance(stored.value, JobState)
+            ]
+        states.sort(key=lambda state: state.updated_at, reverse=True)
+        return (states if limit is None else states[:limit]), len(states)
+
+    async def worker_job_counts(self) -> dict[str, int]:
+        """Return aggregate worker job counts without re-reading every entry."""
+        active_statuses = {JobStatus.CLAIMED, JobStatus.RUNNING, JobStatus.PAUSED}
+        states, total = await self.worker_job_states()
+        return {
+            "total": total,
+            "active": sum(state.status in active_statuses for state in states),
+        }
+
+
+class _EventStream:
+    """Bounded event buffer whose positions stay stable as old events drop out."""
+
+    def __init__(self, max_events: int) -> None:
+        self._events: deque[tuple[int, dict[str, Any]]] = deque(maxlen=max_events)
+        self._positions_by_event_id: dict[Any, int] = {}
+        self._next_position = 0
+
+    @property
+    def next_position(self) -> int:
+        return self._next_position
+
+    @property
+    def event_id_count(self) -> int:
+        return len(self._positions_by_event_id)
+
+    def find_by_event_id(self, event_id: Any) -> tuple[int, dict[str, Any]] | None:
+        position = self._positions_by_event_id.get(event_id)
+        return None if position is None else (position, self._at(position))
+
+    def append(self, event: dict[str, Any]) -> int:
+        position = self._next_position
+        evicted = self._events[0][1] if self._is_full() else None
+        self._events.append((position, dict(event)))
+        if evicted is not None:
+            self._forget_event_id(evicted)
+        event_id = event.get("event_id")
+        if event_id is not None:
+            self._positions_by_event_id[event_id] = position
+        self._next_position = position + 1
+        return position
+
+    def read(self, *, from_position: int, limit: int | None) -> list[tuple[int, dict[str, Any]]]:
+        start = max(0, from_position - self._start_position)
+        end = None if limit is None else start + limit
+        return [(position, dict(event)) for position, event in islice(self._events, start, end)]
+
+    def read_tail(self, *, limit: int) -> list[tuple[int, dict[str, Any]]]:
+        start = max(0, len(self._events) - limit)
+        return [(position, dict(event)) for position, event in islice(self._events, start, None)]
+
+    def _is_full(self) -> bool:
+        return bool(self._events) and len(self._events) == self._events.maxlen
+
+    @property
+    def _start_position(self) -> int:
+        return self._events[0][0] if self._events else self._next_position
+
+    def _at(self, position: int) -> dict[str, Any]:
+        return self._events[position - self._start_position][1]
+
+    def _forget_event_id(self, event: dict[str, Any]) -> None:
+        event_id = event.get("event_id")
+        if event_id is not None:
+            self._positions_by_event_id.pop(event_id, None)
+
 
 class InMemoryEventLog:
-    """Append-only event log with replay and live tail support."""
+    """Append-only event log with replay and live tail support.
+
+    Each stream keeps only its most recent ``max_events_per_stream`` events;
+    positions remain monotonic so cursors held by subscribers and the persister
+    stay meaningful after older events are dropped.
+    """
 
     capabilities = BackendCapabilities({"replay", "live_tail", "delete"})
 
-    def __init__(self) -> None:
-        self._streams: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    def __init__(
+        self, *, max_events_per_stream: int = DEFAULT_EVENT_STREAM_MAX_EVENTS
+    ) -> None:
+        self.max_events_per_stream = max_events_per_stream
+        self._streams: dict[str, _EventStream] = defaultdict(self._new_stream)
         self._condition = asyncio.Condition()
+
+    def _new_stream(self) -> _EventStream:
+        return _EventStream(self.max_events_per_stream)
+
+    def stream_event_id_count(self, stream: str) -> int:
+        """Number of ``event_id`` dedupe entries a stream currently retains.
+
+        The dedupe index is bounded by the stream itself, so this stays at or
+        below ``max_events_per_stream``.
+        """
+        events = self._streams.get(stream)
+        return 0 if events is None else events.event_id_count
 
     async def append(self, stream: str, event: dict[str, Any]) -> int:
         async with self._condition:
             event_id = event.get("event_id")
             if event_id is not None:
-                for position, existing in enumerate(self._streams.get(stream, [])):
-                    if existing.get("event_id") == event_id:
-                        if existing == event:
-                            return position
-                        raise EventIdConflict(
-                            f"event_id {event_id!r} already exists in stream {stream!r}"
-                        )
-            self._streams[stream].append(dict(event))
-            position = len(self._streams[stream]) - 1
+                existing = self._streams[stream].find_by_event_id(event_id)
+                if existing is not None:
+                    position, stored = existing
+                    if stored == event:
+                        return position
+                    raise EventIdConflict(
+                        f"event_id {event_id!r} already exists in stream {stream!r}"
+                    )
+            position = self._streams[stream].append(event)
             self._condition.notify_all()
             return position
 
@@ -117,12 +239,17 @@ class InMemoryEventLog:
         self, stream: str, *, from_position: int = 0, limit: int | None = None
     ) -> list[tuple[int, dict[str, Any]]]:
         async with self._condition:
-            events = self._streams.get(stream, [])
-            end = None if limit is None else from_position + limit
-            return [
-                (position, dict(event))
-                for position, event in enumerate(events[from_position:end], start=from_position)
-            ]
+            events = self._streams.get(stream)
+            if events is None:
+                return []
+            return events.read(from_position=from_position, limit=limit)
+
+    async def read_tail(self, stream: str, *, limit: int) -> list[tuple[int, dict[str, Any]]]:
+        if limit <= 0:
+            return []
+        async with self._condition:
+            events = self._streams.get(stream)
+            return [] if events is None else events.read_tail(limit=limit)
 
     async def read_filtered(
         self,
@@ -143,15 +270,19 @@ class InMemoryEventLog:
     async def subscribe(
         self, stream: str, *, from_position: int | None = None
     ) -> AsyncIterator[tuple[int, dict[str, Any]]]:
-        cursor = len(self._streams.get(stream, [])) if from_position is None else from_position
+        cursor = self._next_position(stream) if from_position is None else from_position
         while True:
             async with self._condition:
-                while cursor >= len(self._streams.get(stream, [])):
+                while cursor >= self._next_position(stream):
                     await self._condition.wait()
-                event = dict(self._streams[stream][cursor])
-                position = cursor
-                cursor += 1
+                # Events dropped by the size cap are skipped rather than replayed.
+                position, event = self._streams[stream].read(from_position=cursor, limit=1)[0]
+                cursor = position + 1
             yield position, event
+
+    def _next_position(self, stream: str) -> int:
+        events = self._streams.get(stream)
+        return 0 if events is None else events.next_position
 
     async def delete(self, stream: str) -> None:
         async with self._condition:
@@ -198,8 +329,17 @@ class InMemoryQueue:
             self._condition.notify_all()
             return job
 
-    def _release_expired_claims(self) -> None:
-        now = _now()
+    async def _release_expired_claims(self, now: datetime) -> None:
+        """Reclaim jobs whose visibility timeout lapsed, as of ``now``.
+
+        Mirrors the Redis and SQLAlchemy queues so the runtime reaper can drive
+        every backend through the same call.
+        """
+        async with self._condition:
+            self._release_expired_claims_locked(now)
+            self._condition.notify_all()
+
+    def _release_expired_claims_locked(self, now: datetime) -> None:
         for queue_entries in self._entries.values():
             for entry in queue_entries.values():
                 if (
@@ -229,7 +369,7 @@ class InMemoryQueue:
         self, queues: list[str], *, visibility_timeout: float
     ) -> ClaimedJob | None:
         async with self._condition:
-            self._release_expired_claims()
+            self._release_expired_claims_locked(_now())
             for queue in queues:
                 entry = self._claimable(queue)
                 if entry is None:
@@ -295,9 +435,9 @@ class InMemoryQueue:
 
     async def stats(self, queue: str) -> QueueStats:
         async with self._condition:
-            self._release_expired_claims()
-            stats = QueueStats(queue=queue)
             now = _now()
+            self._release_expired_claims_locked(now)
+            stats = QueueStats(queue=queue)
             for entry in self._entries.get(queue, {}).values():
                 if entry.dead_lettered:
                     stats.dead_lettered += 1

--- a/skrift/workers/runtime.py
+++ b/skrift/workers/runtime.py
@@ -47,6 +47,19 @@ from skrift.workers.registry import HandlerDescriptor, HandlerRegistry, registry
 LIFECYCLE_STREAM = "workers:lifecycle"
 QUEUE_WAIT_HISTORY_STATE_KEY = "workers:queue_wait_history"
 QUEUE_TREND_HISTORY_STATE_KEY = "workers:queue_trend_history"
+# How long a finished job's state stays queryable before the store reclaims it.
+# Matches the default of `workers.retention.terminal_job_state_ttl`, which is what
+# the pruner uses for the Redis backend; state stores without a pruner (notably the
+# in-memory one) rely on this write-time TTL plus the reaper's sweep instead.
+TERMINAL_JOB_STATE_TTL_SECONDS = 7 * 24 * 60 * 60
+TERMINAL_JOB_STATUSES = frozenset(
+    {
+        JobStatus.COMPLETED,
+        JobStatus.FAILED,
+        JobStatus.DEAD_LETTERED,
+        JobStatus.CANCELLED,
+    }
+)
 ExecutionMode = Literal["inline", "in_process", "out_of_process"]
 logger = logging.getLogger(__name__)
 
@@ -76,6 +89,7 @@ class WorkerConfig:
     visibility_timeout: float = 30.0
     reaper_interval: float = 5.0
     max_reclaims: int = 3
+    terminal_job_state_ttl: float | None = TERMINAL_JOB_STATE_TTL_SECONDS
 
 
 @dataclass(frozen=True)
@@ -1346,9 +1360,17 @@ class WorkerRuntime:
 
     async def _set_state(self, state: JobState) -> None:
         state.updated_at = utcnow()
-        await self.state_store.set(self._job_key(state.job.id), state)
+        await self.state_store.set(
+            self._job_key(state.job.id), state, ttl=self._job_state_ttl(state)
+        )
         async with self._condition:
             self._condition.notify_all()
+
+    def _job_state_ttl(self, state: JobState) -> float | None:
+        """Expire finished job state after the retention window; keep live jobs."""
+        if state.status not in TERMINAL_JOB_STATUSES:
+            return None
+        return self.config.terminal_job_state_ttl
 
     @staticmethod
     def _job_key(job_id: str) -> str:
@@ -1467,6 +1489,7 @@ def configure_workers(
     visibility_timeout: float = 30.0,
     reaper_interval: float = 5.0,
     max_reclaims: int = 3,
+    terminal_job_state_ttl: float | None = TERMINAL_JOB_STATE_TTL_SECONDS,
     backend_imports: WorkerBackendConfig | Mapping[str, str] | Any | None = None,
     settings: Any | None = None,
     session_maker: Any | None = None,
@@ -1491,6 +1514,7 @@ def configure_workers(
             visibility_timeout=visibility_timeout,
             reaper_interval=reaper_interval,
             max_reclaims=max_reclaims,
+            terminal_job_state_ttl=terminal_job_state_ttl,
         ),
         state_store=state_store
         or _instantiate_backend(

--- a/tests/bot_detection/test_store.py
+++ b/tests/bot_detection/test_store.py
@@ -46,3 +46,61 @@ class TestInMemoryBotStateStore:
         monkeypatch.setattr(time, "monotonic", lambda: future)
 
         assert await store.get("ns", "key") is None
+
+
+class TestInMemoryBotStateStoreBounds:
+    """Keys are client IPs: a client that trips a metric once and never
+    returns must not leave a permanent entry behind."""
+
+    @pytest.mark.asyncio
+    async def test_expired_entries_are_swept_without_being_read(self, monkeypatch):
+        store = InMemoryBotStateStore(sweep_every=10)
+        for index in range(50):
+            await store.set("ns", f"gone-{index}", "value", ttl=1)
+
+        future = time.monotonic() + 30
+        monkeypatch.setattr(time, "monotonic", lambda: future)
+
+        # Enough writes to trip the amortized sweep.
+        for index in range(10):
+            await store.set("ns", f"fresh-{index}", "value", ttl=600)
+
+        assert len(store._data) == 10
+
+    @pytest.mark.asyncio
+    async def test_sweep_keeps_live_entries(self, monkeypatch):
+        store = InMemoryBotStateStore(sweep_every=4)
+        await store.set("ns", "long-lived", "value", ttl=600)
+        await store.set("ns", "short-lived", "value", ttl=1)
+
+        future = time.monotonic() + 30
+        monkeypatch.setattr(time, "monotonic", lambda: future)
+
+        for index in range(4):
+            await store.set("ns", f"other-{index}", "value", ttl=600)
+
+        assert await store.get("ns", "long-lived") == "value"
+        assert await store.get("ns", "short-lived") is None
+
+    @pytest.mark.asyncio
+    async def test_max_entries_evicts_oldest_first(self):
+        store = InMemoryBotStateStore(max_entries=3)
+        for name in ("a", "b", "c", "d"):
+            await store.set("ns", name, name, ttl=600)
+
+        assert len(store._data) == 3
+        assert await store.get("ns", "a") is None
+        assert await store.get("ns", "d") == "d"
+
+    @pytest.mark.asyncio
+    async def test_rewriting_a_key_refreshes_its_eviction_order(self):
+        store = InMemoryBotStateStore(max_entries=2)
+        await store.set("ns", "a", "a", ttl=600)
+        await store.set("ns", "b", "b", ttl=600)
+        await store.set("ns", "a", "a2", ttl=600)
+        await store.set("ns", "c", "c", ttl=600)
+
+        # "b" is now the oldest write, so it is the one that goes.
+        assert await store.get("ns", "b") is None
+        assert await store.get("ns", "a") == "a2"
+        assert await store.get("ns", "c") == "c"

--- a/tests/test_cli_serve.py
+++ b/tests/test_cli_serve.py
@@ -1,0 +1,81 @@
+"""Tests for the ``skrift serve`` CLI command."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from click.testing import CliRunner
+
+from skrift.cli import cli
+
+
+def _invoke_serve(*args):
+    """Invoke ``skrift serve`` with both hypercorn entry points mocked out."""
+    process_manager_run = MagicMock(return_value=0)
+    in_process_serve = AsyncMock(return_value=[])
+    with (
+        patch("hypercorn.run.run", process_manager_run),
+        patch("hypercorn.asyncio.serve", in_process_serve),
+    ):
+        result = CliRunner().invoke(cli, ["serve", *args])
+    return result, process_manager_run, in_process_serve
+
+
+def test_serve_with_multiple_workers_uses_hypercorn_process_manager():
+    result, process_manager_run, in_process_serve = _invoke_serve(
+        "--workers", "4", "--host", "0.0.0.0", "--port", "9000"
+    )
+
+    assert result.exit_code == 0, result.output
+    in_process_serve.assert_not_called()
+    process_manager_run.assert_called_once()
+
+    config = process_manager_run.call_args.args[0]
+    assert config.workers == 4
+    assert config.application_path == "skrift.asgi:app"
+    assert config.bind == ["0.0.0.0:9000"]
+    assert not config.use_reloader
+
+
+def test_serve_with_single_worker_runs_the_app_in_process():
+    result, process_manager_run, in_process_serve = _invoke_serve("--workers", "1")
+
+    assert result.exit_code == 0, result.output
+    process_manager_run.assert_not_called()
+    in_process_serve.assert_awaited_once()
+
+    served_app, config = in_process_serve.await_args.args
+    assert served_app is not None
+    assert config.workers == 1
+    assert "shutdown_trigger" in in_process_serve.await_args.kwargs
+
+
+def test_serve_defaults_to_a_single_in_process_worker():
+    result, process_manager_run, in_process_serve = _invoke_serve()
+
+    assert result.exit_code == 0, result.output
+    process_manager_run.assert_not_called()
+    in_process_serve.assert_awaited_once()
+
+    _, config = in_process_serve.await_args.args
+    assert config.workers == 1
+    assert config.bind == ["127.0.0.1:8080"]
+
+
+def test_serve_with_reload_uses_the_reloader_with_one_worker():
+    result, process_manager_run, in_process_serve = _invoke_serve("--reload", "--workers", "4")
+
+    assert result.exit_code == 0, result.output
+    in_process_serve.assert_not_called()
+    process_manager_run.assert_called_once()
+
+    config = process_manager_run.call_args.args[0]
+    assert config.use_reloader is True
+    assert config.workers == 1
+
+
+def test_serve_rejects_worker_counts_below_one():
+    result, process_manager_run, in_process_serve = _invoke_serve("--workers", "0")
+
+    assert result.exit_code != 0
+    assert "--workers must be at least 1" in result.output
+    process_manager_run.assert_not_called()
+    in_process_serve.assert_not_called()

--- a/tests/test_compression_middleware.py
+++ b/tests/test_compression_middleware.py
@@ -1,0 +1,411 @@
+"""Tests for Skrift's bounded gzip compression middleware.
+
+Covers the three memory-bounding behaviours:
+
+* at most ``max_concurrent_compressions`` zlib deflate states are alive at once,
+  and responses past the cap are sent uncompressed rather than queued,
+* compressed bytes are only flushed when a streaming chunk must reach the
+  client (buffered responses accumulate and flush once, at close),
+* ``compression.enabled = false`` removes compression entirely.
+"""
+
+import gzip
+from io import BytesIO
+
+import pytest
+from litestar import Litestar, get
+from litestar.response import Stream
+from litestar.testing import TestClient
+
+from litestar.middleware import DefineMiddleware
+
+import skrift.config as config_mod
+from skrift.config import CompressionConfig
+from skrift.middleware.compression import (
+    DEFAULT_MAX_CONCURRENT_COMPRESSIONS,
+    STREAMING_EXCLUDE_PATTERN,
+    BoundedCompressionConfig,
+    BoundedCompressionMiddleware,
+    ConcurrentCompressionLimiter,
+    SafeGzipCompression,
+    build_compression_config,
+    build_compression_middleware,
+    process_compression_limiter,
+)
+
+LARGE_BODY = "compress me. " * 400
+SMALL_BODY = "tiny"
+
+
+def _config(**overrides) -> BoundedCompressionConfig:
+    """A gzip config wired to an isolated limiter so tests never share slots."""
+    settings = {
+        "backend": "gzip",
+        "compression_facade": SafeGzipCompression,
+        "middleware_class": BoundedCompressionMiddleware,
+        "minimum_size": 100,
+        "compression_limiter": ConcurrentCompressionLimiter(),
+    }
+    settings.update(overrides)
+    return BoundedCompressionConfig(**settings)
+
+
+def _build_app(*compression_middleware) -> Litestar:
+    """Build an app wired the way ``skrift.asgi`` wires compression."""
+    @get("/large", media_type="text/plain", sync_to_thread=False)
+    def large() -> str:
+        return LARGE_BODY
+
+    @get("/small", media_type="text/plain", sync_to_thread=False)
+    def small() -> str:
+        return SMALL_BODY
+
+    @get("/notifications/stream", media_type="text/event-stream", sync_to_thread=False)
+    def stream() -> Stream:
+        def chunks():
+            for index in range(5):
+                yield f"data: {LARGE_BODY}{index}\n\n".encode()
+
+        return Stream(chunks)
+
+    @get("/stream", media_type="text/plain", sync_to_thread=False)
+    def plain_stream() -> Stream:
+        def chunks():
+            for index in range(5):
+                yield f"chunk-{index}-{LARGE_BODY}".encode()
+
+        return Stream(chunks)
+
+    return Litestar(
+        route_handlers=[large, small, stream, plain_stream],
+        middleware=list(compression_middleware),
+        openapi_config=None,
+    )
+
+
+def _app_for(config: BoundedCompressionConfig) -> Litestar:
+    return _build_app(DefineMiddleware(BoundedCompressionMiddleware, config=config))
+
+
+class TestConcurrentCompressionLimiter:
+    def test_try_acquire_bounded_by_limit(self):
+        limiter = ConcurrentCompressionLimiter()
+
+        assert limiter.try_acquire(2) is True
+        assert limiter.try_acquire(2) is True
+        assert limiter.try_acquire(2) is False
+        assert limiter.active_compressors == 2
+
+    def test_release_frees_a_slot(self):
+        limiter = ConcurrentCompressionLimiter()
+        limiter.try_acquire(1)
+
+        limiter.release()
+
+        assert limiter.active_compressors == 0
+        assert limiter.try_acquire(1) is True
+
+    def test_release_without_acquire_fails_fast(self):
+        limiter = ConcurrentCompressionLimiter()
+
+        with pytest.raises(RuntimeError):
+            limiter.release()
+
+    def test_default_cap_is_small(self):
+        assert DEFAULT_MAX_CONCURRENT_COMPRESSIONS == 20
+
+
+class TestSafeGzipCompressionSlots:
+    def test_acquire_returns_none_past_the_cap(self):
+        config = _config(max_concurrent_compressions=3)
+        facades = [
+            SafeGzipCompression.acquire(BytesIO(), "gzip", config) for _ in range(3)
+        ]
+
+        assert all(facade is not None for facade in facades)
+        assert SafeGzipCompression.acquire(BytesIO(), "gzip", config) is None
+
+        facades[0].close()
+        replacement = SafeGzipCompression.acquire(BytesIO(), "gzip", config)
+        assert replacement is not None
+
+        for facade in [*facades[1:], replacement]:
+            facade.close()
+
+    def test_close_releases_the_slot_once(self):
+        config = _config(max_concurrent_compressions=1)
+        facade = SafeGzipCompression.acquire(BytesIO(), "gzip", config)
+
+        facade.close()
+        facade.close()
+
+        assert config.compression_limiter.active_compressors == 0
+
+    def test_close_survives_a_closed_buffer(self):
+        """Python 3.13's GzipFile finalizer raises on an already-closed buffer."""
+        config = _config(max_concurrent_compressions=1)
+        buffer = BytesIO()
+        facade = SafeGzipCompression.acquire(buffer, "gzip", config)
+        facade.write(b"x" * 100)
+        buffer.close()
+
+        facade.close()
+
+        assert config.compression_limiter.active_compressors == 0
+
+    def test_direct_construction_holds_no_slot(self):
+        config = _config(max_concurrent_compressions=1)
+
+        facade = SafeGzipCompression(BytesIO(), "gzip", config)
+        facade.close()
+
+        assert config.compression_limiter.active_compressors == 0
+
+
+class TestFacadeFlushing:
+    def test_write_does_not_flush(self):
+        config = _config()
+        buffer = BytesIO()
+        facade = SafeGzipCompression(buffer, "gzip", config)
+        header_size = len(buffer.getvalue())
+
+        facade.write(b"a" * 5_000)
+
+        assert len(buffer.getvalue()) == header_size
+        facade.close()
+
+    def test_flush_emits_pending_bytes(self):
+        config = _config()
+        buffer = BytesIO()
+        facade = SafeGzipCompression(buffer, "gzip", config)
+        facade.write(b"a" * 5_000)
+
+        facade.flush()
+
+        assert len(buffer.getvalue()) > 0
+        facade.close()
+
+    def test_close_produces_a_valid_gzip_stream(self):
+        config = _config()
+        buffer = BytesIO()
+        facade = SafeGzipCompression(buffer, "gzip", config)
+        facade.write(b"hello ")
+        facade.write(b"world")
+
+        facade.close()
+
+        assert gzip.decompress(buffer.getvalue()) == b"hello world"
+
+
+class TestCompressionMiddlewareResponses:
+    def test_response_over_minimum_size_is_gzipped(self):
+        config = _config()
+        with TestClient(app=_app_for(config)) as client:
+            response = client.get("/large", headers={"accept-encoding": "gzip"})
+
+        assert response.headers["content-encoding"] == "gzip"
+        assert response.text == LARGE_BODY
+
+    def test_response_under_minimum_size_is_not_compressed(self):
+        config = _config(minimum_size=2048)
+        with TestClient(app=_app_for(config)) as client:
+            response = client.get("/small", headers={"accept-encoding": "gzip"})
+
+        assert "content-encoding" not in response.headers
+        assert response.text == SMALL_BODY
+
+    def test_no_slot_falls_back_to_identity(self):
+        config = _config(max_concurrent_compressions=1)
+        held = SafeGzipCompression.acquire(BytesIO(), "gzip", config)
+        assert held is not None
+
+        with TestClient(app=_app_for(config)) as client:
+            response = client.get("/large", headers={"accept-encoding": "gzip"})
+        held.close()
+
+        assert "content-encoding" not in response.headers
+        assert response.text == LARGE_BODY
+
+    def test_slot_is_released_after_a_compressed_response(self):
+        config = _config()
+        with TestClient(app=_app_for(config)) as client:
+            for _ in range(5):
+                client.get("/large", headers={"accept-encoding": "gzip"})
+
+        assert config.compression_limiter.active_compressors == 0
+
+    def test_streaming_response_arrives_intact(self):
+        config = _config()
+        expected = "".join(f"chunk-{index}-{LARGE_BODY}" for index in range(5))
+
+        with TestClient(app=_app_for(config)) as client:
+            response = client.get("/stream", headers={"accept-encoding": "gzip"})
+
+        assert response.headers["content-encoding"] == "gzip"
+        assert response.text == expected
+        assert config.compression_limiter.active_compressors == 0
+
+    def test_excluded_stream_path_is_never_compressed(self):
+        """Every app (primary, site, setup) excludes the SSE endpoint."""
+        middleware = build_compression_middleware(CompressionConfig(minimum_size=100))
+
+        with TestClient(app=_build_app(*middleware)) as client:
+            excluded = client.get(
+                "/notifications/stream", headers={"accept-encoding": "gzip"}
+            )
+            compressed = client.get("/large", headers={"accept-encoding": "gzip"})
+
+        assert "content-encoding" not in excluded.headers
+        assert compressed.headers["content-encoding"] == "gzip"
+        assert process_compression_limiter.active_compressors == 0
+
+    def test_disabled_compression_installs_no_middleware(self):
+        middleware = build_compression_middleware(CompressionConfig(enabled=False))
+
+        assert middleware == []
+        with TestClient(app=_build_app(*middleware)) as client:
+            response = client.get("/large", headers={"accept-encoding": "gzip"})
+
+        assert "content-encoding" not in response.headers
+        assert response.text == LARGE_BODY
+
+    def test_client_without_gzip_support_gets_identity(self):
+        config = _config()
+        with TestClient(app=_app_for(config)) as client:
+            response = client.get("/large", headers={"accept-encoding": "identity"})
+
+        assert "content-encoding" not in response.headers
+        assert response.text == LARGE_BODY
+        assert config.compression_limiter.active_compressors == 0
+
+
+class TestStreamingFlushBehaviour:
+    """Direct ASGI drive: every streamed chunk must reach the client immediately."""
+
+    async def _run(self, config, chunks: list[bytes]) -> list[dict]:
+        async def app(scope, receive, send) -> None:
+            await send(
+                {
+                    "type": "http.response.start",
+                    "status": 200,
+                    "headers": [(b"content-type", b"text/event-stream")],
+                }
+            )
+            for index, chunk in enumerate(chunks):
+                await send(
+                    {
+                        "type": "http.response.body",
+                        "body": chunk,
+                        "more_body": index < len(chunks) - 1,
+                    }
+                )
+
+        middleware = BoundedCompressionMiddleware(app=app, config=config)
+        sent: list[dict] = []
+
+        async def send(message) -> None:
+            sent.append(message)
+
+        scope = {
+            "type": "http",
+            "method": "GET",
+            "path": "/stream",
+            "headers": [(b"accept-encoding", b"gzip")],
+            "state": {},
+        }
+        await middleware(scope, None, send)
+        return sent
+
+    @pytest.mark.asyncio
+    async def test_each_chunk_is_flushed_and_stream_decompresses(self):
+        config = _config()
+        chunks = [f"event-{index}\n\n".encode() for index in range(4)]
+
+        sent = await self._run(config, chunks)
+
+        bodies = [m["body"] for m in sent if m["type"] == "http.response.body"]
+        assert len(bodies) == len(chunks)
+        assert all(body for body in bodies), "a streamed chunk produced no bytes"
+        assert gzip.decompress(b"".join(bodies)) == b"".join(chunks)
+        assert config.compression_limiter.active_compressors == 0
+
+    @pytest.mark.asyncio
+    async def test_streaming_without_a_slot_passes_bytes_through(self):
+        config = _config(max_concurrent_compressions=1)
+        held = SafeGzipCompression.acquire(BytesIO(), "gzip", config)
+        chunks = [f"event-{index}\n\n".encode() for index in range(3)]
+
+        sent = await self._run(config, chunks)
+        held.close()
+
+        start = next(m for m in sent if m["type"] == "http.response.start")
+        header_names = [name.lower() for name, _ in start["headers"]]
+        assert b"content-encoding" not in header_names
+        bodies = [m["body"] for m in sent if m["type"] == "http.response.body"]
+        assert b"".join(bodies) == b"".join(chunks)
+
+    @pytest.mark.asyncio
+    async def test_slot_released_when_the_app_raises(self):
+        config = _config()
+
+        async def failing_app(scope, receive, send) -> None:
+            await send({"type": "http.response.start", "status": 200, "headers": []})
+            await send({"type": "http.response.body", "body": b"x" * 500, "more_body": True})
+            raise RuntimeError("handler blew up mid-stream")
+
+        middleware = BoundedCompressionMiddleware(app=failing_app, config=config)
+
+        async def send(message) -> None:
+            return None
+
+        scope = {
+            "type": "http",
+            "method": "GET",
+            "path": "/stream",
+            "headers": [(b"accept-encoding", b"gzip")],
+            "state": {},
+        }
+        with pytest.raises(RuntimeError):
+            await middleware(scope, None, send)
+
+        assert config.compression_limiter.active_compressors == 0
+
+
+class TestBuildCompressionConfig:
+    def test_disabled_returns_none(self):
+        assert build_compression_config(CompressionConfig(enabled=False)) is None
+
+    def test_defaults_bound_memory(self):
+        config = build_compression_config(CompressionConfig())
+
+        assert config.minimum_size == 2048
+        assert config.max_concurrent_compressions == DEFAULT_MAX_CONCURRENT_COMPRESSIONS
+        assert config.compression_facade is SafeGzipCompression
+        assert config.middleware_class is BoundedCompressionMiddleware
+        assert config.exclude == [STREAMING_EXCLUDE_PATTERN]
+
+    def test_settings_are_applied(self):
+        config = build_compression_config(
+            CompressionConfig(minimum_size=4096, max_concurrent=3)
+        )
+
+        assert config.minimum_size == 4096
+        assert config.max_concurrent_compressions == 3
+
+    def test_extra_excludes_keep_the_stream_path(self):
+        config = build_compression_config(CompressionConfig(), exclude=["/events"])
+
+        assert STREAMING_EXCLUDE_PATTERN in config.exclude
+        assert "/events" in config.exclude
+
+
+class TestCompressionSettingsSection:
+    def test_section_is_registered(self):
+        assert config_mod._CONFIG_SECTIONS["compression"] is CompressionConfig
+
+    def test_defaults(self):
+        settings = CompressionConfig()
+
+        assert settings.enabled is True
+        assert settings.minimum_size == 2048
+        assert settings.max_concurrent == DEFAULT_MAX_CONCURRENT_COMPRESSIONS

--- a/tests/test_mcp_connector_flow.py
+++ b/tests/test_mcp_connector_flow.py
@@ -284,7 +284,12 @@ def test_full_claude_connector_flow(client, engine):
 
     approval = client.post(
         "/oauth/authorize",
-        data={"action": "allow", CSRF_FIELD_NAME: CONSENT_CSRF},
+        data={
+            "action": "allow",
+            # Every consent checkbox left checked — what the rendered form posts.
+            "scope": REQUESTED_SCOPE.split(),
+            CSRF_FIELD_NAME: CONSENT_CSRF,
+        },
         follow_redirects=False,
     )
     code = _code_from_redirect(approval, expected_state="first-state")

--- a/tests/test_media_admin_controller.py
+++ b/tests/test_media_admin_controller.py
@@ -5,6 +5,67 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 
+def make_upload(call_log: list[str] | None = None) -> MagicMock:
+    """A mock UploadFile that records the order of its read/close calls."""
+    log = call_log if call_log is not None else []
+    upload = MagicMock()
+
+    async def read() -> bytes:
+        log.append("read")
+        return b"content"
+
+    async def close() -> None:
+        log.append("close")
+
+    upload.read = AsyncMock(side_effect=read)
+    upload.close = AsyncMock(side_effect=close)
+    upload.filename = "file.png"
+    upload.content_type = "image/png"
+    return upload
+
+
+class TestMediaUploadBufferRelease:
+    @pytest.mark.asyncio
+    async def test_upload_media_releases_the_spooled_buffer_after_reading(self):
+        from skrift.admin.media import MediaAdminController
+
+        controller = MediaAdminController(owner=MagicMock())
+        request = MagicMock()
+        request.app.state.storage_manager = MagicMock()
+        request.user = MagicMock(id="user-id")
+        db_session = AsyncMock()
+        call_log: list[str] = []
+        upload = make_upload(call_log)
+
+        with patch("skrift.admin.media.upload_asset", new_callable=AsyncMock), \
+             patch("skrift.admin.media.flash_success"):
+            await MediaAdminController.upload_media.fn(
+                controller, request, db_session, upload
+            )
+
+        assert call_log == ["read", "close"]
+
+    @pytest.mark.asyncio
+    async def test_upload_media_json_releases_the_spooled_buffer_after_reading(self):
+        from skrift.admin.media import MediaAdminController
+
+        controller = MediaAdminController(owner=MagicMock())
+        request = MagicMock()
+        request.app.state.storage_manager = MagicMock()
+        request.session = {"user_id": "00000000-0000-0000-0000-000000000000"}
+        db_session = AsyncMock()
+        call_log: list[str] = []
+        upload = make_upload(call_log)
+
+        with patch("skrift.admin.media.upload_asset", new_callable=AsyncMock), \
+             patch("skrift.admin.media.get_asset_url", new_callable=AsyncMock):
+            await MediaAdminController.upload_media_json.fn(
+                controller, request, db_session, upload
+            )
+
+        assert call_log == ["read", "close"]
+
+
 class TestMediaAdminController:
     @pytest.mark.asyncio
     async def test_upload_media_uses_generic_flash_on_unexpected_error(self):
@@ -15,10 +76,7 @@ class TestMediaAdminController:
         request.app.state.storage_manager = MagicMock()
         request.user = MagicMock(id="user-id")
         db_session = AsyncMock()
-        upload = MagicMock()
-        upload.read = AsyncMock(return_value=b"content")
-        upload.filename = "file.png"
-        upload.content_type = "image/png"
+        upload = make_upload()
 
         with patch("skrift.admin.media.upload_asset", new_callable=AsyncMock, side_effect=RuntimeError("boom")), \
              patch("skrift.admin.media.flash_error") as mock_flash, \
@@ -42,10 +100,7 @@ class TestMediaAdminController:
         request.app.state.storage_manager = MagicMock()
         request.session = {"user_id": "00000000-0000-0000-0000-000000000000"}
         db_session = AsyncMock()
-        upload = MagicMock()
-        upload.read = AsyncMock(return_value=b"content")
-        upload.filename = "file.png"
-        upload.content_type = "image/png"
+        upload = make_upload()
 
         with patch("skrift.admin.media.upload_asset", new_callable=AsyncMock, side_effect=RuntimeError("boom")), \
              patch("skrift.admin.media.logger.exception") as mock_log:

--- a/tests/test_notification_memory_limits.py
+++ b/tests/test_notification_memory_limits.py
@@ -1,0 +1,291 @@
+"""Tests for bounded memory usage in the notification subsystem.
+
+Covers the in-memory backend's TTL-based expiry, the bounded SSE delivery
+queue, and full teardown of registry edges when a user's last connection
+disconnects.
+"""
+
+import asyncio
+import time
+
+import pytest
+
+from skrift.lib.notification_backends import (
+    CLEANUP_INTERVAL_SECONDS,
+    QUEUED_TTL_HOURS,
+    TIMESERIES_TTL_DAYS,
+    InMemoryBackend,
+)
+from skrift.notifications import (
+    SSE_QUEUE_MAXSIZE,
+    Notification,
+    NotificationMode,
+    NotificationService,
+    SourceRegistry,
+)
+
+
+@pytest.fixture
+def backend():
+    return InMemoryBackend()
+
+
+@pytest.fixture
+def svc():
+    return NotificationService()
+
+
+def _aged(mode: NotificationMode, age_seconds: float, **payload) -> Notification:
+    """Build a notification whose created_at is *age_seconds* in the past."""
+    return Notification(
+        type="aged",
+        created_at=time.time() - age_seconds,
+        mode=mode,
+        payload=payload,
+    )
+
+
+# ===========================================================================
+# InMemoryBackend TTL expiry
+# ===========================================================================
+
+
+class TestInMemoryBackendExpiry:
+    @pytest.mark.asyncio
+    async def test_expires_old_queued_notifications(self, backend):
+        stale = _aged(NotificationMode.QUEUED, QUEUED_TTL_HOURS * 3600 + 60)
+        fresh = _aged(NotificationMode.QUEUED, 60)
+        await backend.store("session:s1", stale)
+        await backend.store("session:s1", fresh)
+
+        await backend._delete_old_notifications()
+
+        remaining = await backend.get_queued_multi(["session:s1"])
+        assert [n.id for n in remaining] == [fresh.id]
+
+    @pytest.mark.asyncio
+    async def test_expires_old_timeseries_notifications(self, backend):
+        stale = _aged(NotificationMode.TIMESERIES, TIMESERIES_TTL_DAYS * 86400 + 60)
+        fresh = _aged(NotificationMode.TIMESERIES, 60)
+        await backend.store("user:alice", stale)
+        await backend.store("user:alice", fresh)
+
+        await backend._delete_old_notifications()
+
+        remaining = await backend.get_since_multi(["user:alice"], 0)
+        assert [n.id for n in remaining] == [fresh.id]
+
+    @pytest.mark.asyncio
+    async def test_keeps_timeseries_younger_than_queued_ttl(self, backend):
+        """Timeseries records live longer than queued ones."""
+        older_than_queued_ttl = _aged(
+            NotificationMode.TIMESERIES, QUEUED_TTL_HOURS * 3600 + 60
+        )
+        await backend.store("user:alice", older_than_queued_ttl)
+
+        await backend._delete_old_notifications()
+
+        remaining = await backend.get_since_multi(["user:alice"], 0)
+        assert [n.id for n in remaining] == [older_than_queued_ttl.id]
+
+    @pytest.mark.asyncio
+    async def test_empty_source_keys_are_removed(self, backend):
+        stale = _aged(NotificationMode.QUEUED, QUEUED_TTL_HOURS * 3600 + 60)
+        await backend.store("session:s1", stale)
+
+        await backend._delete_old_notifications()
+
+        assert backend._queues == {}
+
+    @pytest.mark.asyncio
+    async def test_dismissed_records_for_expired_notifications_are_dropped(self, backend):
+        stale = _aged(NotificationMode.QUEUED, QUEUED_TTL_HOURS * 3600 + 60)
+        await backend.store("session:s1", stale)
+        assert await backend.dismiss_for_subscriber("user:alice", stale.id) == "session:s1"
+
+        await backend._delete_old_notifications()
+        await backend.cleanup_dismissed()
+
+        assert backend._dismissed == {}
+
+    @pytest.mark.asyncio
+    async def test_start_schedules_cleanup_and_stop_cancels_it(self, backend, monkeypatch):
+        monkeypatch.setattr(InMemoryBackend, "_cleanup_interval_seconds", 0.01)
+        stale = _aged(NotificationMode.QUEUED, QUEUED_TTL_HOURS * 3600 + 60)
+        await backend.store("session:s1", stale)
+
+        await backend.start()
+        try:
+            for _ in range(200):
+                await asyncio.sleep(0.01)
+                if not backend._queues:
+                    break
+            assert backend._queues == {}
+        finally:
+            await backend.stop()
+
+        assert backend._cleanup_task is None or backend._cleanup_task.done()
+
+    @pytest.mark.asyncio
+    async def test_cleanup_loop_survives_backend_errors(self, backend, monkeypatch):
+        """A failing sweep is logged and the loop keeps running."""
+        monkeypatch.setattr(InMemoryBackend, "_cleanup_interval_seconds", 0.01)
+        sweeps = []
+
+        async def failing_sweep():
+            sweeps.append(1)
+            raise RuntimeError("boom")
+
+        monkeypatch.setattr(backend, "_delete_old_notifications", failing_sweep)
+
+        await backend.start()
+        try:
+            for _ in range(200):
+                await asyncio.sleep(0.01)
+                if len(sweeps) >= 2:
+                    break
+            assert len(sweeps) >= 2
+        finally:
+            await backend.stop()
+
+    def test_cleanup_interval_default(self, backend):
+        assert backend._cleanup_interval_seconds == CLEANUP_INTERVAL_SECONDS
+
+
+# ===========================================================================
+# Bounded SSE queue
+# ===========================================================================
+
+
+class TestBoundedSSEQueue:
+    @pytest.mark.asyncio
+    async def test_register_connection_queue_is_bounded(self, svc):
+        q = await svc.register_connection("s1", None)
+        assert q.maxsize == SSE_QUEUE_MAXSIZE
+        assert SSE_QUEUE_MAXSIZE > 0
+
+    def test_push_drops_oldest_when_queue_is_full(self):
+        registry = SourceRegistry()
+        q: asyncio.Queue = asyncio.Queue(maxsize=2)
+        registry.add_listener("session:s1", q)
+
+        first = Notification(type="first")
+        second = Notification(type="second")
+        third = Notification(type="third")
+        for notification in (first, second, third):
+            registry.push("session:s1", notification)
+
+        assert q.qsize() == 2
+        assert [q.get_nowait().id for _ in range(2)] == [second.id, third.id]
+
+    @pytest.mark.asyncio
+    async def test_stalled_client_queue_does_not_grow(self, svc):
+        q = await svc.register_connection("s1", None)
+
+        for index in range(SSE_QUEUE_MAXSIZE * 3):
+            await svc.send_to_session(
+                "s1", Notification(type="spam", mode=NotificationMode.EPHEMERAL, payload={"i": index})
+            )
+
+        assert q.qsize() == SSE_QUEUE_MAXSIZE
+
+    def test_slow_listener_does_not_block_other_listeners(self):
+        registry = SourceRegistry()
+        full: asyncio.Queue = asyncio.Queue(maxsize=1)
+        drained: asyncio.Queue = asyncio.Queue(maxsize=8)
+        registry.add_listener("session:s1", full)
+        registry.add_listener("session:s1", drained)
+
+        registry.push("session:s1", Notification(type="one"))
+        latest = Notification(type="two")
+        registry.push("session:s1", latest)
+
+        assert full.qsize() == 1
+        assert full.get_nowait().id == latest.id
+        assert drained.qsize() == 2
+
+
+# ===========================================================================
+# Registry teardown on disconnect
+# ===========================================================================
+
+
+def _registry_footprint(svc: NotificationService) -> tuple[int, ...]:
+    """Sizes of every per-connection structure the service keeps."""
+    registry = svc._registry
+    return (
+        len(registry._listeners),
+        len(registry._subscriptions),
+        len(registry._subscribers),
+        len(svc._loaded_user_subs),
+        len(svc._session_users),
+    )
+
+
+class TestRegistryTeardown:
+    @pytest.mark.asyncio
+    async def test_anonymous_connect_disconnect_returns_to_baseline(self, svc):
+        baseline = _registry_footprint(svc)
+
+        q = await svc.register_connection("s1", None)
+        assert _registry_footprint(svc) != baseline
+        svc.unregister_connection("s1", q)
+
+        assert _registry_footprint(svc) == baseline
+
+    @pytest.mark.asyncio
+    async def test_user_connect_disconnect_returns_to_baseline(self, svc):
+        baseline = _registry_footprint(svc)
+
+        for index in range(5):
+            q = await svc.register_connection(f"s{index}", "alice")
+            svc.unregister_connection(f"s{index}", q)
+
+        assert _registry_footprint(svc) == baseline
+        assert "user:alice" not in svc._registry._subscribers
+        assert "user:alice" not in svc._registry._subscriptions
+
+    @pytest.mark.asyncio
+    async def test_user_edges_survive_while_another_session_is_live(self, svc):
+        first = await svc.register_connection("s1", "alice")
+        second = await svc.register_connection("s2", "alice")
+
+        svc.unregister_connection("s1", first)
+
+        assert "user:alice" in svc._registry._subscriptions
+        assert svc._registry._subscribers["user:alice"] == {"session:s2"}
+        assert "user:alice" in svc._loaded_user_subs
+
+        # The still-live session keeps receiving user broadcasts
+        notification = Notification(type="ping", mode=NotificationMode.EPHEMERAL)
+        await svc.send_to_user("alice", notification)
+        assert second.get_nowait().id == notification.id
+
+        svc.unregister_connection("s2", second)
+        assert _registry_footprint(svc) == (0, 0, 0, 0, 0)
+
+    @pytest.mark.asyncio
+    async def test_persistent_subscriptions_reload_after_full_disconnect(self, svc):
+        backend = svc._get_backend()
+        await backend.add_subscription("user:alice", "blog:tech")
+
+        first = await svc.register_connection("s1", "alice")
+        svc.unregister_connection("s1", first)
+        assert _registry_footprint(svc) == (0, 0, 0, 0, 0)
+
+        second = await svc.register_connection("s2", "alice")
+        notification = Notification(type="post", mode=NotificationMode.EPHEMERAL)
+        await svc.send("blog:tech", notification)
+
+        assert second.get_nowait().id == notification.id
+
+    @pytest.mark.asyncio
+    async def test_global_broadcast_still_reaches_reconnected_session(self, svc):
+        first = await svc.register_connection("s1", "alice")
+        svc.unregister_connection("s1", first)
+
+        second = await svc.register_connection("s1", "alice")
+        notification = Notification(type="announce", mode=NotificationMode.EPHEMERAL)
+        await svc.broadcast(notification)
+
+        assert second.get_nowait().id == notification.id

--- a/tests/test_oauth2_consent.py
+++ b/tests/test_oauth2_consent.py
@@ -1,20 +1,28 @@
 """Phase 3 MCP identity provider — remembered OAuth2 consent.
 
-Covers the ConsentGrant service (find/upsert/union/revoke/cascade), the
+Covers the ConsentGrant service (find/upsert/union/decline/revoke/cascade), the
 ``/oauth/authorize`` consent-skip and re-prompt behaviour, that consent
-approval persists a grant, and that deleting or pruning a client removes its
-grants.
+approval persists a grant, that a user may approve only a subset of the
+requested scopes, and that deleting or pruning a client removes its grants.
 """
 
+import base64
+import hashlib
 from datetime import datetime, timezone, timedelta
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
+from urllib.parse import parse_qs, urlsplit
 
 import pytest
 import pytest_asyncio
+from jinja2 import Environment, FileSystemLoader
+from litestar.datastructures import FormMultiDict
 from litestar.response import Redirect, Template as TemplateResponse
+from markupsafe import Markup
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
+from skrift.auth.tokens import verify_signed_token
 from skrift.config import SecurityHeadersConfig
 from skrift.controllers.oauth2 import OAuth2Controller
 from skrift.db.base import Base
@@ -26,6 +34,7 @@ SECRET = "test-secret-key"
 USER_ID = "00000000-0000-0000-0000-000000000042"
 OTHER_USER_ID = "00000000-0000-0000-0000-000000000099"
 REDIRECT_URI = "http://localhost/cb"
+TEMPLATES_DIR = Path(__file__).resolve().parent.parent / "skrift" / "templates"
 
 
 @pytest_asyncio.fixture
@@ -44,7 +53,15 @@ def _settings():
     settings.secret_key = SECRET
     settings.security_headers = SecurityHeadersConfig()
     settings.oauth2_allowed_resources = []
+    settings.oauth2_issuer = "http://localhost:8000"
+    settings.oauth2_access_token_ttl = 900
     return settings
+
+
+def _pkce_pair():
+    verifier = "consent-code-verifier-long-enough-for-pkce"
+    digest = hashlib.sha256(verifier.encode()).digest()
+    return verifier, base64.urlsafe_b64encode(digest).decode().rstrip("=")
 
 
 async def _make_client(db_session, scopes=None):
@@ -84,6 +101,86 @@ async def _authorize_get(db_session, request):
         return await OAuth2Controller.authorize_get.fn(controller, request, db_session)
 
 
+def _consent_post_request(
+    client_id,
+    requested_scope,
+    granted_scopes,
+    *,
+    action="allow",
+    code_challenge="challenge",
+):
+    """A consent-form submission.
+
+    ``granted_scopes`` is the list of boxes the user left checked — the
+    browser submits one ``scope`` field per checked box, so an empty list
+    submits none at all.
+    """
+    request = MagicMock()
+    request.session = {
+        "user_id": USER_ID,
+        "user_email": "u@example.com",
+        "user_name": "User",
+        "user_picture_url": "",
+        "oauth_authorize": {
+            "client_id": client_id,
+            "redirect_uri": REDIRECT_URI,
+            "state": "xyz",
+            "scope": requested_scope,
+            "code_challenge": code_challenge,
+            "resource": "",
+        },
+    }
+    fields = [("action", action)] + [("scope", scope) for scope in granted_scopes]
+    request.form = AsyncMock(return_value=FormMultiDict(fields))
+    return request
+
+
+async def _authorize_post(db_session, request):
+    controller = OAuth2Controller(owner=MagicMock())
+    with patch("skrift.controllers.oauth2.verify_csrf", new_callable=AsyncMock, return_value=True), \
+         patch("skrift.controllers.oauth2.get_settings", return_value=_settings()):
+        return await OAuth2Controller.authorize_post.fn(controller, request, db_session)
+
+
+async def _exchange_code(db_session, *, client_id, code, code_verifier):
+    controller = OAuth2Controller(owner=MagicMock())
+    request = MagicMock()
+    request.form = AsyncMock(
+        return_value=FormMultiDict(
+            [
+                ("grant_type", "authorization_code"),
+                ("code", code),
+                ("redirect_uri", REDIRECT_URI),
+                ("client_id", client_id),
+                ("code_verifier", code_verifier),
+            ]
+        )
+    )
+    with patch("skrift.controllers.oauth2.get_settings", return_value=_settings()):
+        return await OAuth2Controller.token_exchange.fn(controller, request, db_session)
+
+
+async def _refresh(db_session, *, client_id, refresh_token, scope):
+    controller = OAuth2Controller(owner=MagicMock())
+    request = MagicMock()
+    request.form = AsyncMock(
+        return_value=FormMultiDict(
+            [
+                ("grant_type", "refresh_token"),
+                ("refresh_token", refresh_token),
+                ("client_id", client_id),
+                ("scope", scope),
+            ]
+        )
+    )
+    with patch("skrift.controllers.oauth2.get_settings", return_value=_settings()):
+        return await OAuth2Controller.token_exchange.fn(controller, request, db_session)
+
+
+def _code_from(redirect):
+    return parse_qs(urlsplit(redirect.url).query)["code"][0]
+
+
 class TestConsentService:
     @pytest.mark.asyncio
     async def test_find_grant_missing_returns_none(self, db_session):
@@ -116,6 +213,27 @@ class TestConsentService:
         assert set(found.scope_list) == {"openid", "email"}
         rows = (await db_session.execute(select(ConsentGrant))).scalars().all()
         assert len(rows) == 1
+
+    @pytest.mark.asyncio
+    async def test_declined_scopes_are_removed_from_an_existing_grant(self, db_session):
+        now = datetime.now(tz=timezone.utc)
+        await oauth2_consent_service.upsert_grant(
+            db_session,
+            user_id=USER_ID,
+            client_id="client-a",
+            scopes=["openid", "profile", "email"],
+            granted_at=now,
+        )
+        await oauth2_consent_service.upsert_grant(
+            db_session,
+            user_id=USER_ID,
+            client_id="client-a",
+            scopes=["openid"],
+            declined_scopes=["profile", "email"],
+            granted_at=now,
+        )
+        found = await oauth2_consent_service.find_grant(db_session, USER_ID, "client-a")
+        assert set(found.scope_list) == {"openid"}
 
     @pytest.mark.asyncio
     async def test_grant_is_scoped_per_user(self, db_session):
@@ -246,7 +364,11 @@ class TestAuthorizePostPersistsGrant:
                 "resource": "",
             },
         }
-        request.form = AsyncMock(return_value={"action": "allow"})
+        request.form = AsyncMock(
+            return_value=FormMultiDict(
+                [("action", "allow"), ("scope", "openid"), ("scope", "profile")]
+            )
+        )
 
         with patch("skrift.controllers.oauth2.verify_csrf", new_callable=AsyncMock, return_value=True), \
              patch("skrift.controllers.oauth2.get_settings", return_value=_settings()):
@@ -283,6 +405,245 @@ class TestAuthorizePostPersistsGrant:
         assert isinstance(result, Redirect)
         assert "error=access_denied" in result.url
         assert await oauth2_consent_service.find_grant(db_session, USER_ID, client.client_id) is None
+
+
+class TestPartialConsent:
+    """A user may approve a subset of the requested scopes (RFC 6749 §3.3)."""
+
+    @pytest.mark.asyncio
+    async def test_only_checked_scopes_are_granted_and_coded(self, db_session):
+        client = await _make_client(db_session)
+        request = _consent_post_request(
+            client.client_id, "openid profile email", ["openid", "profile"]
+        )
+
+        result = await _authorize_post(db_session, request)
+
+        assert isinstance(result, Redirect)
+        payload = verify_signed_token(_code_from(result), SECRET)
+        assert payload["scope"] == "openid profile"
+        grant = await oauth2_consent_service.find_grant(db_session, USER_ID, client.client_id)
+        assert set(grant.scope_list) == {"openid", "profile"}
+
+    @pytest.mark.asyncio
+    async def test_every_box_checked_grants_the_full_request(self, db_session):
+        client = await _make_client(db_session)
+        request = _consent_post_request(
+            client.client_id, "openid profile email", ["openid", "profile", "email"]
+        )
+
+        result = await _authorize_post(db_session, request)
+
+        payload = verify_signed_token(_code_from(result), SECRET)
+        assert payload["scope"] == "openid profile email"
+        grant = await oauth2_consent_service.find_grant(db_session, USER_ID, client.client_id)
+        assert set(grant.scope_list) == {"openid", "profile", "email"}
+
+    @pytest.mark.asyncio
+    async def test_scope_outside_the_request_is_rejected(self, db_session):
+        """The authorization request is the ceiling — a submitted scope that was
+        never requested is a tampered form, not a wider grant."""
+        client = await _make_client(db_session)
+        request = _consent_post_request(client.client_id, "openid", ["openid", "email"])
+
+        result = await _authorize_post(db_session, request)
+
+        assert not isinstance(result, Redirect)
+        assert result.status_code == 400
+        assert result.content["error"] == "invalid_scope"
+        assert await oauth2_consent_service.find_grant(db_session, USER_ID, client.client_id) is None
+
+    @pytest.mark.asyncio
+    async def test_unchecking_everything_is_a_denial(self, db_session):
+        client = await _make_client(db_session)
+        request = _consent_post_request(client.client_id, "openid profile", [])
+
+        result = await _authorize_post(db_session, request)
+
+        assert isinstance(result, Redirect)
+        assert "error=access_denied" in result.url
+        assert "state=xyz" in result.url
+        assert "code=" not in result.url
+        assert await oauth2_consent_service.find_grant(db_session, USER_ID, client.client_id) is None
+
+    @pytest.mark.asyncio
+    async def test_denial_button_wins_over_checked_boxes(self, db_session):
+        """Browsers submit checked boxes with whichever button was pressed."""
+        client = await _make_client(db_session)
+        request = _consent_post_request(
+            client.client_id, "openid profile", ["openid"], action="deny"
+        )
+
+        result = await _authorize_post(db_session, request)
+
+        assert isinstance(result, Redirect)
+        assert "error=access_denied" in result.url
+        assert await oauth2_consent_service.find_grant(db_session, USER_ID, client.client_id) is None
+
+    @pytest.mark.asyncio
+    async def test_scopeless_request_still_approves(self, db_session):
+        """A client that asked for no scopes has nothing to uncheck, so an empty
+        submission is an approval — not the uncheck-everything denial."""
+        client = await _make_client(db_session)
+        request = _consent_post_request(client.client_id, "", [])
+
+        result = await _authorize_post(db_session, request)
+
+        assert isinstance(result, Redirect)
+        payload = verify_signed_token(_code_from(result), SECRET)
+        assert payload["scope"] == ""
+
+    @pytest.mark.asyncio
+    async def test_declined_scope_reprompts_on_the_next_request(self, db_session):
+        client = await _make_client(db_session)
+        await _authorize_post(
+            db_session,
+            _consent_post_request(client.client_id, "openid profile email", ["openid"]),
+        )
+
+        result = await _authorize_get(
+            db_session, _authorize_get_request(client.client_id, "openid profile email")
+        )
+
+        assert isinstance(result, TemplateResponse)
+
+    @pytest.mark.asyncio
+    async def test_declining_narrows_a_previously_broader_grant(self, db_session):
+        """Unchecking a scope the user granted before must actually take it
+        away, otherwise the union in upsert_grant would silently restore it and
+        the next authorize would skip consent."""
+        client = await _make_client(db_session)
+        await oauth2_consent_service.upsert_grant(
+            db_session,
+            user_id=USER_ID,
+            client_id=client.client_id,
+            scopes=["openid", "profile", "email"],
+            granted_at=datetime.now(tz=timezone.utc),
+        )
+
+        await _authorize_post(
+            db_session,
+            _consent_post_request(client.client_id, "openid profile email", ["openid"]),
+        )
+
+        grant = await oauth2_consent_service.find_grant(db_session, USER_ID, client.client_id)
+        assert set(grant.scope_list) == {"openid"}
+        reprompt = await _authorize_get(
+            db_session, _authorize_get_request(client.client_id, "openid email")
+        )
+        assert isinstance(reprompt, TemplateResponse)
+
+    @pytest.mark.asyncio
+    async def test_scopes_absent_from_the_screen_survive_a_narrowed_consent(self, db_session):
+        """Only the scopes actually shown to the user are re-decided; an earlier
+        grant for a scope this request never mentioned still stands."""
+        client = await _make_client(db_session)
+        await oauth2_consent_service.upsert_grant(
+            db_session,
+            user_id=USER_ID,
+            client_id=client.client_id,
+            scopes=["email"],
+            granted_at=datetime.now(tz=timezone.utc),
+        )
+
+        await _authorize_post(
+            db_session,
+            _consent_post_request(client.client_id, "openid profile", ["openid"]),
+        )
+
+        grant = await oauth2_consent_service.find_grant(db_session, USER_ID, client.client_id)
+        assert set(grant.scope_list) == {"openid", "email"}
+
+
+class TestNarrowedConsentReachesTheToken:
+    @pytest.mark.asyncio
+    async def test_token_response_carries_only_the_granted_scope(self, db_session):
+        """RFC 6749 §3.3: the token response reports the granted scope when it
+        differs from the requested one."""
+        client = await _make_client(db_session)
+        verifier, challenge = _pkce_pair()
+        approval = await _authorize_post(
+            db_session,
+            _consent_post_request(
+                client.client_id,
+                "openid profile email",
+                ["openid", "email"],
+                code_challenge=challenge,
+            ),
+        )
+
+        token_response = await _exchange_code(
+            db_session,
+            client_id=client.client_id,
+            code=_code_from(approval),
+            code_verifier=verifier,
+        )
+
+        assert token_response.status_code == 200
+        assert token_response.content["scope"] == "openid email"
+
+    @pytest.mark.asyncio
+    async def test_refresh_cannot_widen_a_narrowed_grant(self, db_session):
+        client = await _make_client(db_session)
+        verifier, challenge = _pkce_pair()
+        approval = await _authorize_post(
+            db_session,
+            _consent_post_request(
+                client.client_id,
+                "openid profile email",
+                ["openid"],
+                code_challenge=challenge,
+            ),
+        )
+        token_response = await _exchange_code(
+            db_session,
+            client_id=client.client_id,
+            code=_code_from(approval),
+            code_verifier=verifier,
+        )
+
+        widened = await _refresh(
+            db_session,
+            client_id=client.client_id,
+            refresh_token=token_response.content["refresh_token"],
+            scope="openid profile",
+        )
+
+        assert widened.status_code == 400
+        assert widened.content["error"] == "invalid_scope"
+
+
+class TestConsentTemplateCheckboxes:
+    @staticmethod
+    def _render(**context):
+        environment = Environment(loader=FileSystemLoader(TEMPLATES_DIR), autoescape=True)
+        environment.globals.update(
+            site_name=lambda: "Skrift",
+            static_url=lambda path: f"/static/{path}",
+            csp_nonce=lambda: "test-nonce",
+            csrf_field=lambda: Markup('<input type="hidden" name="_csrf_token" value="t">'),
+        )
+        return environment.get_template("oauth/authorize.html").render(**context)
+
+    def test_each_scope_renders_a_checked_checkbox_inside_the_form(self):
+        html = self._render(
+            client_id="abc",
+            display_name="Consent App",
+            scopes=["openid", "profile"],
+            scope_descriptions=[
+                {"name": "openid", "description": "Verify your identity"},
+                {"name": "profile", "description": "See your profile"},
+            ],
+        )
+
+        for scope_name in ("openid", "profile"):
+            assert f'name="scope" value="{scope_name}"' in html
+        assert html.count('type="checkbox"') == 2
+        assert html.count("checked") == 2
+        assert "Verify your identity" in html
+        assert "See your profile" in html
+        # The boxes are only submitted if they live inside the consent form.
+        assert html.index("<form") < html.index('type="checkbox"') < html.index("</form>")
 
 
 class TestClientDeletionCascade:

--- a/tests/test_oauth2_jwt.py
+++ b/tests/test_oauth2_jwt.py
@@ -17,6 +17,7 @@ import pytest
 import pytest_asyncio
 from joserfc import jwt as jose_jwt
 from joserfc.jwk import ECKey
+from litestar.datastructures import FormMultiDict
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
 from skrift.auth.jwt_tokens import create_access_token_jwt, verify_access_token_jwt
@@ -379,7 +380,9 @@ class TestAuthorizePostCarriesResource:
                 "resource": RESOURCE,
             },
         }
-        request.form = AsyncMock(return_value={"action": "allow"})
+        request.form = AsyncMock(
+            return_value=FormMultiDict([("action", "allow"), ("scope", "openid")])
+        )
         db_session = AsyncMock()
 
         with patch("skrift.controllers.oauth2.verify_csrf", new_callable=AsyncMock, return_value=True), \

--- a/tests/test_oauth2_server.py
+++ b/tests/test_oauth2_server.py
@@ -5,6 +5,7 @@ import hashlib
 from unittest.mock import MagicMock, patch, AsyncMock
 
 import pytest
+from litestar.datastructures import FormMultiDict
 from litestar.response import Redirect, Template as TemplateResponse
 
 from skrift.auth.scopes import SCOPE_DEFINITIONS, register_scope, get_scope_definition
@@ -432,7 +433,7 @@ class TestAuthorizePost:
                 "code_challenge": "",
             },
         }
-        form_data = {"action": "allow"}
+        form_data = FormMultiDict([("action", "allow"), ("scope", "openid")])
         request.form = AsyncMock(return_value=form_data)
         db_session = AsyncMock()
 

--- a/tests/test_permission_cache.py
+++ b/tests/test_permission_cache.py
@@ -1,0 +1,152 @@
+"""Tests for the bounded permission cache in ``skrift.auth.services``.
+
+The cache is process-global, so every test starts from a cleared cache.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from uuid import uuid4
+
+import pytest
+
+from skrift.auth import services
+from skrift.auth.services import (
+    get_user_permissions,
+    invalidate_user_permissions_cache,
+)
+
+
+class _StubRolePermission:
+    def __init__(self, permission: str) -> None:
+        self.permission = permission
+
+
+class _StubRole:
+    def __init__(self, name: str, permissions: list[str]) -> None:
+        self.name = name
+        self.permissions = [_StubRolePermission(p) for p in permissions]
+
+
+class _StubUser:
+    def __init__(self, roles: list[_StubRole]) -> None:
+        self.roles = roles
+
+
+class _StubResult:
+    def __init__(self, user: _StubUser | None) -> None:
+        self._user = user
+
+    def scalar_one_or_none(self) -> _StubUser | None:
+        return self._user
+
+
+class _CountingSession:
+    """AsyncSession stand-in that counts how many queries it served."""
+
+    def __init__(self, user: _StubUser | None = None) -> None:
+        self.user = user
+        self.query_count = 0
+
+    async def execute(self, statement) -> _StubResult:
+        self.query_count += 1
+        return _StubResult(self.user)
+
+
+@pytest.fixture(autouse=True)
+def clear_cache():
+    invalidate_user_permissions_cache()
+    yield
+    invalidate_user_permissions_cache()
+
+
+class TestPermissionCacheBehavior:
+    async def test_fresh_entry_is_served_from_cache(self):
+        session = _CountingSession(_StubUser([_StubRole("editor", ["manage-pages"])]))
+        user_id = str(uuid4())
+
+        first = await get_user_permissions(session, user_id)
+        second = await get_user_permissions(session, user_id)
+
+        assert session.query_count == 1
+        assert first is second
+        assert first.roles == {"editor"}
+        assert first.permissions == {"manage-pages"}
+
+    async def test_expired_entry_is_requeried(self):
+        session = _CountingSession(_StubUser([_StubRole("editor", ["manage-pages"])]))
+        user_id = str(uuid4())
+
+        await get_user_permissions(session, user_id)
+        stale_time = datetime.now() - services.CACHE_TTL - timedelta(seconds=1)
+        _, cached_permissions = services._permission_cache[user_id]
+        services._permission_cache[user_id] = (stale_time, cached_permissions)
+
+        await get_user_permissions(session, user_id)
+
+        assert session.query_count == 2
+
+    async def test_invalidating_one_user_leaves_others_cached(self):
+        session = _CountingSession(_StubUser([]))
+        kept_user_id = str(uuid4())
+        dropped_user_id = str(uuid4())
+
+        await get_user_permissions(session, kept_user_id)
+        await get_user_permissions(session, dropped_user_id)
+        invalidate_user_permissions_cache(dropped_user_id)
+
+        assert kept_user_id in services._permission_cache
+        assert dropped_user_id not in services._permission_cache
+
+    async def test_invalidating_everything_clears_the_cache(self):
+        session = _CountingSession(_StubUser([]))
+        await get_user_permissions(session, str(uuid4()))
+        await get_user_permissions(session, str(uuid4()))
+
+        invalidate_user_permissions_cache()
+
+        assert len(services._permission_cache) == 0
+
+
+class TestPermissionCacheBounds:
+    async def test_cache_never_exceeds_max_entries(self, monkeypatch):
+        monkeypatch.setattr(services, "MAX_PERMISSION_CACHE_ENTRIES", 5)
+        session = _CountingSession(_StubUser([]))
+
+        for _ in range(50):
+            await get_user_permissions(session, str(uuid4()))
+
+        assert len(services._permission_cache) == 5
+
+    async def test_least_recently_used_entry_is_evicted_first(self, monkeypatch):
+        monkeypatch.setattr(services, "MAX_PERMISSION_CACHE_ENTRIES", 3)
+        session = _CountingSession(_StubUser([]))
+        first_user_id = str(uuid4())
+        second_user_id = str(uuid4())
+        third_user_id = str(uuid4())
+
+        await get_user_permissions(session, first_user_id)
+        await get_user_permissions(session, second_user_id)
+        await get_user_permissions(session, third_user_id)
+        # Touching the first user makes the second the least recently used.
+        await get_user_permissions(session, first_user_id)
+        await get_user_permissions(session, str(uuid4()))
+
+        assert first_user_id in services._permission_cache
+        assert second_user_id not in services._permission_cache
+        assert third_user_id in services._permission_cache
+
+    async def test_expired_entries_are_purged_on_write(self):
+        session = _CountingSession(_StubUser([]))
+        abandoned_user_ids = [str(uuid4()) for _ in range(10)]
+        for user_id in abandoned_user_ids:
+            await get_user_permissions(session, user_id)
+
+        stale_time = datetime.now() - services.CACHE_TTL - timedelta(seconds=1)
+        for user_id in abandoned_user_ids:
+            _, cached_permissions = services._permission_cache[user_id]
+            services._permission_cache[user_id] = (stale_time, cached_permissions)
+
+        await get_user_permissions(session, str(uuid4()))
+
+        assert len(services._permission_cache) == 1

--- a/tests/test_request_body_limit.py
+++ b/tests/test_request_body_limit.py
@@ -1,0 +1,152 @@
+"""Request bodies are capped before Litestar buffers them into memory.
+
+Without an explicit cap a single oversized POST is fully buffered (and, for
+multipart, parsed) before any application-level size check runs. The cap has to
+stay above the largest upload a configured store accepts, otherwise legitimate
+uploads would be rejected by the transport instead of by the storage layer.
+"""
+
+from __future__ import annotations
+
+from typing import Annotated
+
+import pytest
+from litestar import Litestar, post
+from litestar.datastructures import UploadFile
+from litestar.enums import RequestEncodingType
+from litestar.params import Body
+from litestar.testing import TestClient
+
+from skrift.config import (
+    DEFAULT_MAX_REQUEST_BODY_SIZE,
+    MULTIPART_FRAMING_OVERHEAD,
+    Settings,
+    StorageConfig,
+    StoreConfig,
+    resolve_request_max_body_size,
+)
+
+
+def build_settings(**overrides) -> Settings:
+    """Settings with only the fields these tests care about."""
+    values = {"secret_key": "test-secret-key"}
+    values.update(overrides)
+    return Settings(**values)
+
+
+def build_storage(**store_sizes: int) -> StorageConfig:
+    """Storage config with one store per named upload limit."""
+    return StorageConfig(
+        default=next(iter(store_sizes)),
+        stores={
+            name: StoreConfig(max_upload_size=size)
+            for name, size in store_sizes.items()
+        },
+    )
+
+
+class TestResolveRequestMaxBodySize:
+    def test_defaults_leave_room_for_the_largest_upload_plus_framing(self):
+        settings = build_settings()
+
+        assert resolve_request_max_body_size(settings) == (
+            settings.storage.stores["default"].max_upload_size
+            + MULTIPART_FRAMING_OVERHEAD
+        )
+
+    def test_configured_floor_wins_when_it_exceeds_upload_needs(self):
+        settings = build_settings(
+            max_request_body_size=50_000_000,
+            storage=build_storage(default=1_024),
+        )
+
+        assert resolve_request_max_body_size(settings) == 50_000_000
+
+    def test_largest_store_limit_wins_across_stores(self):
+        settings = build_settings(
+            max_request_body_size=1_024,
+            storage=build_storage(small=2_048, large=8_192),
+        )
+
+        assert resolve_request_max_body_size(settings) == (
+            8_192 + MULTIPART_FRAMING_OVERHEAD
+        )
+
+    def test_default_floor_matches_the_documented_constant(self):
+        assert build_settings().max_request_body_size == DEFAULT_MAX_REQUEST_BODY_SIZE
+
+
+def build_upload_app(max_body_size: int) -> tuple[Litestar, list[int]]:
+    """An app whose upload handler records the size of each body it receives."""
+    received_sizes: list[int] = []
+
+    @post("/upload")
+    async def upload(
+        data: Annotated[UploadFile, Body(media_type=RequestEncodingType.MULTI_PART)],
+    ) -> dict:
+        content = await data.read()
+        received_sizes.append(len(content))
+        return {"size": len(content)}
+
+    app = Litestar(
+        route_handlers=[upload],
+        request_max_body_size=max_body_size,
+        openapi_config=None,
+    )
+    return app, received_sizes
+
+
+class TestRequestBodyCapEnforcement:
+    def test_oversized_upload_is_rejected_before_the_handler_runs(self):
+        settings = build_settings(
+            max_request_body_size=1_024, storage=build_storage(default=64)
+        )
+        max_body_size = resolve_request_max_body_size(settings)
+        app, received_sizes = build_upload_app(max_body_size)
+
+        with TestClient(app=app) as client:
+            response = client.post(
+                "/upload",
+                files={"data": ("big.bin", b"x" * (max_body_size + 1_024))},
+            )
+
+        assert response.status_code == 413
+        assert received_sizes == []
+
+    def test_upload_at_the_store_limit_still_fits_within_the_cap(self):
+        store_limit = 2 * 1024 * 1024
+        settings = build_settings(storage=build_storage(default=store_limit))
+        app, received_sizes = build_upload_app(
+            resolve_request_max_body_size(settings)
+        )
+
+        with TestClient(app=app) as client:
+            response = client.post(
+                "/upload", files={"data": ("big.bin", b"x" * store_limit)}
+            )
+
+        assert response.status_code == 201
+        assert received_sizes == [store_limit]
+
+    def test_normal_upload_is_unaffected(self):
+        settings = build_settings()
+        app, received_sizes = build_upload_app(
+            resolve_request_max_body_size(settings)
+        )
+
+        with TestClient(app=app) as client:
+            response = client.post(
+                "/upload", files={"data": ("small.txt", b"hello")}
+            )
+
+        assert response.status_code == 201
+        assert received_sizes == [5]
+
+
+class TestSetupAppRequestCap:
+    def test_setup_app_caps_request_bodies(self):
+        from skrift.asgi import create_setup_app
+
+        setup_app = create_setup_app()
+
+        assert setup_app.app.request_max_body_size == DEFAULT_MAX_REQUEST_BODY_SIZE

--- a/tests/test_sitemap_query.py
+++ b/tests/test_sitemap_query.py
@@ -1,0 +1,184 @@
+"""The sitemap must not materialize page bodies or page relationships.
+
+``/sitemap.xml`` is publicly reachable and hit by every crawler, so the query
+behind it is projected down to the three columns the XML actually uses. These
+tests pin that projection: no ``pages.content``, no ``selectin`` relationship
+fan-out, and a hard row cap.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from inspect import signature
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import event
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+from skrift.controllers.sitemap import SitemapController
+from skrift.db.base import Base
+from skrift.db.models import Page  # noqa: F401  (registers table)
+from skrift.db.services import page_service
+
+
+@pytest_asyncio.fixture
+async def sitemap_db():
+    """A SQLite session that records every statement it executes."""
+    engine = create_async_engine("sqlite+aiosqlite://")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    executed_statements: list[str] = []
+
+    @event.listens_for(engine.sync_engine, "before_cursor_execute")
+    def record_statement(conn, cursor, statement, parameters, context, executemany):
+        executed_statements.append(statement)
+
+    maker = async_sessionmaker(engine, expire_on_commit=False)
+    async with maker() as session:
+        yield SimpleNamespace(session=session, statements=executed_statements)
+    await engine.dispose()
+
+
+async def seed_page(session, slug: str, **overrides) -> Page:
+    """Insert a published page with a large body unless overridden."""
+    values = {
+        "slug": slug,
+        "title": slug.title(),
+        "content": "x" * 10_000,
+        "is_published": True,
+        "order": 0,
+    }
+    values.update(overrides)
+    page = Page(**values)
+    session.add(page)
+    await session.commit()
+    return page
+
+
+class TestListPageSitemapEntries:
+    @pytest.mark.asyncio
+    async def test_returns_only_published_and_already_scheduled_pages(self, sitemap_db):
+        await seed_page(sitemap_db.session, "public")
+        await seed_page(sitemap_db.session, "draft", is_published=False)
+        await seed_page(
+            sitemap_db.session,
+            "scheduled",
+            publish_at=datetime.now(UTC) + timedelta(days=1),
+        )
+
+        entries = await page_service.list_page_sitemap_entries(sitemap_db.session)
+
+        assert [entry.slug for entry in entries] == ["public"]
+
+    @pytest.mark.asyncio
+    async def test_entries_expose_only_the_sitemap_columns(self, sitemap_db):
+        await seed_page(sitemap_db.session, "public")
+
+        entry = (await page_service.list_page_sitemap_entries(sitemap_db.session))[0]
+
+        assert entry.slug == "public"
+        assert entry.created_at is not None
+        assert not hasattr(entry, "content")
+        assert not hasattr(entry, "assets")
+
+    @pytest.mark.asyncio
+    async def test_query_selects_no_body_and_triggers_no_relationship_loads(
+        self, sitemap_db
+    ):
+        await seed_page(sitemap_db.session, "public")
+        sitemap_db.statements.clear()
+
+        await page_service.list_page_sitemap_entries(sitemap_db.session)
+
+        assert len(sitemap_db.statements) == 1
+        statement = sitemap_db.statements[0].lower()
+        assert "pages.content" not in statement
+        assert "assets" not in statement
+        assert "page_republish" not in statement
+
+    @pytest.mark.asyncio
+    async def test_row_count_is_capped(self, sitemap_db):
+        for index in range(5):
+            await seed_page(sitemap_db.session, f"page-{index}")
+
+        entries = await page_service.list_page_sitemap_entries(
+            sitemap_db.session, limit=2
+        )
+
+        assert len(entries) == 2
+
+    def test_default_limit_is_the_sitemap_protocol_maximum(self):
+        limit_parameter = signature(
+            page_service.list_page_sitemap_entries
+        ).parameters["limit"]
+
+        assert page_service.SITEMAP_MAX_URLS == 50_000
+        assert limit_parameter.default == page_service.SITEMAP_MAX_URLS
+
+    @pytest.mark.asyncio
+    async def test_non_positive_limit_is_rejected(self, sitemap_db):
+        with pytest.raises(ValueError):
+            await page_service.list_page_sitemap_entries(sitemap_db.session, limit=0)
+
+
+class TestSitemapControllerOutput:
+    @pytest.mark.asyncio
+    async def test_xml_lists_published_pages_with_last_modified(
+        self, sitemap_db, clean_hooks
+    ):
+        await seed_page(sitemap_db.session, "about", order=1)
+        await seed_page(sitemap_db.session, "", order=0)
+        await seed_page(sitemap_db.session, "draft", is_published=False)
+
+        controller = SitemapController(owner=MagicMock())
+        request = MagicMock()
+        request.base_url = "https://example.com/"
+
+        with patch(
+            "skrift.controllers.sitemap.get_cached_site_base_url",
+            return_value="https://example.com",
+        ):
+            response = await controller.sitemap.fn(
+                controller, request, sitemap_db.session
+            )
+
+        xml = response.content
+        assert b"<loc>https://example.com</loc>" in xml
+        assert b"<loc>https://example.com/about</loc>" in xml
+        assert b"draft" not in xml
+        assert b"<priority>1.0</priority>" in xml
+        assert b"<priority>0.8</priority>" in xml
+        assert b"<lastmod>" in xml
+
+    @pytest.mark.asyncio
+    async def test_sitemap_page_filter_still_receives_each_page(
+        self, sitemap_db, clean_hooks
+    ):
+        from skrift.hooks import hooks
+
+        await seed_page(sitemap_db.session, "keep")
+        await seed_page(sitemap_db.session, "drop")
+
+        def drop_by_slug(entry, page):
+            return None if page.slug == "drop" else entry
+
+        hooks.add_filter("sitemap_page", drop_by_slug)
+
+        controller = SitemapController(owner=MagicMock())
+        request = MagicMock()
+        request.base_url = "https://example.com/"
+
+        with patch(
+            "skrift.controllers.sitemap.get_cached_site_base_url",
+            return_value="https://example.com",
+        ):
+            response = await controller.sitemap.fn(
+                controller, request, sitemap_db.session
+            )
+
+        assert b"/keep" in response.content
+        assert b"/drop" not in response.content

--- a/tests/test_sliding_window.py
+++ b/tests/test_sliding_window.py
@@ -7,6 +7,7 @@ identically for the rate-limit middleware and failed-auth tracker.
 from __future__ import annotations
 
 import asyncio
+import time
 
 import pytest
 
@@ -29,6 +30,36 @@ async def _make_redis_counter(window: float = 60.0, prefix: str = "test:ratelimi
 @pytest.fixture
 def in_memory():
     return InMemorySlidingWindowCounter(window=60.0)
+
+
+class _FakeClock:
+    """Deterministic stand-in for ``time.monotonic``."""
+
+    def __init__(self, start: float = 1000.0) -> None:
+        self.now = start
+
+    def __call__(self) -> float:
+        return self.now
+
+    def advance(self, seconds: float) -> None:
+        self.now += seconds
+
+
+@pytest.fixture
+def clock(monkeypatch):
+    fake_clock = _FakeClock()
+    monkeypatch.setattr(time, "monotonic", fake_clock)
+    return fake_clock
+
+
+def _retained_entries(counter: InMemorySlidingWindowCounter, key: str) -> int:
+    """Entries the counter keeps for *key* on the multi-window path."""
+    return counter._multi_buckets[key].entry_count
+
+
+def _retained_hits(counter: InMemorySlidingWindowCounter, key: str) -> int:
+    """Hits the counter still remembers for *key* on the multi-window path."""
+    return counter._multi_buckets[key].hit_count
 
 
 # ---------------------------------------------------------------------------
@@ -188,7 +219,104 @@ class TestMultiWindowAllOrNothingInMemory:
         allowed, _ = await counter.check_and_record_multi("ip", limits)
         assert allowed is False
         # Exactly one hit was ever recorded for this key.
-        assert sum(len(v) for v in counter._multi_buckets.values()) == 1
+        assert _retained_hits(counter, "ip") == 1
+
+
+class TestMultiWindowMemoryBounds:
+    """Long windows must not cost one retained timestamp per hit, and one
+    key's long window must not pin every other key's history."""
+
+    @pytest.mark.asyncio
+    async def test_long_window_history_grows_with_time_not_hit_volume(self, clock):
+        counter = InMemorySlidingWindowCounter(window=60.0)
+        # A day-long window with plenty of headroom: 600 hits, one per second.
+        limits = [(10_000, 86_400.0)]
+        for _ in range(600):
+            allowed, _ = await counter.check_and_record_multi("ip", limits)
+            assert allowed is True
+            clock.advance(1.0)
+
+        # 600 hits span ten minutes, so a coarse-bucketed history keeps a
+        # handful of entries rather than 600 timestamps.
+        assert _retained_entries(counter, "ip") <= 20
+
+    @pytest.mark.asyncio
+    async def test_short_window_key_is_not_pinned_by_another_keys_long_window(
+        self, clock
+    ):
+        counter = InMemorySlidingWindowCounter(window=60.0, cleanup_interval=0.0)
+        await counter.check_and_record_multi("daily-key", [(100, 86_400.0)])
+        await counter.check_and_record_multi("minute-key", [(5, 60.0)])
+
+        clock.advance(180.0)
+        # Any call runs the sweep (cleanup_interval=0).
+        await counter.check_and_record_multi("other-key", [(5, 60.0)])
+
+        assert "minute-key" not in counter._multi_buckets
+        assert "daily-key" in counter._multi_buckets
+
+    @pytest.mark.asyncio
+    async def test_denied_new_key_leaves_no_history_behind(self, clock):
+        counter = InMemorySlidingWindowCounter(window=60.0)
+        allowed, _ = await counter.check_and_record_multi("blocked", [(0, 60.0)])
+        assert allowed is False
+        assert "blocked" not in counter._multi_buckets
+
+
+class TestMultiWindowCoarseAccuracy:
+    """Coarse bucketing may over-count at a bucket edge; it must never
+    under-count, and short windows must stay exact."""
+
+    @pytest.mark.asyncio
+    async def test_long_window_never_under_counts_near_the_edge(self, clock):
+        counter = InMemorySlidingWindowCounter(window=60.0)
+        limits = [(3, 3600.0)]
+        for _ in range(3):
+            allowed, _ = await counter.check_and_record_multi("ip", limits)
+            assert allowed is True
+            clock.advance(1.0)
+
+        # Just inside the hour: the three hits still count, so a fourth is denied.
+        clock.advance(3500.0)
+        allowed, retry_after = await counter.check_and_record_multi("ip", limits)
+        assert allowed is False
+        assert retry_after >= 1
+
+        # Once retry_after has elapsed the caller is admitted again.
+        clock.advance(retry_after)
+        allowed, _ = await counter.check_and_record_multi("ip", limits)
+        assert allowed is True
+
+    @pytest.mark.asyncio
+    async def test_short_window_stays_exact_alongside_a_long_window(self, clock):
+        counter = InMemorySlidingWindowCounter(window=60.0)
+        limits = [(60, 60.0), (1_000, 86_400.0)]
+        for _ in range(60):
+            allowed, _ = await counter.check_and_record_multi("ip", limits)
+            assert allowed is True
+            clock.advance(0.1)
+
+        allowed, retry_after = await counter.check_and_record_multi("ip", limits)
+        assert allowed is False
+        assert 1 <= retry_after <= 61
+
+        # The minute window empties out; the day window still has room.
+        clock.advance(61.0)
+        allowed, _ = await counter.check_and_record_multi("ip", limits)
+        assert allowed is True
+
+    @pytest.mark.asyncio
+    async def test_long_window_limit_is_still_enforced(self, clock):
+        counter = InMemorySlidingWindowCounter(window=60.0)
+        limits = [(5, 86_400.0)]
+        for _ in range(5):
+            allowed, _ = await counter.check_and_record_multi("ip", limits)
+            assert allowed is True
+            clock.advance(600.0)  # spread across several coarse buckets
+
+        allowed, retry_after = await counter.check_and_record_multi("ip", limits)
+        assert allowed is False
+        assert retry_after > 3600
 
 
 @pytest.mark.skipif(not HAS_FAKEREDIS, reason="fakeredis not installed")

--- a/tests/test_worker_backend_contracts.py
+++ b/tests/test_worker_backend_contracts.py
@@ -149,8 +149,8 @@ async def _assert_queue_contract(queue) -> None:
     assert claimed is not None
     assert claimed.job.id == delayed.id
     await asyncio.sleep(0.02)
-    if isinstance(queue, SQLAlchemyQueue):
-        await queue._release_expired_claims(utcnow())
+    # Every queue backend exposes the same reaper entry point the runtime drives.
+    await queue._release_expired_claims(utcnow())
     reclaimed = await queue.claim(["default"], visibility_timeout=1)
     assert reclaimed is not None
     assert reclaimed.job.id == delayed.id

--- a/tests/test_worker_cli.py
+++ b/tests/test_worker_cli.py
@@ -399,3 +399,19 @@ def test_worker_config_validation_rejects_invalid_process_backends():
         context="worker",
         allow_memory_backends=True,
     )
+
+
+def test_configure_worker_runtime_uses_retention_ttl_from_settings():
+    from skrift.cli import _configure_worker_runtime
+    from skrift.config import WorkerRetentionConfig, WorkersConfig
+
+    settings = MagicMock()
+    settings.workers = WorkersConfig(
+        retention=WorkerRetentionConfig(terminal_job_state_ttl=123.0)
+    )
+
+    runtime = _configure_worker_runtime(
+        settings, session_maker=None, queues=["default"], concurrency=1
+    )
+
+    assert runtime.config.terminal_job_state_ttl == 123.0

--- a/tests/test_workers_memory_backend.py
+++ b/tests/test_workers_memory_backend.py
@@ -1,0 +1,297 @@
+"""Memory-pressure regression tests for the in-memory worker backends."""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import timedelta
+
+import pytest
+
+from skrift.workers import (
+    InMemoryEventLog,
+    InMemoryQueue,
+    InMemoryStateStore,
+    Job,
+    JobStatus,
+    RetryPolicy,
+    WorkerConfig,
+    WorkerRuntime,
+)
+from skrift.workers.memory import DEFAULT_EVENT_STREAM_MAX_EVENTS
+from skrift.workers.models import EventIdConflict, JobEnvelope, JobState, utcnow
+from skrift.workers.registry import HandlerRegistry
+from skrift.workers.runtime import TERMINAL_JOB_STATE_TTL_SECONDS
+
+
+class Greeting(Job):
+    name: str
+
+
+async def _claim_with_expired_visibility(queue: InMemoryQueue) -> JobEnvelope:
+    job = JobEnvelope(type="stuck", queue="default")
+    await queue.submit(job)
+    claimed = await queue.claim(["default"], visibility_timeout=0.01)
+    assert claimed is not None
+    await asyncio.sleep(0.02)
+    return job
+
+
+def _entry(queue: InMemoryQueue, job: JobEnvelope):
+    return queue._entries[job.queue][job.id]
+
+
+async def test_release_expired_claims_takes_now_like_the_other_queue_backends():
+    queue = InMemoryQueue()
+    job = await _claim_with_expired_visibility(queue)
+
+    await queue._release_expired_claims(utcnow())
+
+    entry = _entry(queue, job)
+    assert entry.claim_token is None
+    assert entry.job.reclaim_count == 1
+
+
+async def test_release_expired_claims_uses_the_supplied_now():
+    queue = InMemoryQueue()
+    job = JobEnvelope(type="held", queue="default")
+    await queue.submit(job)
+    claimed = await queue.claim(["default"], visibility_timeout=60)
+    assert claimed is not None
+
+    await queue._release_expired_claims(utcnow())
+    assert _entry(queue, job).claim_token is not None
+
+    await queue._release_expired_claims(utcnow() + timedelta(seconds=120))
+    assert _entry(queue, job).claim_token is None
+    assert _entry(queue, job).job.reclaim_count == 1
+
+
+async def test_claim_and_stats_still_reclaim_expired_claims():
+    queue = InMemoryQueue()
+    job = await _claim_with_expired_visibility(queue)
+
+    stats = await queue.stats("default")
+    assert stats.ready == 1
+    assert stats.claimed == 0
+
+    reclaimed = await queue.claim(["default"], visibility_timeout=1)
+    assert reclaimed is not None
+    assert reclaimed.job.id == job.id
+    assert reclaimed.job.reclaim_count == 1
+
+
+async def test_runtime_reaper_reclaims_memory_queue_claims_and_sweeps_state():
+    queue = InMemoryQueue()
+    state_store = InMemoryStateStore()
+    job = await _claim_with_expired_visibility(queue)
+    await state_store.set("workers:jobs:expired", "gone", ttl=0.01)
+    await state_store.set("workers:jobs:live", "kept")
+    await asyncio.sleep(0.02)
+
+    runtime = WorkerRuntime(
+        config=WorkerConfig(mode="in_process", queues=("idle",), reaper_interval=0.02),
+        queue=queue,
+        state_store=state_store,
+        handler_registry=HandlerRegistry(),
+    )
+    await runtime.start()
+    try:
+        for _ in range(100):
+            if _entry(queue, job).claim_token is None and "workers:jobs:expired" not in (
+                state_store._values
+            ):
+                break
+            await asyncio.sleep(0.02)
+    finally:
+        await runtime.stop()
+
+    assert _entry(queue, job).claim_token is None
+    assert _entry(queue, job).job.reclaim_count == 1
+    assert "workers:jobs:expired" not in state_store._values
+    assert "workers:jobs:live" in state_store._values
+
+
+async def test_event_log_bounds_streams_and_keeps_positions_monotonic():
+    log = InMemoryEventLog(max_events_per_stream=3)
+
+    positions = [await log.append("s", {"n": index}) for index in range(6)]
+
+    assert positions == [0, 1, 2, 3, 4, 5]
+    assert await log.read("s") == [(3, {"n": 3}), (4, {"n": 4}), (5, {"n": 5})]
+    assert await log.append("s", {"n": 6}) == 6
+
+
+async def test_event_log_reads_ignore_positions_that_were_pruned():
+    log = InMemoryEventLog(max_events_per_stream=2)
+    for index in range(5):
+        await log.append("s", {"n": index, "job_id": "job-1" if index % 2 else "job-0"})
+
+    assert await log.read("s", from_position=0) == [
+        (3, {"n": 3, "job_id": "job-1"}),
+        (4, {"n": 4, "job_id": "job-0"}),
+    ]
+    assert await log.read("s", from_position=4) == [(4, {"n": 4, "job_id": "job-0"})]
+    assert await log.read("s", from_position=9) == []
+    assert await log.read("s", from_position=0, limit=1) == [(3, {"n": 3, "job_id": "job-1"})]
+    assert await log.read_filtered("s", filters={"job_id": "job-1"}) == [
+        (3, {"n": 3, "job_id": "job-1"})
+    ]
+    assert await log.read_tail("s", limit=1) == [(4, {"n": 4, "job_id": "job-0"})]
+    assert await log.read_tail("s", limit=0) == []
+
+
+async def test_event_log_dedupe_index_is_bounded_with_the_stream():
+    log = InMemoryEventLog(max_events_per_stream=2)
+    assert await log.append("s", {"event_id": "evt-0", "n": 0}) == 0
+    assert await log.append("s", {"event_id": "evt-1", "n": 1}) == 1
+
+    assert await log.append("s", {"event_id": "evt-1", "n": 1}) == 1
+    with pytest.raises(EventIdConflict):
+        await log.append("s", {"event_id": "evt-1", "n": 99})
+
+    assert await log.append("s", {"event_id": "evt-2", "n": 2}) == 2
+    assert log.stream_event_id_count("s") == 2
+    # evt-0 fell out of the retained window, so its id is no longer indexed.
+    assert await log.append("s", {"event_id": "evt-0", "n": 3}) == 3
+    assert log.stream_event_id_count("s") == 2
+
+
+async def test_event_log_subscribe_tails_a_bounded_stream():
+    log = InMemoryEventLog(max_events_per_stream=2)
+    await log.append("s", {"n": 0})
+    await log.append("s", {"n": 1})
+
+    subscription = log.subscribe("s", from_position=2)
+    next_event = asyncio.create_task(anext(subscription))
+    await log.append("s", {"n": 2})
+    assert await asyncio.wait_for(next_event, timeout=1) == (2, {"n": 2})
+    await subscription.aclose()
+
+
+async def test_event_log_subscriber_skips_events_pruned_before_it_read_them():
+    log = InMemoryEventLog(max_events_per_stream=2)
+    subscription = log.subscribe("s", from_position=0)
+    for index in range(4):
+        await log.append("s", {"n": index})
+
+    assert await asyncio.wait_for(anext(subscription), timeout=1) == (2, {"n": 2})
+    assert await asyncio.wait_for(anext(subscription), timeout=1) == (3, {"n": 3})
+    await subscription.aclose()
+
+
+async def test_event_log_defaults_to_a_bounded_stream():
+    log = InMemoryEventLog()
+
+    assert log.max_events_per_stream == DEFAULT_EVENT_STREAM_MAX_EVENTS
+    assert DEFAULT_EVENT_STREAM_MAX_EVENTS > 0
+
+
+async def test_event_log_delete_resets_a_stream():
+    log = InMemoryEventLog(max_events_per_stream=2)
+    await log.append("s", {"n": 0})
+    await log.delete("s")
+
+    assert await log.read("s") == []
+    assert await log.append("s", {"n": 1}) == 0
+    assert await log.list_streams() == ["s"]
+
+
+async def test_state_store_sweep_expired_reclaims_entries():
+    store = InMemoryStateStore()
+    await store.set("workers:jobs:expired", "gone", ttl=0.01)
+    await store.set("workers:jobs:live", "kept")
+    await asyncio.sleep(0.02)
+
+    removed = await store.sweep_expired()
+
+    assert removed == 1
+    assert list(store._values) == ["workers:jobs:live"]
+    assert await store.sweep_expired() == 0
+
+
+async def test_state_store_reports_worker_job_states_with_total():
+    store = InMemoryStateStore()
+    older = JobState(job=JobEnvelope(type="older"))
+    older.updated_at = utcnow() - timedelta(minutes=5)
+    newer = JobState(job=JobEnvelope(type="newer"))
+    newer.updated_at = utcnow()
+    await store.set(f"workers:jobs:{older.job.id}", older)
+    await store.set(f"workers:jobs:{newer.job.id}", newer)
+    await store.set("workers:other", "ignored")
+
+    states, total = await store.worker_job_states(limit=1)
+
+    assert total == 2
+    assert [state.job.type for state in states] == ["newer"]
+
+
+async def test_runtime_expires_terminal_job_state_but_keeps_active_state():
+    state_store = InMemoryStateStore()
+    registry = HandlerRegistry()
+    runtime = WorkerRuntime(
+        config=WorkerConfig(mode="inline"),
+        state_store=state_store,
+        handler_registry=registry,
+    )
+
+    async def greet(job: Greeting) -> str:
+        return job.name.upper()
+
+    registry.register("greet", greet)
+
+    completed = await runtime.submit("greet", {"name": "Ada"})
+    state = await runtime.get_job_state(completed.id)
+    assert state.status == JobStatus.COMPLETED
+
+    stored = state_store._values[f"workers:jobs:{completed.id}"]
+    assert stored.expires_at is not None
+    remaining = (stored.expires_at - utcnow()).total_seconds()
+    assert TERMINAL_JOB_STATE_TTL_SECONDS - 60 < remaining <= TERMINAL_JOB_STATE_TTL_SECONDS
+
+    queued_runtime = WorkerRuntime(
+        config=WorkerConfig(mode="in_process"),
+        state_store=state_store,
+        handler_registry=registry,
+    )
+    submitted = await queued_runtime.submit("greet", {"name": "Grace"})
+    assert (await queued_runtime.get_job_state(submitted.id)).status == JobStatus.SUBMITTED
+    assert state_store._values[f"workers:jobs:{submitted.id}"].expires_at is None
+
+
+async def test_runtime_expires_dead_lettered_job_state():
+    state_store = InMemoryStateStore()
+    registry = HandlerRegistry()
+    runtime = WorkerRuntime(
+        config=WorkerConfig(mode="inline"),
+        state_store=state_store,
+        handler_registry=registry,
+    )
+
+    async def boom(job: Greeting) -> None:
+        raise RuntimeError("nope")
+
+    registry.register("boom", boom, retry_policy=RetryPolicy(max_attempts=1))
+
+    handle = await runtime.submit("boom", {"name": "Ada"})
+    state = await runtime.get_job_state(handle.id)
+    assert state.status == JobStatus.DEAD_LETTERED
+    assert state_store._values[f"workers:jobs:{handle.id}"].expires_at is not None
+
+
+async def test_runtime_expires_cancelled_job_state():
+    state_store = InMemoryStateStore()
+    registry = HandlerRegistry()
+    runtime = WorkerRuntime(
+        config=WorkerConfig(mode="in_process"),
+        state_store=state_store,
+        handler_registry=registry,
+    )
+
+    async def greet(job: Greeting) -> str:
+        return job.name.upper()
+
+    registry.register("greet", greet)
+
+    handle = await runtime.submit("greet", {"name": "Ada"})
+    assert await runtime.cancel(handle.id) is True
+    assert state_store._values[f"workers:jobs:{handle.id}"].expires_at is not None

--- a/uv.lock
+++ b/uv.lock
@@ -2149,7 +2149,7 @@ wheels = [
 
 [[package]]
 name = "skrift"
-version = "0.2.0a12"
+version = "0.2.0a13"
 source = { editable = "." }
 dependencies = [
     { name = "advanced-alchemy" },


### PR DESCRIPTION
## Summary

This release resolves the production memory problem (250MB+ RSS against a 500MB limit) traced by an empirical investigation to an unbounded gzip compression ratchet plus several unbounded in-memory stores, and adds partial-scope OAuth consent so users can grant a subset of an app's requested scopes (#169).

Measured impact: 157MB at concurrency 200 (was ~250MB, permanently ratcheting), 176MB at concurrency 400 (was ~372MB), +0.4MB across 5,000 subsequent requests.

## Changes

### New Features
- OAuth2 consent screen renders each requested scope as a checkbox, letting users grant a subset of the request (#169). The granted set is validated as a subset (superset → `400 invalid_scope`), unchecking everything is a denial, and the token response carries the narrowed scope per RFC 6749 §3.3. Declining a previously granted scope removes it from the stored grant so remembered consent re-prompts instead of silently restoring it.
- New `compression` config section (`enabled`, `minimum_size`, `max_concurrent`) — in-app gzip can now be turned off for proxy/CDN-terminated deployments.
- New `max_request_body_size` config knob; oversized requests are refused with `413` at the transport layer before buffering.

### Bug Fixes
- Gzip compression no longer permanently ratchets process memory: compressors are created lazily, released deterministically, and capped process-wide with identity fallback (Litestar's stock gzip middleware held one zlib state per in-flight request — ~153KB each, never returned).
- `skrift serve --workers N` now actually spawns N worker processes (it silently ran a single worker before).
- In-memory worker queue reaper no longer crashes every tick on a signature mismatch — expired claims are reclaimed and state sweeping runs.
- Legitimate max-size uploads are no longer rejected by Litestar's implicit 10MB transport default (cap now auto-lifts to the largest configured store's `max_upload_size` + framing).
- Rate limiter no longer raises `IndexError` for zero-limit rules.

### Improvements
- Bounded every unbounded in-memory store: worker event log (with O(1) dedupe), terminal job state TTL (wired from `workers.retention`), notification backend TTL cleanup, SSE subscriber-graph cleanup with bounded per-connection queues, LRU permission cache, bot-detection store sweeping, coarse-bucketed long-window rate limiting.
- Sitemap uses a projected query (slug + timestamps) instead of loading every page's full markdown body with relationship fan-out.
- SSE routes on per-site (multisite) apps are now excluded from compression, matching the primary app.
- Memory-honest deployment docs: ~150MB per worker process, RAM-to-worker table, `MALLOC_ARENA_MAX=2` guidance, proxy-level compression recommendation, and reference docs for the new compression/body-size knobs.
- Added `demo/basic-site/.env.example` (the demo cannot boot without `SECRET_KEY`).

## Release version
`0.2.0a13` -> `0.2.0a14`

Closes #169

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lwz8BmW9BL98sagTKYhZyo