### PR TITLE
Release v0.2.0a18 — worker notification backend lifecycle

### DIFF
--- a/.claude/skills/skrift-events/SKILL.md
+++ b/.claude/skills/skrift-events/SKILL.md
@@ -225,6 +225,10 @@ notifications:
 
 Database-backed backends auto-clean: queued notifications after 24h, timeseries after 7 days.
 
+### Backend Lifecycle
+
+The ASGI app and `skrift workers run` both start/stop the configured backend automatically. Nonstandard processes use the public API on the `notifications` singleton: `await notifications.ensure_backend_started(settings=..., session_maker=...)` (idempotent; False when no backend configured), `notifications.backend_started` (False while on the lazy InMemoryBackend fallback), `await notifications.stop_backend()`.
+
 ---
 
 ## Client-Side SSE JS

--- a/docs/guides/notifications.md
+++ b/docs/guides/notifications.md
@@ -141,6 +141,30 @@ The notification service uses a pluggable backend system for storage and cross-r
 
 All DB-backed backends persist notifications in the `stored_notifications` table and share a `_DatabaseStorageMixin` that provides store, remove, group replacement, and background cleanup.
 
+### Backend Lifecycle Outside the ASGI App
+
+The web app starts and stops the configured backend as part of its ASGI lifecycle, and `skrift workers run` does the same for standalone worker processes — notifications published from job handlers reach web replicas out of the box.
+
+Processes with nonstandard lifecycles (scripts, custom entry points) can manage the backend through the public API on the `notifications` service singleton:
+
+```python
+from skrift.notifications import notifications
+
+# Idempotently load and start the backend configured in app.yaml.
+# Returns True when a configured backend is running, False when
+# notifications.backend is not set (in-process fallback stays in effect).
+await notifications.ensure_backend_started(settings=settings, session_maker=session_maker)
+
+# True once a backend was explicitly started and not yet stopped;
+# False while relying on the lazy in-process InMemoryBackend fallback.
+notifications.backend_started
+
+# Stop the backend on shutdown.
+await notifications.stop_backend()
+```
+
+Without a started backend, `notify_user()` and friends fall back to a process-local `InMemoryBackend` — notifications are delivered within the process but never reach other replicas.
+
 ## Client-Side JavaScript
 
 The `notifications.js` script auto-initializes on page load and manages the SSE connection.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "skrift"
-version = "0.2.0a17"
+version = "0.2.0a18"
 description = "A lightweight async Python CMS for crafting modern websites"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/skrift/asgi.py
+++ b/skrift/asgi.py
@@ -1079,8 +1079,7 @@ def create_app() -> ASGIApp:
         from skrift.hooks import APP_STARTUP, LOGFIRE_CONFIGURED, hooks
         await hooks.do_action(LOGFIRE_CONFIGURED)
 
-        notification_service.set_backend(backend)
-        await backend.start()
+        await notification_service.start_backend(backend)
 
         await email_backend.start()
 
@@ -1167,7 +1166,7 @@ def create_app() -> ASGIApp:
             await get_runtime().stop()
 
         await notification_service.disconnect_active_connections()
-        await notification_service._get_backend().stop()
+        await notification_service.stop_backend()
         await email_backend.stop()
         await storage_manager.close()
         await trusted_proxy_manager.stop()

--- a/skrift/cli.py
+++ b/skrift/cli.py
@@ -331,11 +331,16 @@ def workers_run(
         settings.workers.max_reclaims = max_reclaims
 
     async def _run():
+        from skrift.notifications import notifications
+
         db_config = _build_db_config(settings)
         if settings.webhooks.enabled:
             from skrift.webhooks import configure_webhooks
 
             configure_webhooks(settings.webhooks, session_maker=db_config.get_session)
+        await notifications.ensure_backend_started(
+            settings=settings, session_maker=db_config.get_session
+        )
         selected_queues = queues or tuple(settings.workers.queues)
         runtime = _configure_worker_runtime(
             settings,
@@ -356,6 +361,7 @@ def workers_run(
             await shutdown_event.wait()
         finally:
             await runtime.stop()
+            await notifications.stop_backend()
             await db_config.get_engine().dispose()
 
     asyncio.run(_run())

--- a/skrift/notifications.py
+++ b/skrift/notifications.py
@@ -232,6 +232,8 @@ class NotificationService:
     def __init__(self) -> None:
         self._registry = SourceRegistry()
         self._backend: NotificationBackend | None = None
+        self._backend_started: bool = False
+        self._backend_lock = asyncio.Lock()
         self._publisher_id: str = str(uuid4())
         self._loaded_user_subs: set[str] = set()
         self._session_users: dict[str, str] = {}  # session_key -> user_key
@@ -239,6 +241,64 @@ class NotificationService:
     def set_backend(self, backend: NotificationBackend) -> None:
         self._backend = backend
         backend.on_remote_message(self._handle_remote)
+
+    @property
+    def backend_started(self) -> bool:
+        """True once a backend was started via :meth:`start_backend` or
+        :meth:`ensure_backend_started` and not yet stopped.
+
+        False while the service is relying on the lazy in-process
+        ``InMemoryBackend`` fallback, which cannot reach other replicas.
+        """
+        return self._backend_started
+
+    async def start_backend(self, backend: NotificationBackend) -> None:
+        """Install *backend* and start it, marking the lifecycle as running."""
+        self.set_backend(backend)
+        await backend.start()
+        self._backend_started = True
+
+    async def stop_backend(self) -> None:
+        """Stop the current backend (if any) and clear the started flag."""
+        self._backend_started = False
+        if self._backend is not None:
+            await self._backend.stop()
+
+    async def ensure_backend_started(
+        self, settings=None, session_maker=None
+    ) -> bool:
+        """Idempotently load and start the backend configured in settings.
+
+        For processes with nonstandard lifecycles (standalone workers,
+        scripts) that publish notifications outside the ASGI app. Safe to
+        call concurrently and repeatedly; only the first call does work.
+
+        Args:
+            settings: Skrift ``Settings``; defaults to ``get_settings()``.
+            session_maker: Async session maker for database-backed backends.
+
+        Returns:
+            True when a configured backend is running after the call,
+            False when ``notifications.backend`` is not configured (the
+            in-process fallback remains in effect).
+        """
+        if self._backend_started:
+            return True
+        async with self._backend_lock:
+            if self._backend_started:
+                return True
+            if settings is None:
+                from skrift.config import get_settings
+
+                settings = get_settings()
+            if not settings.notifications.backend:
+                return False
+            from skrift.lib.notification_backends import load_backend
+
+            backend_cls = load_backend(settings.notifications.backend)
+            backend = backend_cls(settings=settings, session_maker=session_maker)
+            await self.start_backend(backend)
+            return True
 
     def _get_backend(self) -> NotificationBackend:
         if self._backend is None:

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -1487,3 +1487,131 @@ class TestRedisReaderLoop:
             task.cancel()
 
         assert seen == [{}]
+
+
+# ===========================================================================
+# Public backend lifecycle API
+# ===========================================================================
+
+
+class _RecordingBackend:
+    """Minimal backend stub that records lifecycle calls."""
+
+    def __init__(self, **kwargs):
+        self.started = False
+        self.stopped = False
+        self.callback = None
+
+    async def start(self):
+        self.started = True
+
+    async def stop(self):
+        self.stopped = True
+
+    def on_remote_message(self, callback):
+        self.callback = callback
+
+
+class TestBackendLifecycle:
+    """Test backend_started / start_backend / stop_backend / ensure_backend_started."""
+
+    def test_backend_started_false_on_fresh_service(self, svc):
+        assert svc.backend_started is False
+
+    @pytest.mark.asyncio
+    async def test_lazy_fallback_does_not_mark_started(self, svc):
+        svc._get_backend()
+        assert svc.backend_started is False
+
+    @pytest.mark.asyncio
+    async def test_start_backend_starts_and_marks(self, svc):
+        backend = _RecordingBackend()
+        await svc.start_backend(backend)
+
+        assert backend.started is True
+        assert backend.callback is not None
+        assert svc.backend_started is True
+
+    @pytest.mark.asyncio
+    async def test_stop_backend_stops_and_clears(self, svc):
+        backend = _RecordingBackend()
+        await svc.start_backend(backend)
+        await svc.stop_backend()
+
+        assert backend.stopped is True
+        assert svc.backend_started is False
+
+    @pytest.mark.asyncio
+    async def test_stop_backend_without_backend_is_noop(self, svc):
+        await svc.stop_backend()
+        assert svc.backend_started is False
+
+    @pytest.mark.asyncio
+    async def test_ensure_unconfigured_returns_false(self, svc):
+        from skrift.config import Settings
+
+        settings = Settings(secret_key="test")
+        result = await svc.ensure_backend_started(settings=settings)
+
+        assert result is False
+        assert svc.backend_started is False
+        assert svc._backend is None
+
+    @pytest.mark.asyncio
+    async def test_ensure_configured_loads_and_starts(self, svc):
+        from skrift.config import NotificationsConfig, Settings
+        from skrift.lib.notification_backends import InMemoryBackend
+
+        settings = Settings(
+            secret_key="test",
+            notifications=NotificationsConfig(
+                backend="skrift.lib.notification_backends:InMemoryBackend"
+            ),
+        )
+        try:
+            result = await svc.ensure_backend_started(settings=settings)
+
+            assert result is True
+            assert svc.backend_started is True
+            assert isinstance(svc._backend, InMemoryBackend)
+        finally:
+            await svc.stop_backend()
+
+    @pytest.mark.asyncio
+    async def test_ensure_is_idempotent(self, svc):
+        from skrift.config import NotificationsConfig, Settings
+
+        settings = Settings(
+            secret_key="test",
+            notifications=NotificationsConfig(
+                backend="skrift.lib.notification_backends:InMemoryBackend"
+            ),
+        )
+        try:
+            await svc.ensure_backend_started(settings=settings)
+            first = svc._backend
+            result = await svc.ensure_backend_started(settings=settings)
+
+            assert result is True
+            assert svc._backend is first
+        finally:
+            await svc.stop_backend()
+
+    @pytest.mark.asyncio
+    async def test_ensure_concurrent_calls_start_one_backend(self, svc):
+        from skrift.config import NotificationsConfig, Settings
+
+        settings = Settings(
+            secret_key="test",
+            notifications=NotificationsConfig(
+                backend="skrift.lib.notification_backends:InMemoryBackend"
+            ),
+        )
+        try:
+            results = await asyncio.gather(
+                *(svc.ensure_backend_started(settings=settings) for _ in range(5))
+            )
+            assert all(results)
+            assert svc.backend_started is True
+        finally:
+            await svc.stop_backend()

--- a/uv.lock
+++ b/uv.lock
@@ -2149,7 +2149,7 @@ wheels = [
 
 [[package]]
 name = "skrift"
-version = "0.2.0a13"
+version = "0.2.0a17"
 source = { editable = "." }
 dependencies = [
     { name = "advanced-alchemy" },

--- a/uv.lock
+++ b/uv.lock
@@ -2149,7 +2149,7 @@ wheels = [
 
 [[package]]
 name = "skrift"
-version = "0.2.0a17"
+version = "0.2.0a18"
 source = { editable = "." }
 dependencies = [
     { name = "advanced-alchemy" },


### PR DESCRIPTION
## Summary

`skrift workers run` now owns the notification backend lifecycle, and `NotificationService` exposes a public API for starting, checking, and stopping the configured backend from processes with nonstandard lifecycles.

Closes #176

## Changes

### Bug Fixes
- `skrift workers run` starts the backend configured under `notifications.backend` before the worker runtime and stops it on shutdown, so `notify_user()` calls from job handlers reach web replicas instead of being silently swallowed by the process-local `InMemoryBackend` fallback (#176)

### New Features
- Public backend lifecycle API on the `notifications` service singleton: `backend_started`, `start_backend()`, idempotent and concurrency-safe `ensure_backend_started()`, and `stop_backend()` — embedding projects no longer need to reach into private attributes (#176)

### Improvements
- The ASGI app lifecycle now goes through the same public lifecycle API, so `backend_started` is accurate in web processes too
- Documented the backend lifecycle in the notifications guide

## Release version
`0.2.0a17` -> `0.2.0a18`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019vSqgc4XQT67AFWARZUhgP